### PR TITLE
AST changes, unify version naming (v1 rather than v1_0)

### DIFF
--- a/src/main/scala/wdlTools/cli/Format.scala
+++ b/src/main/scala/wdlTools/cli/Format.scala
@@ -12,7 +12,7 @@ case class Format(conf: WdlToolsConf) extends Command {
   override def apply(): Unit = {
     val url = conf.format.url()
     val opts = conf.format.getOptions
-    val formatter = V1_0Formatter(opts)
+    val formatter = WdlV1Formatter(opts)
     formatter.formatDocuments(url)
     formatter.documents.foreach {
       case (uri, lines) =>

--- a/src/main/scala/wdlTools/formatter/Upgrader.scala
+++ b/src/main/scala/wdlTools/formatter/Upgrader.scala
@@ -11,7 +11,7 @@ case class Upgrader(opts: Options) {
 
   def upgrade(url: URL,
               srcVersion: Option[WdlVersion] = None,
-              destVersion: WdlVersion = WdlVersion.V1_0): Map[URL, Seq[String]] = {
+              destVersion: WdlVersion = WdlVersion.V1): Map[URL, Seq[String]] = {
     val parser = if (srcVersion.isDefined) {
       parsers.getParser(srcVersion.get)
     } else {
@@ -19,12 +19,12 @@ case class Upgrader(opts: Options) {
     }
 
     // the parser will follow imports, so the formatter should not
-    val formatter = V1_0Formatter(opts.copy(followImports = false))
+    val formatter = WdlV1Formatter(opts.copy(followImports = false))
 
     // parse and format the document (and any imports)
     val walker = parser.Walker[Seq[String]](url)
     walker.walk { (docUrl, doc, results) =>
-      if (doc.version >= destVersion) {
+      if (doc.version.value >= destVersion) {
         throw new Exception(s"Cannot convert WDL version ${doc.version} to ${destVersion}")
       }
       results(docUrl) = formatter.formatDocument(doc)

--- a/src/main/scala/wdlTools/generators/ProjectGenerator.scala
+++ b/src/main/scala/wdlTools/generators/ProjectGenerator.scala
@@ -3,7 +3,7 @@ package wdlTools.generators
 import java.net.URL
 import java.nio.file.Path
 
-import wdlTools.formatter.V1_0Formatter
+import wdlTools.formatter.WdlV1Formatter
 import wdlTools.generators.ProjectGenerator._
 import wdlTools.syntax.AbstractSyntax._
 import wdlTools.syntax.{Parsers, WdlFragmentParser, WdlVersion}
@@ -15,7 +15,7 @@ import util.control.Breaks._
 case class ProjectGenerator(opts: Options,
                             name: String,
                             outputDir: Path,
-                            wdlVersion: WdlVersion = WdlVersion.V1_0,
+                            wdlVersion: WdlVersion = WdlVersion.V1,
                             interactive: Boolean = false,
                             readmes: Boolean = false,
                             developerReadmes: Boolean = false,
@@ -29,7 +29,7 @@ case class ProjectGenerator(opts: Options,
   val MAKEFILE_TEMPLATE = "/templates/project/Makefile.ssp"
 
   val defaultDockerImage = "debian:stretch-slim"
-  lazy val formatter: V1_0Formatter = V1_0Formatter(opts)
+  lazy val formatter: WdlV1Formatter = WdlV1Formatter(opts)
   lazy val renderer: Renderer = Renderer()
   lazy val readmeGenerator: ReadmeGenerator =
     ReadmeGenerator(developerReadmes = developerReadmes,
@@ -223,7 +223,7 @@ case class ProjectGenerator(opts: Options,
       taskModels.map(_.toTask)
     }
 
-    val doc = Document(wdlVersion,
+    val doc = Document(Version(wdlVersion, null, None),
                        null,
                        tasksAndLinkedInputs.map(_._1),
                        workflowModel.map(_.toWorkflow(tasksAndLinkedInputs)),
@@ -383,19 +383,19 @@ object ProjectGenerator {
     def toWorkflow(tasksAndLinkedInputs: Vector[(Task, Set[String])]): Workflow = {
       val calls: Vector[Call] = tasksAndLinkedInputs.map {
         case (task, linkedInputs) =>
-          val callInputs: Map[String, Expr] = if (task.input.isDefined) {
-            def getInputValue(inp: Declaration): Option[(String, Expr)] = {
+          val callInputs: Option[CallInputs] = if (task.input.isDefined) {
+            def getInputValue(inp: Declaration): Option[CallInput] = {
               if (linkedInputs.contains(inp.name)) {
-                Some(inp.name -> ExprIdentifier(inp.name, null))
+                Some(CallInput(inp.name, ExprIdentifier(inp.name, null), null))
               } else if (inp.wdlType.isInstanceOf[TypeOptional]) {
                 None
               } else {
-                Some(inp.name -> ValueString("set my value!", null))
+                Some(CallInput(inp.name, ValueString("set my value!", null), null))
               }
             }
-            task.input.get.declarations.flatMap(getInputValue).toMap
+            Some(CallInputs(task.input.get.declarations.flatMap(getInputValue), null))
           } else {
-            Map.empty
+            None
           }
           Call(task.name, None, callInputs, null, None)
       }

--- a/src/main/scala/wdlTools/syntax/AbstractSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/AbstractSyntax.scala
@@ -7,7 +7,7 @@ object AbstractSyntax {
   trait Element {
     val text: TextSource // where in the source program does this element belong
   }
-  trait StatementElement {
+  trait StatementElement extends Element {
 
     /**
       * An optional comment that comes before the element.
@@ -155,12 +155,15 @@ object AbstractSyntax {
   case class MetaSection(kvs: Vector[MetaKV], text: TextSource, comment: Option[Comment])
       extends StatementElement
 
+  case class Version(value: WdlVersion, text: TextSource, comment: Option[Comment])
+      extends DocumentElement
+
   // import statement with the AST for the referenced document
-  case class ImportAlias(id1: String, id2: String, text: TextSource)
+  case class ImportAlias(id1: String, id2: String, text: TextSource) extends Element
   case class ImportDoc(name: Option[String],
                        aliases: Vector[ImportAlias],
                        url: URL,
-                       doc: Document,
+                       doc: Option[Document],
                        text: TextSource,
                        comment: Option[Comment])
       extends DocumentElement
@@ -179,9 +182,12 @@ object AbstractSyntax {
       extends DocumentElement
 
   // TODO: support comments - only one comment before inputs
+  case class CallAlias(name: String, text: TextSource) extends Element
+  case class CallInput(name: String, expr: Expr, text: TextSource) extends Element
+  case class CallInputs(value: Vector[CallInput], text: TextSource) extends Element
   case class Call(name: String,
-                  alias: Option[String],
-                  inputs: Map[String, Expr],
+                  alias: Option[CallAlias],
+                  inputs: Option[CallInputs],
                   text: TextSource,
                   comment: Option[Comment])
       extends WorkflowElement
@@ -210,7 +216,7 @@ object AbstractSyntax {
                       comment: Option[Comment])
       extends StatementElement
 
-  case class Document(version: WdlVersion,
+  case class Document(version: Version,
                       versionTextSource: Option[TextSource] = None,
                       elements: Vector[DocumentElement],
                       workflow: Option[Workflow],

--- a/src/main/scala/wdlTools/syntax/Parsers.scala
+++ b/src/main/scala/wdlTools/syntax/Parsers.scala
@@ -12,11 +12,11 @@ case class Parsers(opts: Options = Options(), defaultLoader: Option[SourceCode.L
   private val loader: SourceCode.Loader = defaultLoader.getOrElse(SourceCode.Loader(opts))
   private lazy val parsers: Map[WdlVersion, WdlParser] = Map(
       WdlVersion.Draft_2 -> draft_2.ParseAll(opts, loader),
-      WdlVersion.V1_0 -> v1_0.ParseAll(opts, loader)
+      WdlVersion.V1 -> v1.ParseAll(opts, loader)
   )
   private lazy val fragmentParsers: Map[WdlVersion, WdlFragmentParser] = Map(
       WdlVersion.Draft_2 -> draft_2.ParseFragment(opts),
-      WdlVersion.V1_0 -> v1_0.ParseFragment(opts)
+      WdlVersion.V1 -> v1.ParseFragment(opts)
   )
 
   def getParser(url: URL): WdlParser = {

--- a/src/main/scala/wdlTools/syntax/draft_2/ConcreteSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/draft_2/ConcreteSyntax.scala
@@ -2,7 +2,7 @@ package wdlTools.syntax.draft_2
 
 import java.net.URL
 
-import wdlTools.syntax.{Comment, TextSource, WdlVersion}
+import wdlTools.syntax.{Comment, TextSource}
 
 // A parser based on a WDL grammar written by Patrick Magee. The tool
 // underlying the grammar is Antlr4.
@@ -178,10 +178,10 @@ object ConcreteSyntax {
 
   case class CallAlias(name: String, text: TextSource) extends Element
   case class CallInput(name: String, expr: Expr, text: TextSource) extends Element
-  case class CallInputs(value: Map[String, Expr], text: TextSource) extends Element
+  case class CallInputs(value: Vector[CallInput], text: TextSource) extends Element
   case class Call(name: String,
-                  alias: Option[String],
-                  inputs: Map[String, Expr],
+                  alias: Option[CallAlias],
+                  inputs: Option[CallInputs],
                   text: TextSource,
                   comment: Option[Comment])
       extends WorkflowElement
@@ -207,8 +207,7 @@ object ConcreteSyntax {
                       comment: Option[Comment])
       extends StatementElement
 
-  case class Document(version: WdlVersion = WdlVersion.Draft_2,
-                      elements: Vector[DocumentElement],
+  case class Document(elements: Vector[DocumentElement],
                       workflow: Option[Workflow],
                       text: TextSource,
                       comment: Option[Comment])

--- a/src/main/scala/wdlTools/syntax/draft_2/Translators.scala
+++ b/src/main/scala/wdlTools/syntax/draft_2/Translators.scala
@@ -184,9 +184,21 @@ object Translators {
                                    comment)
 
       case ConcreteSyntax.Call(name, alias, inputs, text, comment) =>
-        AbstractSyntax.Call(name, alias, inputs.map {
-          case (name, expr) => name -> translateExpr(expr)
-        }, text, comment)
+        AbstractSyntax.Call(
+            name,
+            alias.map {
+              case ConcreteSyntax.CallAlias(callName, callText) =>
+                AbstractSyntax.CallAlias(callName, callText)
+            },
+            inputs.map {
+              case ConcreteSyntax.CallInputs(inputsVec, inputsText) =>
+                AbstractSyntax.CallInputs(inputsVec.map { inp =>
+                  AbstractSyntax.CallInput(inp.name, translateExpr(inp.expr), inp.text)
+                }, inputsText)
+            },
+            text,
+            comment
+        )
 
       case ConcreteSyntax.Scatter(identifier, expr, body, text, comment) =>
         AbstractSyntax.Scatter(identifier,
@@ -217,7 +229,7 @@ object Translators {
   }
 
   def translateImportDoc(importDoc: ConcreteSyntax.ImportDoc,
-                         importedDoc: AbstractSyntax.Document): AbstractSyntax.ImportDoc = {
+                         importedDoc: Option[AbstractSyntax.Document]): AbstractSyntax.ImportDoc = {
     val aliasesAbst: Vector[AbstractSyntax.ImportAlias] = importDoc.aliases.map {
       case ConcreteSyntax.ImportAlias(x, y, alText) => AbstractSyntax.ImportAlias(x, y, alText)
     }

--- a/src/main/scala/wdlTools/syntax/package.scala
+++ b/src/main/scala/wdlTools/syntax/package.scala
@@ -13,9 +13,9 @@ sealed abstract class WdlVersion(val name: String, val order: Int) extends Order
 
 object WdlVersion {
   case object Draft_2 extends WdlVersion("draft-2", 0)
-  case object V1_0 extends WdlVersion("1.0", 1)
+  case object V1 extends WdlVersion("1.0", 1)
 
-  val All: Vector[WdlVersion] = Vector(V1_0, Draft_2).sortWith(_ < _)
+  val All: Vector[WdlVersion] = Vector(V1, Draft_2).sortWith(_ < _)
 
   def fromName(name: String): WdlVersion = {
     All.collectFirst { case v if v.name == name => v }.get
@@ -78,8 +78,8 @@ abstract class WdlParser(opts: Options, loader: SourceCode.Loader) {
       extends DocumentWalker[T] {
     def extractDependencies(document: Document): Map[URL, Document] = {
       document.elements.flatMap {
-        case ImportDoc(_, _, url, doc, _, _) => Some(url -> doc)
-        case _                               => None
+        case ImportDoc(_, _, url, doc, _, _) if doc.isDefined => Some(url -> doc.get)
+        case _                                                => None
       }.toMap
     }
 

--- a/src/main/scala/wdlTools/syntax/v1/ConcreteSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ConcreteSyntax.scala
@@ -1,4 +1,4 @@
-package wdlTools.syntax.v1_0
+package wdlTools.syntax.v1
 
 import java.net.URL
 
@@ -7,7 +7,6 @@ import wdlTools.syntax.{Comment, TextSource, WdlVersion}
 // A concrete syntax for the Workflow Description Language (WDL). This shouldn't be used
 // outside this package. Please use the abstract syntax instead.
 object ConcreteSyntax {
-
   sealed trait Element {
     val text: TextSource // where in the source program does this element belong
   }
@@ -179,10 +178,10 @@ object ConcreteSyntax {
 
   case class CallAlias(name: String, text: TextSource) extends Element
   case class CallInput(name: String, expr: Expr, text: TextSource) extends Element
-  case class CallInputs(value: Map[String, Expr], text: TextSource) extends Element
+  case class CallInputs(value: Vector[CallInput], text: TextSource) extends Element
   case class Call(name: String,
-                  alias: Option[String],
-                  inputs: Map[String, Expr],
+                  alias: Option[CallAlias],
+                  inputs: Option[CallInputs],
                   text: TextSource,
                   comment: Option[Comment])
       extends WorkflowElement
@@ -208,7 +207,7 @@ object ConcreteSyntax {
                       comment: Option[Comment])
       extends StatementElement
 
-  case class Version(value: WdlVersion = WdlVersion.V1_0, text: TextSource) extends Element
+  case class Version(value: WdlVersion = WdlVersion.V1, text: TextSource) extends Element
   case class Document(version: Version,
                       elements: Vector[DocumentElement],
                       workflow: Option[Workflow],

--- a/src/main/scala/wdlTools/syntax/v1/ParseFragment.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ParseFragment.scala
@@ -1,4 +1,4 @@
-package wdlTools.syntax.v1_0
+package wdlTools.syntax.v1
 
 import wdlTools.syntax.{AbstractSyntax, WdlFragmentParser}
 import wdlTools.util.Options

--- a/src/main/scala/wdlTools/syntax/v1/Translators.scala
+++ b/src/main/scala/wdlTools/syntax/v1/Translators.scala
@@ -1,4 +1,4 @@
-package wdlTools.syntax.v1_0
+package wdlTools.syntax.v1
 
 import wdlTools.syntax.AbstractSyntax
 
@@ -189,9 +189,21 @@ object Translators {
                                    comment)
 
       case ConcreteSyntax.Call(name, alias, inputs, text, comment) =>
-        AbstractSyntax.Call(name, alias, inputs.map {
-          case (name, expr) => name -> translateExpr(expr)
-        }, text, comment)
+        AbstractSyntax.Call(
+            name,
+            alias.map {
+              case ConcreteSyntax.CallAlias(callName, callText) =>
+                AbstractSyntax.CallAlias(callName, callText)
+            },
+            inputs.map {
+              case ConcreteSyntax.CallInputs(inputsMap, inputsText) =>
+                AbstractSyntax.CallInputs(inputsMap.map { inp =>
+                  AbstractSyntax.CallInput(inp.name, translateExpr(inp.expr), inp.text)
+                }, inputsText)
+            },
+            text,
+            comment
+        )
 
       case ConcreteSyntax.Scatter(identifier, expr, body, text, comment) =>
         AbstractSyntax.Scatter(identifier,
@@ -234,7 +246,7 @@ object Translators {
   }
 
   def translateImportDoc(importDoc: ConcreteSyntax.ImportDoc,
-                         importedDoc: AbstractSyntax.Document): AbstractSyntax.ImportDoc = {
+                         importedDoc: Option[AbstractSyntax.Document]): AbstractSyntax.ImportDoc = {
     val aliasesAbst: Vector[AbstractSyntax.ImportAlias] = importDoc.aliases.map {
       case ConcreteSyntax.ImportAlias(x, y, alText) => AbstractSyntax.ImportAlias(x, y, alText)
     }

--- a/src/main/scala/wdlTools/syntax/v1/package.scala
+++ b/src/main/scala/wdlTools/syntax/v1/package.scala
@@ -1,4 +1,4 @@
-package wdlTools.syntax.v1_0
+package wdlTools.syntax.v1
 
 import org.antlr.v4.runtime.{CharStream, CommonTokenStream}
 import org.openwdl.wdl.parser.v1_0.{WdlV1Lexer, WdlV1Parser}

--- a/src/main/scala/wdlTools/typing/TypeChecker.scala
+++ b/src/main/scala/wdlTools/typing/TypeChecker.scala
@@ -653,8 +653,12 @@ case class TypeChecker(stdlib: Stdlib) {
   // 2. all the compulsory callee arguments must be specified. Optionals
   //    and arguments that have defaults can be skipped.
   private def applyCall(call: Call, ctx: Context): (String, WT_Call) = {
-    val callerInputs = call.inputs.map {
-      case (name, expr) => name -> typeEval(expr, ctx)
+    val callerInputs: Map[String, WT] = call.inputs match {
+      case Some(CallInputs(value, _)) =>
+        value.map { inp =>
+          inp.name -> typeEval(inp.expr, ctx)
+        }.toMap
+      case None => Map.empty
     }
 
     val (calleeInputs, calleeOutputs) = ctx.callables.get(call.name) match {
@@ -713,7 +717,7 @@ case class TypeChecker(stdlib: Stdlib) {
       case None =>
         val parts = call.name.split("\\.")
         parts.last
-      case Some(alias) => alias
+      case Some(alias) => alias.name
     }
 
     if (ctx.declarations contains callName)
@@ -873,7 +877,7 @@ case class TypeChecker(stdlib: Stdlib) {
         accu.bindCallable(tt, task.text)
 
       case (accu: Context, iStat: ImportDoc) =>
-        val iCtx = apply(iStat.doc, contextEmpty)
+        val iCtx = apply(iStat.doc.get, contextEmpty)
 
         // Figure out what to name the sub-document
         val namespace = iStat.name match {
@@ -885,9 +889,9 @@ case class TypeChecker(stdlib: Stdlib) {
             // will be named:
             //    stdlib
             //    C
-            val nsName = iStat.url.getFile().replaceAll("/", "")
+            val nsName = iStat.url.getFile.replaceAll("/", "")
             if (nsName.endsWith(".wdl"))
-              nsName.dropRight(".wdl".size)
+              nsName.dropRight(".wdl".length)
             else
               nsName
           case Some(x) => x
@@ -911,6 +915,5 @@ case class TypeChecker(stdlib: Stdlib) {
       case None     => context
       case Some(wf) => applyWorkflow(wf, context)
     }
-
   }
 }

--- a/src/test/scala/wdlTools/format/BaseTest.scala
+++ b/src/test/scala/wdlTools/format/BaseTest.scala
@@ -23,7 +23,7 @@ class BaseTest extends FlatSpec with Matchers {
 
   it should "handle the runtime section correctly" in {
     val doc = parser.parse(getWdlURL(fname = "simple.wdl", subdir = "after"))
-    doc.version shouldBe WdlVersion.V1
+    doc.version.value shouldBe WdlVersion.V1
   }
 
   def getWdlSource(fname: String, subdir: String): String = {

--- a/src/test/scala/wdlTools/format/BaseTest.scala
+++ b/src/test/scala/wdlTools/format/BaseTest.scala
@@ -4,14 +4,14 @@ import java.net.URL
 import java.nio.file.{Path, Paths}
 
 import org.scalatest.{FlatSpec, Matchers}
-import wdlTools.formatter.V1_0Formatter
-import wdlTools.syntax.{WdlVersion, v1_0}
+import wdlTools.formatter.WdlV1Formatter
+import wdlTools.syntax.{WdlVersion, v1}
 import wdlTools.util.{Options, SourceCode, Util}
 
 class BaseTest extends FlatSpec with Matchers {
   private lazy val opts = Options()
   private lazy val loader = SourceCode.Loader(opts)
-  private lazy val parser = v1_0.ParseAll(opts, loader)
+  private lazy val parser = v1.ParseAll(opts, loader)
 
   def getWdlPath(fname: String, subdir: String): Path = {
     Paths.get(getClass.getResource(s"/format/${subdir}/${fname}").getPath)
@@ -23,7 +23,7 @@ class BaseTest extends FlatSpec with Matchers {
 
   it should "handle the runtime section correctly" in {
     val doc = parser.parse(getWdlURL(fname = "simple.wdl", subdir = "after"))
-    doc.version shouldBe WdlVersion.V1_0
+    doc.version shouldBe WdlVersion.V1
   }
 
   def getWdlSource(fname: String, subdir: String): String = {
@@ -33,7 +33,7 @@ class BaseTest extends FlatSpec with Matchers {
   it should "reformat simple WDL" in {
     val beforeURL = getWdlURL(fname = "simple.wdl", subdir = "before")
     val expected = getWdlSource(fname = "simple.wdl", subdir = "after")
-    val formatter = V1_0Formatter(opts)
+    val formatter = WdlV1Formatter(opts)
     formatter.formatDocuments(beforeURL)
     formatter.documents(beforeURL).mkString("\n") shouldBe expected
   }

--- a/src/test/scala/wdlTools/syntax/AbstractSyntaxTest.scala
+++ b/src/test/scala/wdlTools/syntax/AbstractSyntaxTest.scala
@@ -28,7 +28,7 @@ class AbstractSyntaxTest extends FlatSpec with Matchers {
   it should "handle import statements" in {
     val doc = parser.apply(getWorkflowSource("imports.wdl"))
 
-    doc.version shouldBe WdlVersion.V1
+    doc.version.value shouldBe WdlVersion.V1
 
     val imports = doc.elements.collect {
       case x: ImportDoc => x
@@ -40,7 +40,7 @@ class AbstractSyntaxTest extends FlatSpec with Matchers {
 
   it should "handle optionals" in {
     val doc = parser.apply(getTaskSource("missing_type_bug.wdl"))
-    doc.version shouldBe WdlVersion.V1
+    doc.version.value shouldBe WdlVersion.V1
   }
 
   it should "type check GATK tasks" in {
@@ -49,7 +49,7 @@ class AbstractSyntaxTest extends FlatSpec with Matchers {
     val sourceCode = loader.apply(Util.getURL(url))
     val doc = parser.apply(sourceCode)
 
-    doc.version shouldBe WdlVersion.V1
+    doc.version.value shouldBe WdlVersion.V1
   }
 
   it should "type check GATK joint genotyping workflow" taggedAs Edge in {
@@ -58,7 +58,7 @@ class AbstractSyntaxTest extends FlatSpec with Matchers {
     val sourceCode = loader.apply(Util.getURL(url))
     val doc = parser.apply(sourceCode)
 
-    doc.version shouldBe WdlVersion.V1
+    doc.version.value shouldBe WdlVersion.V1
   }
 
 }

--- a/src/test/scala/wdlTools/syntax/AbstractSyntaxTest.scala
+++ b/src/test/scala/wdlTools/syntax/AbstractSyntaxTest.scala
@@ -4,7 +4,7 @@ import AbstractSyntax._
 import java.nio.file.Paths
 
 import org.scalatest.{FlatSpec, Matchers}
-import wdlTools.syntax.v1_0.ParseAll
+import wdlTools.syntax.v1.ParseAll
 import wdlTools.util.{Options, SourceCode, Util, Verbosity}
 
 class AbstractSyntaxTest extends FlatSpec with Matchers {
@@ -28,7 +28,7 @@ class AbstractSyntaxTest extends FlatSpec with Matchers {
   it should "handle import statements" in {
     val doc = parser.apply(getWorkflowSource("imports.wdl"))
 
-    doc.version shouldBe WdlVersion.V1_0
+    doc.version shouldBe WdlVersion.V1
 
     val imports = doc.elements.collect {
       case x: ImportDoc => x
@@ -40,7 +40,7 @@ class AbstractSyntaxTest extends FlatSpec with Matchers {
 
   it should "handle optionals" in {
     val doc = parser.apply(getTaskSource("missing_type_bug.wdl"))
-    doc.version shouldBe WdlVersion.V1_0
+    doc.version shouldBe WdlVersion.V1
   }
 
   it should "type check GATK tasks" in {
@@ -49,7 +49,7 @@ class AbstractSyntaxTest extends FlatSpec with Matchers {
     val sourceCode = loader.apply(Util.getURL(url))
     val doc = parser.apply(sourceCode)
 
-    doc.version shouldBe WdlVersion.V1_0
+    doc.version shouldBe WdlVersion.V1
   }
 
   it should "type check GATK joint genotyping workflow" taggedAs Edge in {
@@ -58,7 +58,7 @@ class AbstractSyntaxTest extends FlatSpec with Matchers {
     val sourceCode = loader.apply(Util.getURL(url))
     val doc = parser.apply(sourceCode)
 
-    doc.version shouldBe WdlVersion.V1_0
+    doc.version shouldBe WdlVersion.V1
   }
 
 }

--- a/src/test/scala/wdlTools/syntax/draft_2/ConcreteSyntaxTest.scala
+++ b/src/test/scala/wdlTools/syntax/draft_2/ConcreteSyntaxTest.scala
@@ -3,14 +3,7 @@ package wdlTools.syntax.draft_2
 import java.nio.file.Paths
 
 import org.scalatest.{FlatSpec, Matchers}
-import wdlTools.syntax.{
-  CommentCompound,
-  CommentEmpty,
-  CommentLine,
-  CommentPreformatted,
-  Edge,
-  WdlVersion
-}
+import wdlTools.syntax.{CommentCompound, CommentEmpty, CommentLine, CommentPreformatted, Edge}
 import wdlTools.syntax.draft_2.ConcreteSyntax._
 import wdlTools.util.Verbosity.Quiet
 import wdlTools.util.{Options, SourceCode, Util}
@@ -91,7 +84,6 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
   it should "handle types and expressions" in {
     val doc = getDocument(getTaskSource("expressions.wdl"))
 
-    doc.version shouldBe WdlVersion.Draft_2
     doc.elements.size shouldBe 1
     val elem = doc.elements(0)
     elem shouldBe a[Task]
@@ -266,7 +258,6 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
   it should "handle get name" in {
     val doc = getDocument(getTaskSource("get_name_bug.wdl"))
 
-    doc.version shouldBe WdlVersion.Draft_2
     doc.elements.size shouldBe 1
     val elem = doc.elements(0)
     elem shouldBe a[Task]
@@ -294,7 +285,6 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
   it should "parse a task with an output section only" in {
     val doc = getDocument(getTaskSource("output_section.wdl"))
 
-    doc.version shouldBe WdlVersion.Draft_2
     doc.elements.size shouldBe 1
     val elem = doc.elements(0)
     elem shouldBe a[Task]
@@ -311,7 +301,6 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
   it should "parse a task" in {
     val doc = getDocument(getTaskSource("wc.wdl"))
 
-    doc.version shouldBe WdlVersion.Draft_2
     doc.comment shouldBe Some(
         CommentLine("A task that counts how many lines a file has")
     )
@@ -391,7 +380,6 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
   it should "handle string interpolation" in {
     val doc = getDocument(getTaskSource("interpolation.wdl"))
 
-    doc.version shouldBe WdlVersion.Draft_2
     doc.elements.size shouldBe 1
     val elem = doc.elements(0)
     elem shouldBe a[Task]
@@ -420,7 +408,6 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
     val doc = getDocument(getWorkflowSource("I.wdl"))
     doc.elements.size shouldBe 0
 
-    doc.version shouldBe WdlVersion.Draft_2
     val wf = doc.workflow.get
     wf shouldBe a[Workflow]
 
@@ -432,10 +419,10 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
     }
     calls.size shouldBe 1
     calls(0) should matchPattern {
-      case Call("bar", Some("boz"), _, _, _) =>
+      case Call("bar", Some(CallAlias("boz", _)), _, _, _) =>
     }
-    calls(0).inputs.toVector should matchPattern {
-      case Vector(("i", ExprIdentifier("s", _))) =>
+    calls(0).inputs.get.value should matchPattern {
+      case Vector(CallInput("i", ExprIdentifier("s", _), _)) =>
     }
 
     val scatters = wf.body.collect {
@@ -451,8 +438,8 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
       case Call("add", None, _, _, _) =>
     }
     val call = scatters(0).body(0).asInstanceOf[Call]
-    call.inputs.toVector should matchPattern {
-      case Vector(("x", ExprIdentifier("i", _))) =>
+    call.inputs.get.value should matchPattern {
+      case Vector(CallInput("x", ExprIdentifier("i", _), _)) =>
     }
 
     val conditionals = wf.body.collect {
@@ -477,8 +464,6 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
 
   it should "handle import statements" in {
     val doc = getDocument(getWorkflowSource("imports.wdl"))
-
-    doc.version shouldBe WdlVersion.Draft_2
 
     val imports = doc.elements.collect {
       case x: ImportDoc => x
@@ -521,7 +506,6 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
     val doc = getDocument(getWorkflowSource("chained_expr.wdl"))
     doc.elements.size shouldBe 0
 
-    doc.version shouldBe WdlVersion.Draft_2
     val wf = doc.workflow.get
     wf shouldBe a[Workflow]
 

--- a/src/test/scala/wdlTools/syntax/v1/ConcreteSyntaxTest.scala
+++ b/src/test/scala/wdlTools/syntax/v1/ConcreteSyntaxTest.scala
@@ -428,10 +428,10 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
     }
     calls.size shouldBe 1
     calls(0) should matchPattern {
-      case Call("bar", Some("boz"), _, _, _) =>
+      case Call("bar", Some(CallAlias("boz", _)), _, _, _) =>
     }
-    calls(0).inputs.toVector should matchPattern {
-      case Vector(("i", ExprIdentifier("s", _))) =>
+    calls(0).inputs.get.value should matchPattern {
+      case Vector(CallInput("i", ExprIdentifier("s", _), _)) =>
     }
 
     val scatters = wf.body.collect {
@@ -447,8 +447,8 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
       case Call("add", None, _, _, _) =>
     }
     val call = scatters(0).body(0).asInstanceOf[Call]
-    call.inputs.toVector should matchPattern {
-      case Vector(("x", ExprIdentifier("i", _))) =>
+    call.inputs.get.value should matchPattern {
+      case Vector(CallInput("x", ExprIdentifier("i", _), _)) =>
     }
 
     val conditionals = wf.body.collect {

--- a/src/test/scala/wdlTools/syntax/v1/ConcreteSyntaxTest.scala
+++ b/src/test/scala/wdlTools/syntax/v1/ConcreteSyntaxTest.scala
@@ -1,10 +1,10 @@
-package wdlTools.syntax.v1_0
+package wdlTools.syntax.v1
 
 import java.nio.file.Paths
 
 import org.scalatest.{FlatSpec, Matchers}
 import wdlTools.syntax.{Edge, WdlVersion}
-import wdlTools.syntax.v1_0.ConcreteSyntax._
+import wdlTools.syntax.v1.ConcreteSyntax._
 import wdlTools.util.Verbosity.Quiet
 import wdlTools.util.{Options, SourceCode, Util}
 
@@ -89,7 +89,7 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
   it should "handle types and expressions" in {
     val doc = getDocument(getTaskSource("expressions.wdl"))
 
-    doc.version.value shouldBe WdlVersion.V1_0
+    doc.version.value shouldBe WdlVersion.V1
     doc.elements.size shouldBe 1
     val elem = doc.elements(0)
     elem shouldBe a[Task]
@@ -265,7 +265,7 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
   it should "handle get name" in {
     val doc = getDocument(getTaskSource("get_name_bug.wdl"))
 
-    doc.version.value shouldBe WdlVersion.V1_0
+    doc.version.value shouldBe WdlVersion.V1
     doc.elements.size shouldBe 1
     val elem = doc.elements(0)
     elem shouldBe a[Task]
@@ -294,7 +294,7 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
   it should "parse a task with an output section only" in {
     val doc = getDocument(getTaskSource("output_section.wdl"))
 
-    doc.version.value shouldBe WdlVersion.V1_0
+    doc.version.value shouldBe WdlVersion.V1
     doc.elements.size shouldBe 1
     val elem = doc.elements(0)
     elem shouldBe a[Task]
@@ -311,7 +311,7 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
   it should "parse a task" in {
     val doc = getDocument(getTaskSource("wc.wdl"))
 
-    doc.version.value shouldBe WdlVersion.V1_0
+    doc.version.value shouldBe WdlVersion.V1
     doc.elements.size shouldBe 1
     val elem = doc.elements(0)
     elem shouldBe a[Task]
@@ -363,7 +363,7 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
   it should "handle string interpolation" in {
     val doc = getDocument(getTaskSource("interpolation.wdl"))
 
-    doc.version.value shouldBe WdlVersion.V1_0
+    doc.version.value shouldBe WdlVersion.V1
     doc.elements.size shouldBe 1
     val elem = doc.elements(0)
     elem shouldBe a[Task]
@@ -391,7 +391,7 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
   it should "parse structs" in {
     val doc = getDocument(getStructSource("I.wdl"))
 
-    doc.version.value shouldBe WdlVersion.V1_0
+    doc.version.value shouldBe WdlVersion.V1
     val structs = doc.elements.collect {
       case x: TypeStruct => x
     }
@@ -416,7 +416,7 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
     val doc = getDocument(getWorkflowSource("I.wdl"))
     doc.elements.size shouldBe 0
 
-    doc.version.value shouldBe WdlVersion.V1_0
+    doc.version.value shouldBe WdlVersion.V1
     val wf = doc.workflow.get
     wf shouldBe a[Workflow]
 
@@ -472,7 +472,7 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
   it should "handle import statements" in {
     val doc = getDocument(getWorkflowSource("imports.wdl"))
 
-    doc.version.value shouldBe WdlVersion.V1_0
+    doc.version.value shouldBe WdlVersion.V1
 
     val imports = doc.elements.collect {
       case x: ImportDoc => x
@@ -517,7 +517,7 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
     val doc = getDocument(getWorkflowSource("chained_expr.wdl"))
     doc.elements.size shouldBe 0
 
-    doc.version.value shouldBe WdlVersion.V1_0
+    doc.version.value shouldBe WdlVersion.V1
     val wf = doc.workflow.get
     wf shouldBe a[Workflow]
 
@@ -535,7 +535,7 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
     val sourceCode = loader.apply(Util.getURL(url))
     val doc = getDocument(sourceCode)
 
-    doc.version.value shouldBe WdlVersion.V1_0
+    doc.version.value shouldBe WdlVersion.V1
     doc.elements.size shouldBe 19
   }
 }

--- a/src/test/scala/wdlTools/typing/TypeCheckerTest.scala
+++ b/src/test/scala/wdlTools/typing/TypeCheckerTest.scala
@@ -4,7 +4,7 @@ import collection.JavaConverters._
 import java.nio.file.{Files, Path, Paths}
 
 import org.scalatest.{FlatSpec, Matchers}
-import wdlTools.syntax.v1_0.ParseAll
+import wdlTools.syntax.v1.ParseAll
 import wdlTools.syntax.AbstractSyntax._
 import wdlTools.util.{Options, SourceCode, Util, Verbosity}
 

--- a/src/test/scala/wdlTools/typing/TypeCheckerTest.scala
+++ b/src/test/scala/wdlTools/typing/TypeCheckerTest.scala
@@ -19,7 +19,8 @@ class TypeCheckerTest extends FlatSpec with Matchers {
               Paths.get(getClass.getResource("/typing/v1_0/workflows/negative").getPath)
           )
       ),
-      verbosity = Verbosity.Verbose
+      verbosity = Verbosity.Verbose,
+      followImports = true
   )
   private val loader = SourceCode.Loader(opts)
   private val parser = ParseAll(opts, loader)
@@ -112,7 +113,7 @@ class TypeCheckerTest extends FlatSpec with Matchers {
     }
   }
 
-  it should "be able to handle GATK" taggedAs Edge in {
+  ignore should "be able to handle GATK" taggedAs Edge in {
     val url = Util.getURL(
         "https://raw.githubusercontent.com/gatk-workflows/gatk4-germline-snps-indels/master/JointGenotyping-terra.wdl"
     )
@@ -126,7 +127,7 @@ class TypeCheckerTest extends FlatSpec with Matchers {
     checker.apply(doc)
   } */
 
-  it should "handle compound expressions" taggedAs (Edge) in {
+  it should "handle compound expressions" taggedAs Edge in {
     val src =
       Paths.get(
           getClass.getResource("/typing/v1_0/workflows/positive/compound_expr_bug.wdl").getPath

--- a/src/test/scala/wdlTools/upgrade/BaseTest.scala
+++ b/src/test/scala/wdlTools/upgrade/BaseTest.scala
@@ -27,7 +27,7 @@ class BaseTest extends FlatSpec with Matchers {
     val (beforeURL, afterPath) = getBeforeAfterPair("simple.wdl")
     val expected = Util.readFromFile(afterPath)
     val upgrader = Upgrader(opts)
-    val documents = upgrader.upgrade(beforeURL, Some(WdlVersion.Draft_2), WdlVersion.V1_0)
+    val documents = upgrader.upgrade(beforeURL, Some(WdlVersion.Draft_2), WdlVersion.V1)
     documents(beforeURL).mkString("\n") shouldBe expected
   }
 }


### PR DESCRIPTION
* AST changes:
  * Add Version element
  * Make doc optional in ImportDoc
  * Make the various parts of Call be elements
* Unify WDL version naming (use v1/V1 everywhere)
* Remove followImports option from check command - type-checker always follows imports