### PR TITLE
Some syntax changes to support development of linter and formatter

### DIFF
--- a/src/main/antlr4/draft_2/WdlDraft2Lexer.g4
+++ b/src/main/antlr4/draft_2/WdlDraft2Lexer.g4
@@ -22,8 +22,8 @@ OUTPUT: 'output';
 PARAMETERMETA: 'parameter_meta';
 META: 'meta';
 
-HEREDOC_COMMAND: 'command' ' '* '<<<' -> pushMode(HereDocCommand);
-COMMAND: 'command' ' '* '{' -> pushMode(Command);
+HEREDOC_COMMAND: 'command' [ \t\r\n]* '<<<' -> pushMode(HereDocCommand);
+COMMAND: 'command' [ \t\r\n]* '{' -> pushMode(Command);
 
 RUNTIME: 'runtime';
 BOOLEAN: 'Boolean';
@@ -88,10 +88,6 @@ DQUOTE: '"' -> pushMode(DquoteInterpolatedString);
 
 WHITESPACE
 	: [ \t\r\n]+ -> channel(HIDDEN)
-	;
-
-COMMENT
-	: '#' ~[\r\n]* -> channel(HIDDEN)
 	;
 
 Identifier: CompleteIdentifier;

--- a/src/main/antlr4/v1/WdlV1Lexer.g4
+++ b/src/main/antlr4/v1/WdlV1Lexer.g4
@@ -24,8 +24,8 @@ OUTPUT: 'output';
 PARAMETERMETA: 'parameter_meta';
 META: 'meta';
 
-HEREDOC_COMMAND: 'command' ' '* '<<<' -> pushMode(HereDocCommand);
-COMMAND: 'command' ' '* '{' -> pushMode(Command);
+HEREDOC_COMMAND: 'command' [ \t\r\n]* '<<<' -> pushMode(HereDocCommand);
+COMMAND: 'command' [ \t\r\n]* '{' -> pushMode(Command);
 
 RUNTIME: 'runtime';
 BOOLEAN: 'Boolean';

--- a/src/main/scala/wdlTools/formatter/WdlV1Formatter.scala
+++ b/src/main/scala/wdlTools/formatter/WdlV1Formatter.scala
@@ -307,8 +307,8 @@ case class WdlV1Formatter(opts: Options,
       case ExprMap(value, _) =>
         Container(
             value.map {
-              case (k, v) => KeyValue(nested(k), nested(v))
-            }.toVector,
+              case ExprMapItem(k, v, _) => KeyValue(nested(k), nested(v))
+            },
             prefix = Some(Token.MapOpen),
             suffix = Some(Token.MapClose),
             wrapAll = true
@@ -316,8 +316,8 @@ case class WdlV1Formatter(opts: Options,
       case ExprObject(value, _) =>
         Container(
             value.map {
-              case (k, v) => KeyValue(Token(k), nested(v))
-            }.toVector,
+              case ExprObjectMember(k, v, _) => KeyValue(Token(k), nested(v))
+            },
             prefix = Some(Token.MapOpen),
             suffix = Some(Token.MapClose),
             wrapAll = true
@@ -426,10 +426,11 @@ case class WdlV1Formatter(opts: Options,
         lineFormatter.appendComment(importDoc.comment.get)
       }
       lineFormatter.beginLine()
-      lineFormatter.appendAll(Vector(Token.Import, StringLiteral(importDoc.url.toString)),
+      lineFormatter.appendAll(Vector(Token.Import, StringLiteral(importDoc.addr.toString)),
                               Wrapping.Never)
       if (importDoc.name.isDefined) {
-        lineFormatter.appendAll(Vector(Token.As, Token(importDoc.name.get)), Wrapping.AsNeeded)
+        lineFormatter.appendAll(Vector(Token.As, Token(importDoc.name.get.value)),
+                                Wrapping.AsNeeded)
       }
       importDoc.aliases.foreach { alias =>
         lineFormatter.appendAll(Vector(Token.Alias, Token(alias.id1), Token.As, Token(alias.id2)),

--- a/src/main/scala/wdlTools/generators/ProjectGenerator.scala
+++ b/src/main/scala/wdlTools/generators/ProjectGenerator.scala
@@ -70,8 +70,8 @@ case class ProjectGenerator(opts: Options,
       case ExprPair(l, r, _)                                                             => requiresEvaluation(l) || requiresEvaluation(r)
       case ExprArray(value, _)                                                           => value.exists(requiresEvaluation)
       case ExprMap(value, _) =>
-        value.exists(elt => requiresEvaluation(elt._1) || requiresEvaluation(elt._2))
-      case ExprObject(value, _) => value.values.exists(requiresEvaluation)
+        value.exists(elt => requiresEvaluation(elt.key) || requiresEvaluation(elt.value))
+      case ExprObject(value, _) => value.exists(item => requiresEvaluation(item.value))
       case _                    => true
     }
   }
@@ -223,7 +223,8 @@ case class ProjectGenerator(opts: Options,
       taskModels.map(_.toTask)
     }
 
-    val doc = Document(Version(wdlVersion, null, None),
+    val doc = Document(null,
+                       Version(wdlVersion, null, None),
                        null,
                        tasksAndLinkedInputs.map(_._1),
                        workflowModel.map(_.toWorkflow(tasksAndLinkedInputs)),
@@ -270,7 +271,7 @@ object ProjectGenerator {
     }
 
     def toMeta: Option[MetaKV] = {
-      val metaMap: Map[String, Expr] = Map(
+      val metaMap: Vector[ExprObjectMember] = Map(
           "label" -> label.map(ValueString(_, null)),
           "help" -> help.map(ValueString(_, null)),
           "patterns" -> (if (patterns.isEmpty) {
@@ -285,8 +286,10 @@ object ProjectGenerator {
                           Some(ExprArray(choices.toVector, null))
                         })
       ).collect {
-        case (key, Some(value)) => key -> value
-      }
+          case (key, Some(value)) => key -> value
+        }
+        .map(item => ExprObjectMember(item._1, item._2, null))
+        .toVector
       if (metaMap.isEmpty) {
         None
       } else {

--- a/src/main/scala/wdlTools/syntax/draft_2/ConcreteSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/draft_2/ConcreteSyntax.scala
@@ -51,8 +51,10 @@ object ConcreteSyntax {
   // For example:
   //  "some string part ~{ident + ident} some string part after"
   case class ExprCompoundString(value: Vector[Expr], text: TextSource) extends Expr
-  case class ExprMapLiteral(value: Map[Expr, Expr], text: TextSource) extends Expr
-  case class ExprObjectLiteral(value: Map[String, Expr], text: TextSource) extends Expr
+  case class ExprMapItem(key: Expr, value: Expr, text: TextSource) extends Expr
+  case class ExprMapLiteral(value: Vector[ExprMapItem], text: TextSource) extends Expr
+  case class ExprObjectMember(key: String, value: Expr, text: TextSource) extends Expr
+  case class ExprObjectLiteral(value: Vector[ExprObjectMember], text: TextSource) extends Expr
   case class ExprArrayLiteral(value: Vector[Expr], text: TextSource) extends Expr
 
   case class ExprIdentifier(id: String, text: TextSource) extends Expr
@@ -156,9 +158,11 @@ object ConcreteSyntax {
   case class ImportAlias(id1: String, id2: String, text: TextSource) extends Element
 
   // import statement as read from the document
-  case class ImportDoc(name: Option[String],
+  case class ImportAddr(value: String, text: TextSource) extends Element
+  case class ImportName(value: String, text: TextSource) extends Element
+  case class ImportDoc(name: Option[ImportName],
                        aliases: Vector[ImportAlias],
-                       url: URL,
+                       addr: ImportAddr,
                        text: TextSource,
                        comment: Option[Comment])
       extends DocumentElement
@@ -207,7 +211,8 @@ object ConcreteSyntax {
                       comment: Option[Comment])
       extends StatementElement
 
-  case class Document(elements: Vector[DocumentElement],
+  case class Document(docSourceURL: URL,
+                      elements: Vector[DocumentElement],
                       workflow: Option[Workflow],
                       text: TextSource,
                       comment: Option[Comment])

--- a/src/main/scala/wdlTools/syntax/draft_2/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/draft_2/ParseAll.scala
@@ -47,7 +47,7 @@ case class ParseAll(opts: Options, loader: SourceCode.Loader) extends WdlParser(
     val elems: Vector[AbstractSyntax.DocumentElement] = doc.elements.map {
       case importDoc: ConcreteSyntax.ImportDoc =>
         val importedDoc = if (opts.followImports) {
-          Some(followImport(importDoc.url))
+          Some(followImport(getDocSourceURL(importDoc.addr.value)))
         } else {
           None
         }
@@ -57,8 +57,8 @@ case class ParseAll(opts: Options, loader: SourceCode.Loader) extends WdlParser(
     }
 
     val aWf = doc.workflow.map(translateWorkflow)
-    val version = AbstractSyntax.Version(WdlVersion.Draft_2, TextSource(-1, -1), None)
-    AbstractSyntax.Document(version, None, elems, aWf, doc.text, doc.comment)
+    val version = AbstractSyntax.Version(WdlVersion.Draft_2, TextSource.empty, None)
+    AbstractSyntax.Document(doc.docSourceURL, version, None, elems, aWf, doc.text, doc.comment)
   }
 
   def apply(sourceCode: SourceCode): AbstractSyntax.Document = {

--- a/src/main/scala/wdlTools/syntax/draft_2/ParseTop.scala
+++ b/src/main/scala/wdlTools/syntax/draft_2/ParseTop.scala
@@ -8,7 +8,7 @@ import collection.JavaConverters._
 import org.antlr.v4.runtime._
 import org.antlr.v4.runtime.tree.TerminalNode
 import org.openwdl.wdl.parser.draft_2._
-import wdlTools.syntax.Antlr4Util.Grammar
+import wdlTools.syntax.Antlr4Util.{Grammar, getTextSource}
 import wdlTools.syntax.draft_2.ConcreteSyntax._
 import wdlTools.syntax.{Comment, SyntaxException, TextSource}
 import wdlTools.util.Options
@@ -18,22 +18,15 @@ case class ParseTop(opts: Options,
                     docSourceURL: Option[URL] = None)
     extends WdlDraft2ParserBaseVisitor[Element] {
 
-  private def getSourceText(ctx: ParserRuleContext): TextSource = {
-    grammar.getSourceText(ctx, docSourceURL)
-  }
-
-  private def getSourceText(symbol: TerminalNode): TextSource = {
-    grammar.getSourceText(symbol, docSourceURL)
-  }
-
   private def getComment(ctx: ParserRuleContext): Option[Comment] = {
     grammar.getComment(ctx)
   }
 
   private def getIdentifierText(identifier: TerminalNode, ctx: ParserRuleContext): String = {
-    if (identifier == null)
-      throw new SyntaxException("missing identifier", getSourceText(ctx))
-    identifier.getText()
+    if (identifier == null) {
+      throw new SyntaxException("missing identifier", getTextSource(ctx))
+    }
+    identifier.getText
   }
 
   /*
@@ -44,7 +37,7 @@ map_type
   override def visitMap_type(ctx: WdlDraft2Parser.Map_typeContext): Type = {
     val kt: Type = visitWdl_type(ctx.wdl_type(0))
     val vt: Type = visitWdl_type(ctx.wdl_type(1))
-    TypeMap(kt, vt, getSourceText(ctx))
+    TypeMap(kt, vt, getTextSource(ctx))
   }
 
   /*
@@ -55,7 +48,7 @@ array_type
   override def visitArray_type(ctx: WdlDraft2Parser.Array_typeContext): Type = {
     val t: Type = visitWdl_type(ctx.wdl_type())
     val nonEmpty = ctx.PLUS() != null
-    TypeArray(t, nonEmpty, getSourceText(ctx))
+    TypeArray(t, nonEmpty, getTextSource(ctx))
   }
 
   /*
@@ -66,7 +59,7 @@ pair_type
   override def visitPair_type(ctx: WdlDraft2Parser.Pair_typeContext): Type = {
     val lt: Type = visitWdl_type(ctx.wdl_type(0))
     val rt: Type = visitWdl_type(ctx.wdl_type(1))
-    TypePair(lt, rt, getSourceText(ctx))
+    TypePair(lt, rt, getTextSource(ctx))
   }
 
   /*
@@ -85,18 +78,18 @@ type_base
     if (ctx.pair_type() != null)
       return visitPair_type(ctx.pair_type())
     if (ctx.STRING() != null)
-      return TypeString(getSourceText(ctx))
+      return TypeString(getTextSource(ctx))
     if (ctx.FILE() != null)
-      return TypeFile(getSourceText(ctx))
+      return TypeFile(getTextSource(ctx))
     if (ctx.BOOLEAN() != null)
-      return TypeBoolean(getSourceText(ctx))
+      return TypeBoolean(getTextSource(ctx))
     if (ctx.OBJECT() != null)
-      return TypeObject(getSourceText(ctx))
+      return TypeObject(getTextSource(ctx))
     if (ctx.INT() != null)
-      return TypeInt(getSourceText(ctx))
+      return TypeInt(getTextSource(ctx))
     if (ctx.FLOAT() != null)
-      return TypeFloat(getSourceText(ctx))
-    throw new SyntaxException("sanity: unrecgonized type case", getSourceText(ctx))
+      return TypeFloat(getTextSource(ctx))
+    throw new SyntaxException("sanity: unrecgonized type case", getTextSource(ctx))
   }
 
   /*
@@ -107,7 +100,7 @@ wdl_type
   override def visitWdl_type(ctx: WdlDraft2Parser.Wdl_typeContext): Type = {
     val t = visitType_base(ctx.type_base())
     if (ctx.OPTIONAL() != null) {
-      TypeOptional(t, getSourceText(ctx))
+      TypeOptional(t, getTextSource(ctx))
     } else {
       t
     }
@@ -117,12 +110,12 @@ wdl_type
 
   override def visitNumber(ctx: WdlDraft2Parser.NumberContext): Expr = {
     if (ctx.IntLiteral() != null) {
-      return ExprInt(ctx.getText.toInt, getSourceText(ctx))
+      return ExprInt(ctx.getText.toInt, getTextSource(ctx))
     }
     if (ctx.FloatLiteral() != null) {
-      return ExprFloat(ctx.getText.toDouble, getSourceText(ctx))
+      return ExprFloat(ctx.getText.toDouble, getTextSource(ctx))
     }
-    throw new SyntaxException("Not an integer nor a float", getSourceText(ctx))
+    throw new SyntaxException("Not an integer nor a float", getTextSource(ctx))
   }
 
   /* expression_placeholder_option
@@ -139,20 +132,20 @@ wdl_type
       else if (ctx.number() != null)
         visitNumber(ctx.number())
       else
-        throw new SyntaxException("sanity: not a string or a number", getSourceText(ctx))
+        throw new SyntaxException("sanity: not a string or a number", getTextSource(ctx))
 
     if (ctx.BoolLiteral() != null) {
       val b = ctx.BoolLiteral().getText.toLowerCase() == "true"
-      return ExprPlaceholderPartEqual(b, expr, getSourceText(ctx))
+      return ExprPlaceholderPartEqual(b, expr, getTextSource(ctx))
     }
     if (ctx.DEFAULT() != null) {
-      return ExprPlaceholderPartDefault(expr, getSourceText(ctx))
+      return ExprPlaceholderPartDefault(expr, getTextSource(ctx))
     }
     if (ctx.SEP() != null) {
-      return ExprPlaceholderPartSep(expr, getSourceText(ctx))
+      return ExprPlaceholderPartSep(expr, getTextSource(ctx))
     }
     throw new SyntaxException(s"Not one of three known variants of a placeholder",
-                              getSourceText(ctx))
+                              getTextSource(ctx))
   }
 
   // These are full expressions of the same kind
@@ -169,7 +162,7 @@ wdl_type
       // ${x + 3}
       return expr
     }
-    val source = getSourceText(ctx)
+    val source = getTextSource(ctx)
 
     // This is a place-holder such as
     //   ${default="foo" optional_value}
@@ -181,7 +174,7 @@ wdl_type
         case ExprPlaceholderPartSep(sep, _) =>
           return ExprPlaceholderSep(sep, expr, source)
         case _ =>
-          throw new SyntaxException("invalid place holder", getSourceText(ctx))
+          throw new SyntaxException("invalid place holder", getTextSource(ctx))
       }
     }
 
@@ -193,13 +186,13 @@ wdl_type
         case (ExprPlaceholderPartEqual(false, x, _), ExprPlaceholderPartEqual(true, y, _)) =>
           return ExprPlaceholderEqual(y, x, expr, source)
         case (_: ExprPlaceholderPartEqual, _: ExprPlaceholderPartEqual) =>
-          throw new SyntaxException("invalid boolean place holder", getSourceText(ctx))
+          throw new SyntaxException("invalid boolean place holder", getTextSource(ctx))
         case (_, _) =>
-          throw new SyntaxException("invalid place holder", getSourceText(ctx))
+          throw new SyntaxException("invalid place holder", getTextSource(ctx))
       }
     }
 
-    throw new SyntaxException("invalid place holder", getSourceText(ctx))
+    throw new SyntaxException("invalid place holder", getTextSource(ctx))
   }
 
   /* string_part
@@ -209,9 +202,9 @@ wdl_type
     val parts: Vector[Expr] = ctx
       .StringPart()
       .asScala
-      .map(x => ExprString(x.getText, getSourceText(x)))
+      .map(x => ExprString(x.getText, getTextSource(x)))
       .toVector
-    ExprCompoundString(parts, getSourceText(ctx))
+    ExprCompoundString(parts, getTextSource(ctx))
   }
 
   /* string_expr_part
@@ -235,7 +228,7 @@ wdl_type
   ): ExprCompoundString = {
     val exprPart = visitString_expr_part(ctx.string_expr_part())
     val strPart = visitString_part(ctx.string_part())
-    ExprCompoundString(Vector(exprPart, strPart), getSourceText(ctx))
+    ExprCompoundString(Vector(exprPart, strPart), getTextSource(ctx))
   }
 
   /*
@@ -245,7 +238,7 @@ string
   ;
    */
   override def visitString(ctx: WdlDraft2Parser.StringContext): Expr = {
-    val stringPart = ExprString(ctx.string_part().getText, getSourceText(ctx.string_part()))
+    val stringPart = ExprString(ctx.string_part().getText, getTextSource(ctx.string_part()))
     val exprPart: Vector[ExprCompoundString] = ctx
       .string_expr_with_string_part()
       .asScala
@@ -257,7 +250,7 @@ string
       stringPart
     } else {
       // A string that includes interpolation
-      ExprCompoundString(Vector(stringPart) ++ exprPart2, getSourceText(ctx))
+      ExprCompoundString(Vector(stringPart) ++ exprPart2, getTextSource(ctx))
     }
   }
 
@@ -270,7 +263,7 @@ string
   override def visitPrimitive_literal(ctx: WdlDraft2Parser.Primitive_literalContext): Expr = {
     if (ctx.BoolLiteral() != null) {
       val value = ctx.getText.toLowerCase() == "true"
-      return ExprBoolean(value, getSourceText(ctx))
+      return ExprBoolean(value, getTextSource(ctx))
     }
     if (ctx.number() != null) {
       return visitNumber(ctx.number())
@@ -279,87 +272,87 @@ string
       return visitString(ctx.string())
     }
     if (ctx.Identifier() != null) {
-      return ExprIdentifier(ctx.getText, getSourceText(ctx))
+      return ExprIdentifier(ctx.getText, getTextSource(ctx))
     }
     throw new SyntaxException("Not one of four supported variants of primitive_literal",
-                              getSourceText(ctx))
+                              getTextSource(ctx))
   }
 
   override def visitLor(ctx: WdlDraft2Parser.LorContext): Expr = {
     val arg0: Expr = visitExpr_infix0(ctx.expr_infix0())
     val arg1: Expr = visitExpr_infix1(ctx.expr_infix1())
-    ExprLor(arg0, arg1, getSourceText(ctx))
+    ExprLor(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitLand(ctx: WdlDraft2Parser.LandContext): Expr = {
     val arg0 = visitExpr_infix1(ctx.expr_infix1())
     val arg1 = visitExpr_infix2(ctx.expr_infix2())
-    ExprLand(arg0, arg1, getSourceText(ctx))
+    ExprLand(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitEqeq(ctx: WdlDraft2Parser.EqeqContext): Expr = {
     val arg0 = visitExpr_infix2(ctx.expr_infix2())
     val arg1 = visitExpr_infix3(ctx.expr_infix3())
-    ExprEqeq(arg0, arg1, getSourceText(ctx))
+    ExprEqeq(arg0, arg1, getTextSource(ctx))
   }
   override def visitLt(ctx: WdlDraft2Parser.LtContext): Expr = {
     val arg0 = visitExpr_infix2(ctx.expr_infix2())
     val arg1 = visitExpr_infix3(ctx.expr_infix3())
-    ExprLt(arg0, arg1, getSourceText(ctx))
+    ExprLt(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitGte(ctx: WdlDraft2Parser.GteContext): Expr = {
     val arg0 = visitExpr_infix2(ctx.expr_infix2())
     val arg1 = visitExpr_infix3(ctx.expr_infix3())
-    ExprGte(arg0, arg1, getSourceText(ctx))
+    ExprGte(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitNeq(ctx: WdlDraft2Parser.NeqContext): Expr = {
     val arg0 = visitExpr_infix2(ctx.expr_infix2())
     val arg1 = visitExpr_infix3(ctx.expr_infix3())
-    ExprNeq(arg0, arg1, getSourceText(ctx))
+    ExprNeq(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitLte(ctx: WdlDraft2Parser.LteContext): Expr = {
     val arg0 = visitExpr_infix2(ctx.expr_infix2())
     val arg1 = visitExpr_infix3(ctx.expr_infix3())
-    ExprLte(arg0, arg1, getSourceText(ctx))
+    ExprLte(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitGt(ctx: WdlDraft2Parser.GtContext): Expr = {
     val arg0 = visitExpr_infix2(ctx.expr_infix2())
     val arg1 = visitExpr_infix3(ctx.expr_infix3())
-    ExprGt(arg0, arg1, getSourceText(ctx))
+    ExprGt(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitAdd(ctx: WdlDraft2Parser.AddContext): Expr = {
     val arg0 = visitExpr_infix3(ctx.expr_infix3())
     val arg1 = visitExpr_infix4(ctx.expr_infix4())
-    ExprAdd(arg0, arg1, getSourceText(ctx))
+    ExprAdd(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitSub(ctx: WdlDraft2Parser.SubContext): Expr = {
     val arg0 = visitExpr_infix3(ctx.expr_infix3())
     val arg1 = visitExpr_infix4(ctx.expr_infix4())
-    ExprSub(arg0, arg1, getSourceText(ctx))
+    ExprSub(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitMod(ctx: WdlDraft2Parser.ModContext): Expr = {
     val arg0 = visitExpr_infix4(ctx.expr_infix4())
     val arg1 = visitExpr_infix5(ctx.expr_infix5())
-    ExprMod(arg0, arg1, getSourceText(ctx))
+    ExprMod(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitMul(ctx: WdlDraft2Parser.MulContext): Expr = {
     val arg0 = visitExpr_infix4(ctx.expr_infix4())
     val arg1 = visitExpr_infix5(ctx.expr_infix5())
-    ExprMul(arg0, arg1, getSourceText(ctx))
+    ExprMul(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitDivide(ctx: WdlDraft2Parser.DivideContext): Expr = {
     val arg0 = visitExpr_infix4(ctx.expr_infix4())
     val arg1 = visitExpr_infix5(ctx.expr_infix5())
-    ExprDivide(arg0, arg1, getSourceText(ctx))
+    ExprDivide(arg0, arg1, getTextSource(ctx))
   }
 
   // | LPAREN expr RPAREN #expression_group
@@ -374,14 +367,14 @@ string
       .asScala
       .map(x => visitExpr(x))
       .toVector
-    ExprArrayLiteral(elements, getSourceText(ctx))
+    ExprArrayLiteral(elements, getTextSource(ctx))
   }
 
   // | LPAREN expr COMMA expr RPAREN #pair_literal
   override def visitPair_literal(ctx: WdlDraft2Parser.Pair_literalContext): Expr = {
     val arg0 = visitExpr(ctx.expr(0))
     val arg1 = visitExpr(ctx.expr(1))
-    ExprPair(arg0, arg1, getSourceText(ctx))
+    ExprPair(arg0, arg1, getTextSource(ctx))
   }
 
   //| LBRACE (expr COLON expr (COMMA expr COLON expr)*)* RBRACE #map_literal
@@ -394,32 +387,45 @@ string
 
     val n = elements.size
     if (n % 2 != 0)
-      throw new SyntaxException("the expressions in a map must come in pairs", getSourceText(ctx))
+      throw new SyntaxException("the expressions in a map must come in pairs", getTextSource(ctx))
 
-    val m: Map[Expr, Expr] =
-      Vector.tabulate(n / 2)(i => elements(2 * i) -> elements(2 * i + 1)).toMap
-    ExprMapLiteral(m, getSourceText(ctx))
+    val m: Vector[ExprMapItem] = Vector.tabulate(n / 2) { i =>
+      val key = elements(2 * i)
+      val value = elements(2 * i + 1)
+      ExprMapItem(key,
+                  value,
+                  TextSource(key.text.line, key.text.col, value.text.endLine, value.text.endCol))
+    }
+    ExprMapLiteral(m, getTextSource(ctx))
   }
 
   // | OBJECT_LITERAL LBRACE (Identifier COLON expr (COMMA Identifier COLON expr)*)* RBRACE #object_literal
   override def visitObject_literal(ctx: WdlDraft2Parser.Object_literalContext): Expr = {
-    val ids: Vector[String] = ctx
+    val ids: Vector[TerminalNode] = ctx
       .Identifier()
       .asScala
-      .map(x => x.getText)
       .toVector
     val elements: Vector[Expr] = ctx
       .expr()
       .asScala
       .map(x => visitExpr(x))
       .toVector
-    ExprObjectLiteral((ids zip elements).toMap, getSourceText(ctx))
+    val members = ids.zip(elements).map { pair =>
+      val id = pair._1
+      val expr = pair._2
+      val textSource = TextSource(id.getSymbol.getLine,
+                                  id.getSymbol.getCharPositionInLine,
+                                  expr.text.endLine,
+                                  expr.text.endCol)
+      ExprObjectMember(id.getText, expr, textSource)
+    }
+    ExprObjectLiteral(members, getTextSource(ctx))
   }
 
   // | NOT expr #negate
   override def visitNegate(ctx: WdlDraft2Parser.NegateContext): Expr = {
     val expr = visitExpr(ctx.expr())
-    ExprNegate(expr, getSourceText(ctx))
+    ExprNegate(expr, getTextSource(ctx))
   }
 
   // | (PLUS | MINUS) expr #unirarysigned
@@ -427,18 +433,18 @@ string
     val expr = visitExpr(ctx.expr())
 
     if (ctx.PLUS() != null)
-      ExprUniraryPlus(expr, getSourceText(ctx))
+      ExprUniraryPlus(expr, getTextSource(ctx))
     else if (ctx.MINUS() != null)
-      ExprUniraryMinus(expr, getSourceText(ctx))
+      ExprUniraryMinus(expr, getTextSource(ctx))
     else
-      throw new SyntaxException("sanity", getSourceText(ctx))
+      throw new SyntaxException("sanity", getTextSource(ctx))
   }
 
   // | expr_core LBRACK expr RBRACK #at
   override def visitAt(ctx: WdlDraft2Parser.AtContext): Expr = {
     val array = visitExpr_core(ctx.expr_core())
     val index = visitExpr(ctx.expr())
-    ExprAt(array, index, getSourceText(ctx))
+    ExprAt(array, index, getTextSource(ctx))
   }
 
   // | Identifier LPAREN (expr (COMMA expr)*)? RPAREN #apply
@@ -449,7 +455,7 @@ string
       .asScala
       .map(x => visitExpr(x))
       .toVector
-    ExprApply(funcName, elements, getSourceText(ctx))
+    ExprApply(funcName, elements, getTextSource(ctx))
   }
 
   // | IF expr THEN expr ELSE expr #ifthenelse
@@ -459,19 +465,19 @@ string
       .asScala
       .map(x => visitExpr(x))
       .toVector
-    ExprIfThenElse(elements(0), elements(1), elements(2), getSourceText(ctx))
+    ExprIfThenElse(elements(0), elements(1), elements(2), getTextSource(ctx))
   }
 
   override def visitLeft_name(ctx: WdlDraft2Parser.Left_nameContext): Expr = {
     val id = getIdentifierText(ctx.Identifier(), ctx)
-    ExprIdentifier(id, getSourceText(ctx))
+    ExprIdentifier(id, getTextSource(ctx))
   }
 
   // | expr_core DOT Identifier #get_name
   override def visitGet_name(ctx: WdlDraft2Parser.Get_nameContext): Expr = {
     val e = visitExpr_core(ctx.expr_core())
     val id = ctx.Identifier.getText
-    ExprGetName(e, id, getSourceText(ctx))
+    ExprGetName(e, id, getTextSource(ctx))
   }
 
   /*expr_infix0
@@ -563,7 +569,7 @@ string
       visitChildren(ctx).asInstanceOf[Expr]
     } catch {
       case ex: NullPointerException =>
-        throw new SyntaxException("bad expression", getSourceText(ctx))
+        throw new SyntaxException("bad expression", getTextSource(ctx))
     }
   }
 
@@ -608,10 +614,10 @@ unbound_decls
    */
   override def visitUnbound_decls(ctx: WdlDraft2Parser.Unbound_declsContext): Declaration = {
     if (ctx.wdl_type() == null)
-      throw new SyntaxException("type missing in declaration", getSourceText(ctx))
+      throw new SyntaxException("type missing in declaration", getTextSource(ctx))
     val wdlType: Type = visitWdl_type(ctx.wdl_type())
     val name: String = getIdentifierText(ctx.Identifier(), ctx)
-    Declaration(name, wdlType, None, getSourceText(ctx), getComment(ctx))
+    Declaration(name, wdlType, None, getTextSource(ctx), getComment(ctx))
   }
 
   /*
@@ -621,13 +627,13 @@ bound_decls
    */
   override def visitBound_decls(ctx: WdlDraft2Parser.Bound_declsContext): Declaration = {
     if (ctx.wdl_type() == null)
-      throw new SyntaxException("type missing in declaration", getSourceText(ctx))
+      throw new SyntaxException("type missing in declaration", getTextSource(ctx))
     val wdlType: Type = visitWdl_type(ctx.wdl_type())
     val name: String = getIdentifierText(ctx.Identifier(), ctx)
     if (ctx.expr() == null)
-      return Declaration(name, wdlType, None, getSourceText(ctx), getComment(ctx))
+      return Declaration(name, wdlType, None, getTextSource(ctx), getComment(ctx))
     val expr: Expr = visitExpr(ctx.expr())
-    Declaration(name, wdlType, Some(expr), getSourceText(ctx), getComment(ctx))
+    Declaration(name, wdlType, Some(expr), getTextSource(ctx), getComment(ctx))
   }
 
   /*
@@ -641,7 +647,7 @@ any_decls
       return visitUnbound_decls(ctx.unbound_decls())
     if (ctx.bound_decls() != null)
       return visitBound_decls(ctx.bound_decls())
-    throw new SyntaxException("bad declaration format", getSourceText(ctx))
+    throw new SyntaxException("bad declaration format", getTextSource(ctx))
   }
 
   /* meta_kv
@@ -650,7 +656,7 @@ any_decls
   override def visitMeta_kv(ctx: WdlDraft2Parser.Meta_kvContext): MetaKV = {
     val id = getIdentifierText(ctx.Identifier(), ctx)
     val value = ctx.string().string_part().getText
-    MetaKV(id, value, getSourceText(ctx), getComment(ctx))
+    MetaKV(id, value, getTextSource(ctx), getComment(ctx))
   }
 
   //  PARAMETERMETA LBRACE meta_kv* RBRACE #parameter_meta
@@ -662,7 +668,7 @@ any_decls
       .asScala
       .map(x => visitMeta_kv(x))
       .toVector
-    ParameterMetaSection(kvs, getSourceText(ctx), getComment(ctx))
+    ParameterMetaSection(kvs, getTextSource(ctx), getComment(ctx))
   }
 
   //  META LBRACE meta_kv* RBRACE #meta
@@ -672,7 +678,7 @@ any_decls
       .asScala
       .map(x => visitMeta_kv(x))
       .toVector
-    MetaSection(kvs, getSourceText(ctx), getComment(ctx))
+    MetaSection(kvs, getTextSource(ctx), getComment(ctx))
   }
 
   /* task_runtime_kv
@@ -681,7 +687,7 @@ any_decls
   override def visitTask_runtime_kv(ctx: WdlDraft2Parser.Task_runtime_kvContext): RuntimeKV = {
     val id: String = ctx.Identifier.getText
     val expr: Expr = visitExpr(ctx.expr())
-    RuntimeKV(id, expr, getSourceText(ctx), getComment(ctx))
+    RuntimeKV(id, expr, getTextSource(ctx), getComment(ctx))
   }
 
   /* task_runtime
@@ -693,7 +699,7 @@ any_decls
       .asScala
       .map(x => visitTask_runtime_kv(x))
       .toVector
-    RuntimeSection(kvs, getSourceText(ctx), getComment(ctx))
+    RuntimeSection(kvs, getTextSource(ctx), getComment(ctx))
   }
 
   /*
@@ -707,7 +713,7 @@ task_input
       .asScala
       .map(x => visitAny_decls(x))
       .toVector
-    InputSection(decls, getSourceText(ctx), None)
+    InputSection(decls, getTextSource(ctx), None)
   }
 
   /* task_output
@@ -719,7 +725,7 @@ task_input
       .asScala
       .map(x => visitBound_decls(x))
       .toVector
-    OutputSection(decls, getSourceText(ctx), getComment(ctx))
+    OutputSection(decls, getTextSource(ctx), getComment(ctx))
   }
 
   /* task_command_string_part
@@ -733,7 +739,7 @@ task_input
       .asScala
       .map(x => x.getText)
       .mkString("")
-    ExprString(text, getSourceText(ctx))
+    ExprString(text, getTextSource(ctx))
   }
 
   /* task_command_expr_part
@@ -761,7 +767,7 @@ task_input
     val stringPart: Expr = visitTask_command_string_part(
         ctx.task_command_string_part()
     )
-    ExprCompoundString(Vector(exprPart, stringPart), getSourceText(ctx))
+    ExprCompoundString(Vector(exprPart, stringPart), getTextSource(ctx))
   }
 
   /* task_command
@@ -787,7 +793,7 @@ task_input
 
     // TODO: do the above until reaching a fixed point
 
-    CommandSection(cleanedParts, getSourceText(ctx), getComment(ctx))
+    CommandSection(cleanedParts, getTextSource(ctx), getComment(ctx))
   }
 
   // A that should appear zero or once. Make sure this is the case.
@@ -800,7 +806,7 @@ task_input
       case n =>
         throw new SyntaxException(
             s"section ${sectionName} appears ${n} times, it cannot appear more than once",
-            getSourceText(ctx)
+            getTextSource(ctx)
         )
     }
   }
@@ -814,7 +820,7 @@ task_input
       case n =>
         throw new SyntaxException(
             s"section ${sectionName} appears ${n} times, it must appear exactly once",
-            getSourceText(ctx)
+            getTextSource(ctx)
         )
     }
   }
@@ -838,7 +844,7 @@ task_input
     val both = inputVarNames intersect outputVarNames
     if (both.nonEmpty)
       throw new SyntaxException(s"${both} appears in both input and output sections",
-                                getSourceText(ctx))
+                                getTextSource(ctx))
 
     val ioVarNames = inputVarNames ++ outputVarNames
 
@@ -847,7 +853,7 @@ task_input
         if (!(ioVarNames contains k))
           throw new SyntaxException(
               s"parameter ${k} does not appear in the input or output sections",
-              getSourceText(ctx)
+              getTextSource(ctx)
           )
     }
   }
@@ -858,8 +864,8 @@ task_input
       case ExprPair(l, r, _)                                                        => requiresEvaluation(l) || requiresEvaluation(r)
       case ExprArrayLiteral(value, _)                                               => value.exists(requiresEvaluation)
       case ExprMapLiteral(value, _) =>
-        value.exists(elt => requiresEvaluation(elt._1) || requiresEvaluation(elt._2))
-      case ExprObjectLiteral(value, _) => value.values.exists(requiresEvaluation)
+        value.exists(elt => requiresEvaluation(elt.key) || requiresEvaluation(elt.value))
+      case ExprObjectLiteral(value, _) => value.exists(member => requiresEvaluation(member.value))
       case _                           => true
     }
   }
@@ -922,43 +928,46 @@ task_input
         meta = meta,
         parameterMeta = parameterMeta,
         runtime = runtime,
-        text = getSourceText(ctx),
+        text = getTextSource(ctx),
         comment = getComment(ctx)
     )
+  }
+
+  def visitImport_addr(ctx: WdlDraft2Parser.StringContext): ImportAddr = {
+    val addr = ctx.getText.replaceAll("\"", "")
+    ImportAddr(addr, getTextSource(ctx))
   }
 
   /*
 import_as
     : AS Identifier
     ;
+   */
+  override def visitImport_as(ctx: WdlDraft2Parser.Import_asContext): ImportName = {
+    ImportName(ctx.Identifier().getText, getTextSource(ctx))
+  }
 
+  /*
  import_doc
 	: IMPORT string import_as? (import_alias)*
 	;
    */
   override def visitImport_doc(ctx: WdlDraft2Parser.Import_docContext): ImportDoc = {
-    val url = ctx.string().getText.replaceAll("\"", "")
+    val addr = visitImport_addr(ctx.string())
     val name =
       if (ctx.import_as() == null)
         None
       else
-        Some(getIdentifierText(ctx.import_as().Identifier(), ctx))
+        Some(visitImport_as(ctx.import_as()))
 
-    val docUrl =
-      try {
-        opts.getURL(url)
-      } catch {
-        case e: Exception =>
-          throw new SyntaxException(e.getMessage, getSourceText(ctx))
-      }
-    ImportDoc(name, Vector.empty, docUrl, getSourceText(ctx), getComment(ctx))
+    ImportDoc(name, Vector.empty, addr, getTextSource(ctx), getComment(ctx))
   }
 
   /* call_alias
 	: AS Identifier
 	; */
   override def visitCall_alias(ctx: WdlDraft2Parser.Call_aliasContext): CallAlias = {
-    CallAlias(getIdentifierText(ctx.Identifier(), ctx), getSourceText(ctx))
+    CallAlias(getIdentifierText(ctx.Identifier(), ctx), getTextSource(ctx))
   }
 
   /* call_input
@@ -966,7 +975,7 @@ import_as
 	; */
   override def visitCall_input(ctx: WdlDraft2Parser.Call_inputContext): CallInput = {
     val expr = visitExpr(ctx.expr())
-    CallInput(getIdentifierText(ctx.Identifier(), ctx), expr, getSourceText(ctx))
+    CallInput(getIdentifierText(ctx.Identifier(), ctx), expr, getTextSource(ctx))
   }
 
   /* call_inputs
@@ -980,7 +989,7 @@ import_as
         visitCall_input(x)
       }
       .toVector
-    CallInputs(inputs, getSourceText(ctx))
+    CallInputs(inputs, getTextSource(ctx))
   }
 
   /* call_body
@@ -988,7 +997,7 @@ import_as
 	; */
   override def visitCall_body(ctx: WdlDraft2Parser.Call_bodyContext): CallInputs = {
     if (ctx.call_inputs() == null)
-      CallInputs(Vector.empty, getSourceText(ctx))
+      CallInputs(Vector.empty, getTextSource(ctx))
     else
       visitCall_inputs(ctx.call_inputs())
   }
@@ -1013,7 +1022,7 @@ import_as
         Some(visitCall_body(ctx.call_body()))
       }
 
-    Call(name, alias, inputs, getSourceText(ctx), getComment(ctx))
+    Call(name, alias, inputs, getTextSource(ctx), getComment(ctx))
   }
 
   /*
@@ -1028,7 +1037,7 @@ scatter
       .asScala
       .map(visitInner_workflow_element)
       .toVector
-    Scatter(id, expr, body, getSourceText(ctx), getComment(ctx))
+    Scatter(id, expr, body, getTextSource(ctx), getComment(ctx))
   }
 
   /* conditional
@@ -1041,7 +1050,7 @@ scatter
       .asScala
       .map(visitInner_workflow_element)
       .toVector
-    Conditional(expr, body, getSourceText(ctx), getComment(ctx))
+    Conditional(expr, body, getTextSource(ctx), getComment(ctx))
   }
 
   /* workflow_input
@@ -1053,7 +1062,7 @@ scatter
       .asScala
       .map(x => visitAny_decls(x))
       .toVector
-    InputSection(decls, getSourceText(ctx), None)
+    InputSection(decls, getTextSource(ctx), None)
   }
 
   /* workflow_output
@@ -1066,7 +1075,7 @@ scatter
       .asScala
       .map(x => visitBound_decls(x))
       .toVector
-    OutputSection(decls, getSourceText(ctx), getComment(ctx))
+    OutputSection(decls, getTextSource(ctx), getComment(ctx))
   }
 
   /* inner_workflow_element
@@ -1139,7 +1148,7 @@ workflow
 
     parameterMeta.foreach(validateParamMeta(_, input, output, ctx))
 
-    Workflow(name, input, output, meta, parameterMeta, wfElems, getSourceText(ctx), getComment(ctx))
+    Workflow(name, input, output, meta, parameterMeta, wfElems, getTextSource(ctx), getComment(ctx))
   }
 
   /*
@@ -1174,7 +1183,7 @@ document
       else
         Some(visitWorkflow(ctx.workflow()))
 
-    Document(elems, workflow, getSourceText(ctx), getComment(ctx))
+    Document(docSourceURL.get, elems, workflow, getTextSource(ctx), getComment(ctx))
   }
 
   def parseDocument: Document = {

--- a/src/main/scala/wdlTools/syntax/draft_2/Translators.scala
+++ b/src/main/scala/wdlTools/syntax/draft_2/Translators.scala
@@ -41,12 +41,12 @@ object Translators {
       case ConcreteSyntax.ExprArrayLiteral(vec, srcText) =>
         AbstractSyntax.ExprArray(vec.map(translateExpr), srcText)
       case ConcreteSyntax.ExprMapLiteral(m, srcText) =>
-        AbstractSyntax.ExprMap(m.map {
-          case (k, v) => translateExpr(k) -> translateExpr(v)
+        AbstractSyntax.ExprMap(m.map { item =>
+          AbstractSyntax.ExprMapItem(translateExpr(item.key), translateExpr(item.value), item.text)
         }, srcText)
       case ConcreteSyntax.ExprObjectLiteral(m, srcText) =>
-        AbstractSyntax.ExprObject(m.map {
-          case (fieldName, v) => fieldName -> translateExpr(v)
+        AbstractSyntax.ExprObject(m.map { member =>
+          AbstractSyntax.ExprObjectMember(member.key, translateExpr(member.value), member.text)
         }, srcText)
 
       // string place holders
@@ -230,14 +230,18 @@ object Translators {
 
   def translateImportDoc(importDoc: ConcreteSyntax.ImportDoc,
                          importedDoc: Option[AbstractSyntax.Document]): AbstractSyntax.ImportDoc = {
+    val addrAbst = AbstractSyntax.ImportAddr(importDoc.addr.value, importDoc.addr.text)
+    val nameAbst = importDoc.name.map {
+      case ConcreteSyntax.ImportName(value, text) => AbstractSyntax.ImportName(value, text)
+    }
     val aliasesAbst: Vector[AbstractSyntax.ImportAlias] = importDoc.aliases.map {
       case ConcreteSyntax.ImportAlias(x, y, alText) => AbstractSyntax.ImportAlias(x, y, alText)
     }
 
     // Replace the original statement with a new one
-    AbstractSyntax.ImportDoc(importDoc.name,
+    AbstractSyntax.ImportDoc(nameAbst,
                              aliasesAbst,
-                             importDoc.url,
+                             addrAbst,
                              importedDoc,
                              importDoc.text,
                              importDoc.comment)

--- a/src/main/scala/wdlTools/syntax/package.scala
+++ b/src/main/scala/wdlTools/syntax/package.scala
@@ -50,7 +50,7 @@ case class TextSource(line: Int, col: Int, endLine: Int, endCol: Int) extends Or
 }
 
 object TextSource {
-  lazy val empty: TextSource = TextSource(0, 0, 0, 0)
+  val empty: TextSource = TextSource(0, 0, 0, 0)
 
   def fromSpan(start: TextSource, stop: TextSource): TextSource = {
     TextSource(

--- a/src/main/scala/wdlTools/syntax/v1/ConcreteSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ConcreteSyntax.scala
@@ -54,8 +54,10 @@ object ConcreteSyntax {
   // For example:
   //  "some string part ~{ident + ident} some string part after"
   case class ExprCompoundString(value: Vector[Expr], text: TextSource) extends Expr
-  case class ExprMapLiteral(value: Map[Expr, Expr], text: TextSource) extends Expr
-  case class ExprObjectLiteral(value: Map[String, Expr], text: TextSource) extends Expr
+  case class ExprMapItem(key: Expr, value: Expr, text: TextSource) extends Expr
+  case class ExprMapLiteral(value: Vector[ExprMapItem], text: TextSource) extends Expr
+  case class ExprObjectMember(key: String, value: Expr, text: TextSource) extends Expr
+  case class ExprObjectLiteral(value: Vector[ExprObjectMember], text: TextSource) extends Expr
   case class ExprArrayLiteral(value: Vector[Expr], text: TextSource) extends Expr
 
   case class ExprIdentifier(id: String, text: TextSource) extends Expr
@@ -153,12 +155,14 @@ object ConcreteSyntax {
       extends StatementElement
 
   // imports
+  case class ImportAddr(value: String, text: TextSource) extends Element
+  case class ImportName(value: String, text: TextSource) extends Element
   case class ImportAlias(id1: String, id2: String, text: TextSource) extends Element
 
   // import statement as read from the document
-  case class ImportDoc(name: Option[String],
+  case class ImportDoc(name: Option[ImportName],
                        aliases: Vector[ImportAlias],
-                       url: URL,
+                       addr: ImportAddr,
                        text: TextSource,
                        comment: Option[Comment])
       extends DocumentElement
@@ -208,7 +212,8 @@ object ConcreteSyntax {
       extends StatementElement
 
   case class Version(value: WdlVersion = WdlVersion.V1, text: TextSource) extends Element
-  case class Document(version: Version,
+  case class Document(docSourceURL: URL,
+                      version: Version,
                       elements: Vector[DocumentElement],
                       workflow: Option[Workflow],
                       text: TextSource,

--- a/src/main/scala/wdlTools/syntax/v1/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ParseAll.scala
@@ -37,7 +37,7 @@ case class ParseAll(opts: Options, loader: SourceCode.Loader) extends WdlParser(
       case struct: ConcreteSyntax.TypeStruct => translateStruct(struct)
       case importDoc: ConcreteSyntax.ImportDoc =>
         val importedDoc = if (opts.followImports) {
-          Some(followImport(importDoc.url))
+          Some(followImport(getDocSourceURL(importDoc.addr.value)))
         } else {
           None
         }
@@ -48,7 +48,13 @@ case class ParseAll(opts: Options, loader: SourceCode.Loader) extends WdlParser(
 
     val aWf = doc.workflow.map(translateWorkflow)
     val version = AbstractSyntax.Version(doc.version.value, doc.version.text, None)
-    AbstractSyntax.Document(version, Some(doc.version.text), elems, aWf, doc.text, doc.comment)
+    AbstractSyntax.Document(doc.docSourceURL,
+                            version,
+                            Some(doc.version.text),
+                            elems,
+                            aWf,
+                            doc.text,
+                            doc.comment)
   }
 
   override def canParse(sourceCode: SourceCode): Boolean = {

--- a/src/main/scala/wdlTools/syntax/v1/ParseTop.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ParseTop.scala
@@ -7,7 +7,7 @@ import java.net.URL
 import org.antlr.v4.runtime._
 import org.antlr.v4.runtime.tree.TerminalNode
 import org.openwdl.wdl.parser.v1._
-import wdlTools.syntax.Antlr4Util.Grammar
+import wdlTools.syntax.Antlr4Util.{Grammar, getTextSource}
 import wdlTools.syntax.v1.ConcreteSyntax._
 import wdlTools.syntax.{Comment, SyntaxException, TextSource, WdlVersion}
 import wdlTools.util.{Options, Util}
@@ -20,22 +20,14 @@ case class ParseTop(opts: Options,
                     docSourceURL: Option[URL] = None)
     extends WdlV1ParserBaseVisitor[Element] {
 
-  private def getSourceText(ctx: ParserRuleContext): TextSource = {
-    grammar.getSourceText(ctx, docSourceURL)
-  }
-
-  private def getSourceText(symbol: TerminalNode): TextSource = {
-    grammar.getSourceText(symbol, docSourceURL)
-  }
-
   private def getComment(ctx: ParserRuleContext): Option[Comment] = {
     grammar.getComment(ctx)
   }
 
   private def getIdentifierText(identifier: TerminalNode, ctx: ParserRuleContext): String = {
     if (identifier == null)
-      throw new SyntaxException("missing identifier", getSourceText(ctx))
-    identifier.getText()
+      throw new SyntaxException("missing identifier", getTextSource(ctx))
+    identifier.getText
   }
 
   /*
@@ -59,12 +51,12 @@ struct
     members.foreach { member =>
       if (memberNames.contains(member.name)) {
         throw new SyntaxException(s"struct ${sName} has field ${member.name} defined twice",
-                                  getSourceText(ctx))
+                                  getTextSource(ctx))
       }
       memberNames.add(member.name)
     }
 
-    TypeStruct(sName, members, getSourceText(ctx), getComment(ctx))
+    TypeStruct(sName, members, getTextSource(ctx), getComment(ctx))
   }
 
   /*
@@ -75,7 +67,7 @@ map_type
   override def visitMap_type(ctx: WdlV1Parser.Map_typeContext): Type = {
     val kt: Type = visitWdl_type(ctx.wdl_type(0))
     val vt: Type = visitWdl_type(ctx.wdl_type(1))
-    TypeMap(kt, vt, getSourceText(ctx))
+    TypeMap(kt, vt, getTextSource(ctx))
   }
 
   /*
@@ -86,7 +78,7 @@ array_type
   override def visitArray_type(ctx: WdlV1Parser.Array_typeContext): Type = {
     val t: Type = visitWdl_type(ctx.wdl_type())
     val nonEmpty = ctx.PLUS() != null
-    TypeArray(t, nonEmpty, getSourceText(ctx))
+    TypeArray(t, nonEmpty, getTextSource(ctx))
   }
 
   /*
@@ -97,7 +89,7 @@ pair_type
   override def visitPair_type(ctx: WdlV1Parser.Pair_typeContext): Type = {
     val lt: Type = visitWdl_type(ctx.wdl_type(0))
     val rt: Type = visitWdl_type(ctx.wdl_type(1))
-    TypePair(lt, rt, getSourceText(ctx))
+    TypePair(lt, rt, getTextSource(ctx))
   }
 
   /*
@@ -116,20 +108,20 @@ type_base
     if (ctx.pair_type() != null)
       return visitPair_type(ctx.pair_type())
     if (ctx.STRING() != null)
-      return TypeString(getSourceText(ctx))
+      return TypeString(getTextSource(ctx))
     if (ctx.FILE() != null)
-      return TypeFile(getSourceText(ctx))
+      return TypeFile(getTextSource(ctx))
     if (ctx.BOOLEAN() != null)
-      return TypeBoolean(getSourceText(ctx))
+      return TypeBoolean(getTextSource(ctx))
     if (ctx.OBJECT() != null)
-      return TypeObject(getSourceText(ctx))
+      return TypeObject(getTextSource(ctx))
     if (ctx.INT() != null)
-      return TypeInt(getSourceText(ctx))
+      return TypeInt(getTextSource(ctx))
     if (ctx.FLOAT() != null)
-      return TypeFloat(getSourceText(ctx))
+      return TypeFloat(getTextSource(ctx))
     if (ctx.Identifier() != null)
-      return TypeIdentifier(ctx.getText, getSourceText(ctx))
-    throw new SyntaxException("unrecgonized type", getSourceText(ctx))
+      return TypeIdentifier(ctx.getText, getTextSource(ctx))
+    throw new SyntaxException("unrecgonized type", getTextSource(ctx))
   }
 
   /*
@@ -140,7 +132,7 @@ wdl_type
   override def visitWdl_type(ctx: WdlV1Parser.Wdl_typeContext): Type = {
     val t = visitType_base(ctx.type_base())
     if (ctx.OPTIONAL() != null) {
-      TypeOptional(t, getSourceText(ctx))
+      TypeOptional(t, getTextSource(ctx))
     } else {
       t
     }
@@ -150,12 +142,12 @@ wdl_type
 
   override def visitNumber(ctx: WdlV1Parser.NumberContext): Expr = {
     if (ctx.IntLiteral() != null) {
-      return ExprInt(ctx.getText.toInt, getSourceText(ctx))
+      return ExprInt(ctx.getText.toInt, getTextSource(ctx))
     }
     if (ctx.FloatLiteral() != null) {
-      return ExprFloat(ctx.getText.toDouble, getSourceText(ctx))
+      return ExprFloat(ctx.getText.toDouble, getTextSource(ctx))
     }
-    throw new SyntaxException(s"Not an integer nor a float ${ctx.getText}", getSourceText(ctx))
+    throw new SyntaxException(s"Not an integer nor a float ${ctx.getText}", getTextSource(ctx))
   }
 
   /* expression_placeholder_option
@@ -172,20 +164,20 @@ wdl_type
       else if (ctx.number() != null)
         visitNumber(ctx.number())
       else
-        throw new SyntaxException("sanity: not a string or a number", getSourceText(ctx))
+        throw new SyntaxException("sanity: not a string or a number", getTextSource(ctx))
 
     if (ctx.BoolLiteral() != null) {
       val b = ctx.BoolLiteral().getText.toLowerCase() == "true"
-      return ExprPlaceholderPartEqual(b, expr, getSourceText(ctx))
+      return ExprPlaceholderPartEqual(b, expr, getTextSource(ctx))
     }
     if (ctx.DEFAULT() != null) {
-      return ExprPlaceholderPartDefault(expr, getSourceText(ctx))
+      return ExprPlaceholderPartDefault(expr, getTextSource(ctx))
     }
     if (ctx.SEP() != null) {
-      return ExprPlaceholderPartSep(expr, getSourceText(ctx))
+      return ExprPlaceholderPartSep(expr, getTextSource(ctx))
     }
     throw new SyntaxException(s"Not one of three known variants of a placeholder",
-                              getSourceText(ctx))
+                              getTextSource(ctx))
   }
 
   // These are full expressions of the same kind
@@ -202,7 +194,7 @@ wdl_type
       // ${x + 3}
       return expr
     }
-    val source = getSourceText(ctx)
+    val source = getTextSource(ctx)
 
     // This is a place-holder such as
     //   ${default="foo" optional_value}
@@ -214,7 +206,7 @@ wdl_type
         case ExprPlaceholderPartSep(sep, _) =>
           return ExprPlaceholderSep(sep, expr, source)
         case _ =>
-          throw new SyntaxException("invalid place holder", getSourceText(ctx))
+          throw new SyntaxException("invalid place holder", getTextSource(ctx))
       }
     }
 
@@ -226,13 +218,13 @@ wdl_type
         case (ExprPlaceholderPartEqual(false, x, _), ExprPlaceholderPartEqual(true, y, _)) =>
           return ExprPlaceholderEqual(y, x, expr, source)
         case (_: ExprPlaceholderPartEqual, _: ExprPlaceholderPartEqual) =>
-          throw new SyntaxException("invalid boolean place holder", getSourceText(ctx))
+          throw new SyntaxException("invalid boolean place holder", getTextSource(ctx))
         case (_, _) =>
-          throw new SyntaxException("invalid place holder", getSourceText(ctx))
+          throw new SyntaxException("invalid place holder", getTextSource(ctx))
       }
     }
 
-    throw new SyntaxException("invalid place holder", getSourceText(ctx))
+    throw new SyntaxException("invalid place holder", getTextSource(ctx))
   }
 
   /* string_part
@@ -242,9 +234,9 @@ wdl_type
     val parts: Vector[Expr] = ctx
       .StringPart()
       .asScala
-      .map(x => ExprString(x.getText, getSourceText(x)))
+      .map(x => ExprString(x.getText, getTextSource(x)))
       .toVector
-    ExprCompoundString(parts, getSourceText(ctx))
+    ExprCompoundString(parts, getTextSource(ctx))
   }
 
   /* string_expr_part
@@ -268,7 +260,7 @@ wdl_type
   ): ExprCompoundString = {
     val exprPart = visitString_expr_part(ctx.string_expr_part())
     val strPart = visitString_part(ctx.string_part())
-    ExprCompoundString(Vector(exprPart, strPart), getSourceText(ctx))
+    ExprCompoundString(Vector(exprPart, strPart), getTextSource(ctx))
   }
 
   /*
@@ -278,7 +270,7 @@ string
   ;
    */
   override def visitString(ctx: WdlV1Parser.StringContext): Expr = {
-    val stringPart = ExprString(ctx.string_part().getText, getSourceText(ctx.string_part()))
+    val stringPart = ExprString(ctx.string_part().getText, getTextSource(ctx.string_part()))
     val exprPart: Vector[ExprCompoundString] = ctx
       .string_expr_with_string_part()
       .asScala
@@ -290,7 +282,7 @@ string
       stringPart
     } else {
       // A string that includes interpolation
-      ExprCompoundString(Vector(stringPart) ++ exprPart2, getSourceText(ctx))
+      ExprCompoundString(Vector(stringPart) ++ exprPart2, getTextSource(ctx))
     }
   }
 
@@ -303,7 +295,7 @@ string
   override def visitPrimitive_literal(ctx: WdlV1Parser.Primitive_literalContext): Expr = {
     if (ctx.BoolLiteral() != null) {
       val value = ctx.getText.toLowerCase() == "true"
-      return ExprBoolean(value, getSourceText(ctx))
+      return ExprBoolean(value, getTextSource(ctx))
     }
     if (ctx.number() != null) {
       return visitNumber(ctx.number())
@@ -312,87 +304,87 @@ string
       return visitString(ctx.string())
     }
     if (ctx.Identifier() != null) {
-      return ExprIdentifier(ctx.getText, getSourceText(ctx))
+      return ExprIdentifier(ctx.getText, getTextSource(ctx))
     }
     throw new SyntaxException("Not one of four supported variants of primitive_literal",
-                              getSourceText(ctx))
+                              getTextSource(ctx))
   }
 
   override def visitLor(ctx: WdlV1Parser.LorContext): Expr = {
     val arg0: Expr = visitExpr_infix0(ctx.expr_infix0())
     val arg1: Expr = visitExpr_infix1(ctx.expr_infix1())
-    ExprLor(arg0, arg1, getSourceText(ctx))
+    ExprLor(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitLand(ctx: WdlV1Parser.LandContext): Expr = {
     val arg0 = visitExpr_infix1(ctx.expr_infix1())
     val arg1 = visitExpr_infix2(ctx.expr_infix2())
-    ExprLand(arg0, arg1, getSourceText(ctx))
+    ExprLand(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitEqeq(ctx: WdlV1Parser.EqeqContext): Expr = {
     val arg0 = visitExpr_infix2(ctx.expr_infix2())
     val arg1 = visitExpr_infix3(ctx.expr_infix3())
-    ExprEqeq(arg0, arg1, getSourceText(ctx))
+    ExprEqeq(arg0, arg1, getTextSource(ctx))
   }
   override def visitLt(ctx: WdlV1Parser.LtContext): Expr = {
     val arg0 = visitExpr_infix2(ctx.expr_infix2())
     val arg1 = visitExpr_infix3(ctx.expr_infix3())
-    ExprLt(arg0, arg1, getSourceText(ctx))
+    ExprLt(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitGte(ctx: WdlV1Parser.GteContext): Expr = {
     val arg0 = visitExpr_infix2(ctx.expr_infix2())
     val arg1 = visitExpr_infix3(ctx.expr_infix3())
-    ExprGte(arg0, arg1, getSourceText(ctx))
+    ExprGte(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitNeq(ctx: WdlV1Parser.NeqContext): Expr = {
     val arg0 = visitExpr_infix2(ctx.expr_infix2())
     val arg1 = visitExpr_infix3(ctx.expr_infix3())
-    ExprNeq(arg0, arg1, getSourceText(ctx))
+    ExprNeq(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitLte(ctx: WdlV1Parser.LteContext): Expr = {
     val arg0 = visitExpr_infix2(ctx.expr_infix2())
     val arg1 = visitExpr_infix3(ctx.expr_infix3())
-    ExprLte(arg0, arg1, getSourceText(ctx))
+    ExprLte(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitGt(ctx: WdlV1Parser.GtContext): Expr = {
     val arg0 = visitExpr_infix2(ctx.expr_infix2())
     val arg1 = visitExpr_infix3(ctx.expr_infix3())
-    ExprGt(arg0, arg1, getSourceText(ctx))
+    ExprGt(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitAdd(ctx: WdlV1Parser.AddContext): Expr = {
     val arg0 = visitExpr_infix3(ctx.expr_infix3())
     val arg1 = visitExpr_infix4(ctx.expr_infix4())
-    ExprAdd(arg0, arg1, getSourceText(ctx))
+    ExprAdd(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitSub(ctx: WdlV1Parser.SubContext): Expr = {
     val arg0 = visitExpr_infix3(ctx.expr_infix3())
     val arg1 = visitExpr_infix4(ctx.expr_infix4())
-    ExprSub(arg0, arg1, getSourceText(ctx))
+    ExprSub(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitMod(ctx: WdlV1Parser.ModContext): Expr = {
     val arg0 = visitExpr_infix4(ctx.expr_infix4())
     val arg1 = visitExpr_infix5(ctx.expr_infix5())
-    ExprMod(arg0, arg1, getSourceText(ctx))
+    ExprMod(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitMul(ctx: WdlV1Parser.MulContext): Expr = {
     val arg0 = visitExpr_infix4(ctx.expr_infix4())
     val arg1 = visitExpr_infix5(ctx.expr_infix5())
-    ExprMul(arg0, arg1, getSourceText(ctx))
+    ExprMul(arg0, arg1, getTextSource(ctx))
   }
 
   override def visitDivide(ctx: WdlV1Parser.DivideContext): Expr = {
     val arg0 = visitExpr_infix4(ctx.expr_infix4())
     val arg1 = visitExpr_infix5(ctx.expr_infix5())
-    ExprDivide(arg0, arg1, getSourceText(ctx))
+    ExprDivide(arg0, arg1, getTextSource(ctx))
   }
 
   // | LPAREN expr RPAREN #expression_group
@@ -407,14 +399,14 @@ string
       .asScala
       .map(x => visitExpr(x))
       .toVector
-    ExprArrayLiteral(elements, getSourceText(ctx))
+    ExprArrayLiteral(elements, getTextSource(ctx))
   }
 
   // | LPAREN expr COMMA expr RPAREN #pair_literal
   override def visitPair_literal(ctx: WdlV1Parser.Pair_literalContext): Expr = {
     val arg0 = visitExpr(ctx.expr(0))
     val arg1 = visitExpr(ctx.expr(1))
-    ExprPair(arg0, arg1, getSourceText(ctx))
+    ExprPair(arg0, arg1, getTextSource(ctx))
   }
 
   //| LBRACE (expr COLON expr (COMMA expr COLON expr)*)* RBRACE #map_literal
@@ -427,32 +419,45 @@ string
 
     val n = elements.size
     if (n % 2 != 0)
-      throw new SyntaxException("the expressions in a map must come in pairs", getSourceText(ctx))
+      throw new SyntaxException("the expressions in a map must come in pairs", getTextSource(ctx))
 
-    val m: Map[Expr, Expr] =
-      Vector.tabulate(n / 2)(i => elements(2 * i) -> elements(2 * i + 1)).toMap
-    ExprMapLiteral(m, getSourceText(ctx))
+    val m: Vector[ExprMapItem] = Vector.tabulate(n / 2) { i =>
+      val key = elements(2 * i)
+      val value = elements(2 * i + 1)
+      ExprMapItem(key,
+                  value,
+                  TextSource(key.text.line, key.text.col, value.text.endLine, value.text.endCol))
+    }
+    ExprMapLiteral(m, getTextSource(ctx))
   }
 
   // | OBJECT_LITERAL LBRACE (Identifier COLON expr (COMMA Identifier COLON expr)*)* RBRACE #object_literal
   override def visitObject_literal(ctx: WdlV1Parser.Object_literalContext): Expr = {
-    val ids: Vector[String] = ctx
+    val ids: Vector[TerminalNode] = ctx
       .Identifier()
       .asScala
-      .map(x => x.getText)
       .toVector
     val elements: Vector[Expr] = ctx
       .expr()
       .asScala
       .map(x => visitExpr(x))
       .toVector
-    ExprObjectLiteral((ids zip elements).toMap, getSourceText(ctx))
+    val members = ids.zip(elements).map { pair =>
+      val id = pair._1
+      val expr = pair._2
+      val textSource = TextSource(id.getSymbol.getLine,
+                                  id.getSymbol.getCharPositionInLine,
+                                  expr.text.endLine,
+                                  expr.text.endCol)
+      ExprObjectMember(id.getText, expr, textSource)
+    }
+    ExprObjectLiteral(members, getTextSource(ctx))
   }
 
   // | NOT expr #negate
   override def visitNegate(ctx: WdlV1Parser.NegateContext): Expr = {
     val expr = visitExpr(ctx.expr())
-    ExprNegate(expr, getSourceText(ctx))
+    ExprNegate(expr, getTextSource(ctx))
   }
 
   // | (PLUS | MINUS) expr #unirarysigned
@@ -460,18 +465,18 @@ string
     val expr = visitExpr(ctx.expr())
 
     if (ctx.PLUS() != null)
-      ExprUniraryPlus(expr, getSourceText(ctx))
+      ExprUniraryPlus(expr, getTextSource(ctx))
     else if (ctx.MINUS() != null)
-      ExprUniraryMinus(expr, getSourceText(ctx))
+      ExprUniraryMinus(expr, getTextSource(ctx))
     else
-      throw new SyntaxException("bad unirary expression", getSourceText(ctx))
+      throw new SyntaxException("bad unirary expression", getTextSource(ctx))
   }
 
   // | expr_core LBRACK expr RBRACK #at
   override def visitAt(ctx: WdlV1Parser.AtContext): Expr = {
     val array = visitExpr_core(ctx.expr_core())
     val index = visitExpr(ctx.expr())
-    ExprAt(array, index, getSourceText(ctx))
+    ExprAt(array, index, getTextSource(ctx))
   }
 
   // | Identifier LPAREN (expr (COMMA expr)*)? RPAREN #apply
@@ -482,7 +487,7 @@ string
       .asScala
       .map(x => visitExpr(x))
       .toVector
-    ExprApply(funcName, elements, getSourceText(ctx))
+    ExprApply(funcName, elements, getTextSource(ctx))
   }
 
   // | IF expr THEN expr ELSE expr #ifthenelse
@@ -492,19 +497,19 @@ string
       .asScala
       .map(x => visitExpr(x))
       .toVector
-    ExprIfThenElse(elements(0), elements(1), elements(2), getSourceText(ctx))
+    ExprIfThenElse(elements(0), elements(1), elements(2), getTextSource(ctx))
   }
 
   override def visitLeft_name(ctx: WdlV1Parser.Left_nameContext): Expr = {
     val id = getIdentifierText(ctx.Identifier(), ctx)
-    ExprIdentifier(id, getSourceText(ctx))
+    ExprIdentifier(id, getTextSource(ctx))
   }
 
   // | expr_core DOT Identifier #get_name
   override def visitGet_name(ctx: WdlV1Parser.Get_nameContext): Expr = {
     val e = visitExpr_core(ctx.expr_core())
     val id = ctx.Identifier.getText
-    ExprGetName(e, id, getSourceText(ctx))
+    ExprGetName(e, id, getTextSource(ctx))
   }
 
   /*expr_infix0
@@ -598,8 +603,8 @@ string
     try {
       visitChildren(ctx).asInstanceOf[Expr]
     } catch {
-      case ex: NullPointerException =>
-        throw new SyntaxException("bad expression", getSourceText(ctx))
+      case _: NullPointerException =>
+        throw new SyntaxException("bad expression", getTextSource(ctx))
     }
   }
 
@@ -635,7 +640,7 @@ string
       case left_name: WdlV1Parser.Left_nameContext         => visitLeft_name(left_name)
       case get_name: WdlV1Parser.Get_nameContext           => visitGet_name(get_name)
       case _ =>
-        throw new SyntaxException("bad expression", getSourceText(ctx))
+        throw new SyntaxException("bad expression", getTextSource(ctx))
     }
   }
 
@@ -646,10 +651,10 @@ unbound_decls
    */
   override def visitUnbound_decls(ctx: WdlV1Parser.Unbound_declsContext): Declaration = {
     if (ctx.wdl_type() == null)
-      throw new SyntaxException("type missing in declaration", getSourceText(ctx))
+      throw new SyntaxException("type missing in declaration", getTextSource(ctx))
     val wdlType: Type = visitWdl_type(ctx.wdl_type())
     val name: String = getIdentifierText(ctx.Identifier(), ctx)
-    Declaration(name, wdlType, None, getSourceText(ctx), getComment(ctx))
+    Declaration(name, wdlType, None, getTextSource(ctx), getComment(ctx))
   }
 
   /*
@@ -659,13 +664,13 @@ bound_decls
    */
   override def visitBound_decls(ctx: WdlV1Parser.Bound_declsContext): Declaration = {
     if (ctx.wdl_type() == null)
-      throw new SyntaxException("type missing in declaration", getSourceText(ctx))
+      throw new SyntaxException("type missing in declaration", getTextSource(ctx))
     val wdlType = visitWdl_type(ctx.wdl_type())
     val name: String = getIdentifierText(ctx.Identifier(), ctx)
     if (ctx.expr() == null)
-      return Declaration(name, wdlType, None, getSourceText(ctx), getComment(ctx))
+      return Declaration(name, wdlType, None, getTextSource(ctx), getComment(ctx))
     val expr: Expr = visitExpr(ctx.expr())
-    Declaration(name, wdlType, Some(expr), getSourceText(ctx), getComment(ctx))
+    Declaration(name, wdlType, Some(expr), getTextSource(ctx), getComment(ctx))
   }
 
   /*
@@ -679,7 +684,7 @@ any_decls
       return visitUnbound_decls(ctx.unbound_decls())
     if (ctx.bound_decls() != null)
       return visitBound_decls(ctx.bound_decls())
-    throw new SyntaxException("bad declaration format", getSourceText(ctx))
+    throw new SyntaxException("bad declaration format", getTextSource(ctx))
   }
 
   /* meta_kv
@@ -688,7 +693,7 @@ any_decls
   override def visitMeta_kv(ctx: WdlV1Parser.Meta_kvContext): MetaKV = {
     val id = getIdentifierText(ctx.Identifier(), ctx)
     val expr = visitExpr(ctx.expr())
-    MetaKV(id, expr, getSourceText(ctx), getComment(ctx))
+    MetaKV(id, expr, getTextSource(ctx), getComment(ctx))
   }
 
   //  PARAMETERMETA LBRACE meta_kv* RBRACE #parameter_meta
@@ -700,7 +705,7 @@ any_decls
       .asScala
       .map(x => visitMeta_kv(x))
       .toVector
-    ParameterMetaSection(kvs, getSourceText(ctx), getComment(ctx))
+    ParameterMetaSection(kvs, getTextSource(ctx), getComment(ctx))
   }
 
   //  META LBRACE meta_kv* RBRACE #meta
@@ -710,7 +715,7 @@ any_decls
       .asScala
       .map(x => visitMeta_kv(x))
       .toVector
-    MetaSection(kvs, getSourceText(ctx), getComment(ctx))
+    MetaSection(kvs, getTextSource(ctx), getComment(ctx))
   }
 
   /* task_runtime_kv
@@ -719,7 +724,7 @@ any_decls
   override def visitTask_runtime_kv(ctx: WdlV1Parser.Task_runtime_kvContext): RuntimeKV = {
     val id: String = getIdentifierText(ctx.Identifier(), ctx)
     val expr: Expr = visitExpr(ctx.expr())
-    RuntimeKV(id, expr, getSourceText(ctx), getComment(ctx))
+    RuntimeKV(id, expr, getTextSource(ctx), getComment(ctx))
   }
 
   /* task_runtime
@@ -731,7 +736,7 @@ any_decls
       .asScala
       .map(x => visitTask_runtime_kv(x))
       .toVector
-    RuntimeSection(kvs, getSourceText(ctx), getComment(ctx))
+    RuntimeSection(kvs, getTextSource(ctx), getComment(ctx))
   }
 
   /*
@@ -745,7 +750,7 @@ task_input
       .asScala
       .map(x => visitAny_decls(x))
       .toVector
-    InputSection(decls, getSourceText(ctx), getComment(ctx))
+    InputSection(decls, getTextSource(ctx), getComment(ctx))
   }
 
   /* task_output
@@ -757,7 +762,7 @@ task_input
       .asScala
       .map(x => visitBound_decls(x))
       .toVector
-    OutputSection(decls, getSourceText(ctx), getComment(ctx))
+    OutputSection(decls, getTextSource(ctx), getComment(ctx))
   }
 
   /* task_command_string_part
@@ -771,7 +776,7 @@ task_input
       .asScala
       .map(x => x.getText)
       .mkString("")
-    ExprString(text, getSourceText(ctx))
+    ExprString(text, getTextSource(ctx))
   }
 
   /* task_command_expr_part
@@ -799,7 +804,7 @@ task_input
     val stringPart: Expr = visitTask_command_string_part(
         ctx.task_command_string_part()
     )
-    ExprCompoundString(Vector(exprPart, stringPart), getSourceText(ctx))
+    ExprCompoundString(Vector(exprPart, stringPart), getTextSource(ctx))
   }
 
   /* task_command
@@ -825,7 +830,7 @@ task_input
 
     // TODO: do the above until reaching a fixed point
 
-    CommandSection(cleanedParts, getSourceText(ctx), getComment(ctx))
+    CommandSection(cleanedParts, getTextSource(ctx), getComment(ctx))
   }
 
   // A that should appear zero or once. Make sure this is the case.
@@ -838,7 +843,7 @@ task_input
       case n =>
         throw new SyntaxException(
             s"section ${sectionName} appears ${n} times, it cannot appear more than once",
-            getSourceText(ctx)
+            getTextSource(ctx)
         )
     }
   }
@@ -852,7 +857,7 @@ task_input
       case n =>
         throw new SyntaxException(
             s"section ${sectionName} appears ${n} times, it must appear exactly once",
-            getSourceText(ctx)
+            getTextSource(ctx)
         )
     }
   }
@@ -880,9 +885,7 @@ task_input
         val decl: Declaration = inputSection.get.declarations.find(decl => decl.name == varName).get
         val text = decl.text
         Util.warning(
-            s"""|Warning: "${varName}" appears in both input and output sections.
-                |In file ${text.url} line ${text.line} col ${text.col}""".stripMargin
-              .replaceAll("\n", " "),
+            s"Warning: '${varName}' appears in both input and output sections at ${text}",
             opts.verbosity
         )
       }
@@ -895,7 +898,7 @@ task_input
         if (!(ioVarNames contains k))
           throw new SyntaxException(
               s"parameter ${k} does not appear in the input or output sections",
-              getSourceText(ctx)
+              getTextSource(ctx)
           )
     }
   }
@@ -940,9 +943,14 @@ task_input
         meta = meta,
         parameterMeta = parameterMeta,
         runtime = runtime,
-        text = getSourceText(ctx),
+        text = getTextSource(ctx),
         getComment(ctx)
     )
+  }
+
+  def visitImport_addr(ctx: WdlV1Parser.StringContext): ImportAddr = {
+    val addr = ctx.getText.replaceAll("\"", "")
+    ImportAddr(addr, getTextSource(ctx))
   }
 
   /* import_alias
@@ -954,47 +962,44 @@ task_input
       .asScala
       .map(x => x.getText)
       .toVector
-    ImportAlias(ids(0), ids(1), getSourceText(ctx))
+    ImportAlias(ids(0), ids(1), getTextSource(ctx))
   }
 
   /*
-import_as
-    : AS Identifier
-    ;
+    import_as
+        : AS Identifier
+        ;
+   */
+  override def visitImport_as(ctx: WdlV1Parser.Import_asContext): ImportName = {
+    ImportName(ctx.Identifier().getText, getTextSource(ctx))
+  }
 
+  /*
  import_doc
 	: IMPORT string import_as? (import_alias)*
 	;
    */
   override def visitImport_doc(ctx: WdlV1Parser.Import_docContext): ImportDoc = {
-    val url = ctx.string().getText.replaceAll("\"", "")
+    val addr = visitImport_addr(ctx.string())
     val name =
       if (ctx.import_as() == null)
         None
       else
-        Some(getIdentifierText(ctx.import_as().Identifier(), ctx))
+        Some(visitImport_as(ctx.import_as()))
 
     val aliases = ctx
       .import_alias()
       .asScala
       .map(x => visitImport_alias(x))
       .toVector
-
-    val docUrl =
-      try {
-        opts.getURL(url)
-      } catch {
-        case e: Exception =>
-          throw new SyntaxException(e.getMessage, getSourceText(ctx))
-      }
-    ImportDoc(name, aliases, docUrl, getSourceText(ctx), getComment(ctx))
+    ImportDoc(name, aliases, addr, getTextSource(ctx), getComment(ctx))
   }
 
   /* call_alias
 	: AS Identifier
 	; */
   override def visitCall_alias(ctx: WdlV1Parser.Call_aliasContext): CallAlias = {
-    CallAlias(getIdentifierText(ctx.Identifier(), ctx), getSourceText(ctx))
+    CallAlias(getIdentifierText(ctx.Identifier(), ctx), getTextSource(ctx))
   }
 
   /* call_input
@@ -1002,7 +1007,7 @@ import_as
 	; */
   override def visitCall_input(ctx: WdlV1Parser.Call_inputContext): CallInput = {
     val expr = visitExpr(ctx.expr())
-    CallInput(getIdentifierText(ctx.Identifier(), ctx), expr, getSourceText(ctx))
+    CallInput(getIdentifierText(ctx.Identifier(), ctx), expr, getTextSource(ctx))
   }
 
   /* call_inputs
@@ -1016,7 +1021,7 @@ import_as
         visitCall_input(x)
       }
       .toVector
-    CallInputs(inputs, getSourceText(ctx))
+    CallInputs(inputs, getTextSource(ctx))
   }
 
   /* call_body
@@ -1024,7 +1029,7 @@ import_as
 	; */
   override def visitCall_body(ctx: WdlV1Parser.Call_bodyContext): CallInputs = {
     if (ctx.call_inputs() == null)
-      CallInputs(Vector.empty, getSourceText(ctx))
+      CallInputs(Vector.empty, getTextSource(ctx))
     else
       visitCall_inputs(ctx.call_inputs())
   }
@@ -1049,7 +1054,7 @@ import_as
         Some(visitCall_body(ctx.call_body()))
       }
 
-    Call(name, alias, inputs, getSourceText(ctx), getComment(ctx))
+    Call(name, alias, inputs, getTextSource(ctx), getComment(ctx))
   }
 
   /*
@@ -1064,7 +1069,7 @@ scatter
       .asScala
       .map(visitInner_workflow_element)
       .toVector
-    Scatter(id, expr, body, getSourceText(ctx), getComment(ctx))
+    Scatter(id, expr, body, getTextSource(ctx), getComment(ctx))
   }
 
   /* conditional
@@ -1077,7 +1082,7 @@ scatter
       .asScala
       .map(visitInner_workflow_element)
       .toVector
-    Conditional(expr, body, getSourceText(ctx), getComment(ctx))
+    Conditional(expr, body, getTextSource(ctx), getComment(ctx))
   }
 
   /* workflow_input
@@ -1089,7 +1094,7 @@ scatter
       .asScala
       .map(x => visitAny_decls(x))
       .toVector
-    InputSection(decls, getSourceText(ctx), getComment(ctx))
+    InputSection(decls, getTextSource(ctx), getComment(ctx))
   }
 
   /* workflow_output
@@ -1102,7 +1107,7 @@ scatter
       .asScala
       .map(x => visitBound_decls(x))
       .toVector
-    OutputSection(decls, getSourceText(ctx), getComment(ctx))
+    OutputSection(decls, getTextSource(ctx), getComment(ctx))
   }
 
   /* inner_workflow_element
@@ -1166,7 +1171,7 @@ workflow
 
     parameterMeta.foreach(validateParamMeta(_, input, output, ctx))
 
-    Workflow(name, input, output, meta, parameterMeta, wfElems, getSourceText(ctx), getComment(ctx))
+    Workflow(name, input, output, meta, parameterMeta, wfElems, getTextSource(ctx), getComment(ctx))
   }
 
   /*
@@ -1187,7 +1192,7 @@ document_element
     if (ctx.RELEASE_VERSION() == null)
       throw new Exception("version not specified")
     val value = ctx.RELEASE_VERSION().getText
-    Version(WdlVersion.fromName(value), getSourceText(ctx))
+    Version(WdlVersion.fromName(value), getTextSource(ctx))
   }
 
   /*
@@ -1211,7 +1216,7 @@ document
       else
         Some(visitWorkflow(ctx.workflow()))
 
-    Document(version, elems, workflow, getSourceText(ctx), getComment(ctx))
+    Document(docSourceURL.get, version, elems, workflow, getTextSource(ctx), getComment(ctx))
   }
 
   def parseDocument: Document = {

--- a/src/main/scala/wdlTools/syntax/v1/Translators.scala
+++ b/src/main/scala/wdlTools/syntax/v1/Translators.scala
@@ -46,12 +46,12 @@ object Translators {
       case ConcreteSyntax.ExprArrayLiteral(vec, srcText) =>
         AbstractSyntax.ExprArray(vec.map(translateExpr), srcText)
       case ConcreteSyntax.ExprMapLiteral(m, srcText) =>
-        AbstractSyntax.ExprMap(m.map {
-          case (k, v) => translateExpr(k) -> translateExpr(v)
+        AbstractSyntax.ExprMap(m.map { item =>
+          AbstractSyntax.ExprMapItem(translateExpr(item.key), translateExpr(item.value), item.text)
         }, srcText)
       case ConcreteSyntax.ExprObjectLiteral(m, srcText) =>
-        AbstractSyntax.ExprObject(m.map {
-          case (fieldName, v) => fieldName -> translateExpr(v)
+        AbstractSyntax.ExprObject(m.map { member =>
+          AbstractSyntax.ExprObjectMember(member.key, translateExpr(member.value), member.text)
         }, srcText)
 
       // string place holders
@@ -247,14 +247,18 @@ object Translators {
 
   def translateImportDoc(importDoc: ConcreteSyntax.ImportDoc,
                          importedDoc: Option[AbstractSyntax.Document]): AbstractSyntax.ImportDoc = {
+    val addrAbst = AbstractSyntax.ImportAddr(importDoc.addr.value, importDoc.text)
+    val nameAbst = importDoc.name.map {
+      case ConcreteSyntax.ImportName(value, text) => AbstractSyntax.ImportName(value, text)
+    }
     val aliasesAbst: Vector[AbstractSyntax.ImportAlias] = importDoc.aliases.map {
       case ConcreteSyntax.ImportAlias(x, y, alText) => AbstractSyntax.ImportAlias(x, y, alText)
     }
 
     // Replace the original statement with a new one
-    AbstractSyntax.ImportDoc(importDoc.name,
+    AbstractSyntax.ImportDoc(nameAbst,
                              aliasesAbst,
-                             importDoc.url,
+                             addrAbst,
                              importedDoc,
                              importDoc.text,
                              importDoc.comment)

--- a/src/main/scala/wdlTools/typing/Stdlib.scala
+++ b/src/main/scala/wdlTools/typing/Stdlib.scala
@@ -7,7 +7,7 @@ import wdlTools.syntax.{AbstractSyntax, TextSource}
 //import wdlTools.util.Util
 
 case class Stdlib(conf: Options) {
-  val tUtil = TUtil(conf)
+  private val tUtil = TUtil(conf)
 
   private val stdlibV1_0: Vector[WT_StdlibFunc] = Vector(
       WT_Function0("stdout", WT_File),
@@ -121,7 +121,7 @@ case class Stdlib(conf: Options) {
     val result: Vector[WT] = allCandidatePrototypes.flatten
     result.size match {
       case 0 =>
-        val inputsStr = inputTypes.map(tUtil.toString(_)).mkString("\n")
+        val inputsStr = inputTypes.map(tUtil.toString).mkString("\n")
         val candidatesStr = candidates.map(tUtil.toString(_)).mkString("\n")
         throw new TypeException(s"""|Invoking stdlib function ${funcName} with badly typed arguments
                                     |${candidatesStr}

--- a/src/main/scala/wdlTools/typing/TUtil.scala
+++ b/src/main/scala/wdlTools/typing/TUtil.scala
@@ -8,7 +8,7 @@ import WdlTypes._
 // This is the WDL typesystem
 case class TUtil(conf: Options) {
   // Type checking rules, are we lenient or strict in checking coercions.
-  val regime = conf.typeChecking
+  private val regime = conf.typeChecking
 
   // check if the right hand side of an assignment matches the left hand side
   //
@@ -104,7 +104,7 @@ case class TUtil(conf: Options) {
   def unify(x: WT, y: WT, ctx: TypeUnificationContext): (WT, TypeUnificationContext) = {
     (x, y) match {
       // base case, primitive types
-      case (_, _) if (isPrimitive(x) && isPrimitive(y) && isCoercibleTo(x, y)) =>
+      case (_, _) if isPrimitive(x) && isPrimitive(y) && isCoercibleTo(x, y) =>
         (x, ctx)
       case (WT_Optional(l), WT_Optional(r)) =>
         val (t, ctx2) = unify(l, r, ctx)
@@ -133,7 +133,7 @@ case class TUtil(conf: Options) {
       case (WT_Identifier(l), WT_Identifier(r)) if l == r =>
         // a user defined type
         (WT_Identifier(l), ctx)
-      case (WT_Var(i), WT_Var(j)) if (i == j) =>
+      case (WT_Var(i), WT_Var(j)) if i == j =>
         (WT_Var(i), ctx)
 
       case (a: WT_Var, b: WT_Var) =>
@@ -154,7 +154,7 @@ case class TUtil(conf: Options) {
       case (a: WT_Var, z) =>
         if (!(ctx contains a)) {
           // found a binding for a type variable
-          (z, (ctx + (a -> z)))
+          (z, ctx + (a -> z))
         } else {
           // a binding already exists, choose the more general
           // type
@@ -244,7 +244,7 @@ case class TUtil(conf: Options) {
       case WT_Optional(t)    => s"Optional[${toString(t)}]"
 
       // a user defined structure
-      case WT_Struct(name, members) => s"Struct($name)"
+      case WT_Struct(name, _) => s"Struct($name)"
 
       case WT_Task(name, input, output) =>
         val inputs = input

--- a/src/main/scala/wdlTools/typing/package.scala
+++ b/src/main/scala/wdlTools/typing/package.scala
@@ -5,7 +5,7 @@ import wdlTools.syntax.TextSource
 // Type error exception
 final class TypeException(message: String) extends Exception(message) {
   def this(msg: String, text: TextSource) =
-    this(s"${msg} in file ${text.url} line ${text.line} col ${text.col}")
+    this(s"${msg} at ${text}")
 }
 
 final class TypeUnificationException(message: String) extends Exception(message)

--- a/src/main/scala/wdlTools/util/Util.scala
+++ b/src/main/scala/wdlTools/util/Util.scala
@@ -22,16 +22,16 @@ object Util {
     config.getString("wdlTools.version")
   }
 
-  def getURL(pathOrUrl: String, searchPath: Option[Vector[Path]] = None): URL = {
+  def getURL(pathOrUrl: String, searchPath: Vector[Path] = Vector.empty): URL = {
     if (pathOrUrl.contains("://")) {
       new URL(pathOrUrl)
     } else {
       val path: Path = Paths.get(pathOrUrl)
       val resolved: Option[Path] = if (Files.exists(path)) {
         Some(path)
-      } else if (searchPath.isDefined) {
+      } else if (searchPath.nonEmpty) {
         // search in all directories where imports may be found
-        searchPath.get.map(d => d.resolve(pathOrUrl)).collectFirst {
+        searchPath.map(d => d.resolve(pathOrUrl)).collectFirst {
           case fp if Files.exists(fp) => fp
         }
       } else None

--- a/src/main/scala/wdlTools/util/package.scala
+++ b/src/main/scala/wdlTools/util/package.scala
@@ -14,6 +14,7 @@ object Verbosity extends Enumeration {
 }
 
 object TypeCheckingRegime extends Enumeration {
+  type TypeCheckingRegime = Value
   val Strict, Moderate, Lenient = Value
 
   def fromName(name: String): TypeCheckingRegime.Value = {
@@ -30,7 +31,7 @@ import Verbosity._
   * @param verbosity verbosity level.
   * @param antlr4Trace whether to turn on tracing in the ANTLR4 parser.
   */
-case class Options(localDirectories: Option[Vector[Path]] = None,
+case class Options(localDirectories: Vector[Path] = Vector.empty,
                    followImports: Boolean = false,
                    verbosity: Verbosity = Normal,
                    antlr4Trace: Boolean = false,

--- a/src/test/scala/wdlTools/syntax/AbstractSyntaxTest.scala
+++ b/src/test/scala/wdlTools/syntax/AbstractSyntaxTest.scala
@@ -12,7 +12,7 @@ class AbstractSyntaxTest extends FlatSpec with Matchers {
   private val workflowsDir = Paths.get(getClass.getResource("/syntax/v1/workflows").getPath)
   private val opts =
     Options(antlr4Trace = false,
-            localDirectories = Some(Vector(tasksDir, workflowsDir)),
+            localDirectories = Vector(tasksDir, workflowsDir),
             verbosity = Verbosity.Quiet)
   private val loader = SourceCode.Loader(opts)
   private val parser = ParseAll(opts, loader)

--- a/src/test/scala/wdlTools/syntax/draft_2/ConcreteSyntaxTest.scala
+++ b/src/test/scala/wdlTools/syntax/draft_2/ConcreteSyntaxTest.scala
@@ -15,7 +15,7 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
   private val opts = Options(
       antlr4Trace = false,
       verbosity = Quiet,
-      localDirectories = Some(Vector(tasksDir, workflowsDir))
+      localDirectories = Vector(tasksDir, workflowsDir)
   )
   private val loader = SourceCode.Loader(opts)
   private val grammarFactory = WdlDraft2GrammarFactory(opts)

--- a/src/test/scala/wdlTools/syntax/v1/ConcreteSyntaxTest.scala
+++ b/src/test/scala/wdlTools/syntax/v1/ConcreteSyntaxTest.scala
@@ -16,7 +16,7 @@ class ConcreteSyntaxTest extends FlatSpec with Matchers {
   private val opts = Options(
       antlr4Trace = false,
       verbosity = Quiet,
-      localDirectories = Some(Vector(tasksDir, workflowsDir, structsDir))
+      localDirectories = Vector(tasksDir, workflowsDir, structsDir)
   )
   private val loader = SourceCode.Loader(opts)
   private val grammarFactory = WdlV1GrammarFactory(opts)

--- a/src/test/scala/wdlTools/typing/TypeCheckerTest.scala
+++ b/src/test/scala/wdlTools/typing/TypeCheckerTest.scala
@@ -10,10 +10,8 @@ import wdlTools.util.{Options, SourceCode, TypeCheckingRegime, Util, Verbosity}
 class TypeCheckerTest extends FlatSpec with Matchers {
   private val opts = Options(
       antlr4Trace = false,
-      localDirectories = Some(
-          Vector(
-              Paths.get(getClass.getResource("/typing/v1").getPath)
-          )
+      localDirectories = Vector(
+          Paths.get(getClass.getResource("/typing/v1").getPath)
       ),
       verbosity = Verbosity.Normal,
       followImports = true
@@ -35,35 +33,35 @@ class TypeCheckerTest extends FlatSpec with Matchers {
 
   val controlTable: Map[String, TResult] = Map(
       // workflows
-      "census.wdl" -> TResult(true),
-      "compound_expr_bug.wdl" -> TResult(true),
-      "imports.wdl" -> TResult(true),
-      "linear.wdl" -> TResult(true),
-      "nested.wdl" -> TResult(true),
-      "types.wdl" -> TResult(true),
-      "coercions_questionable.wdl" -> TResult(true, Some(TypeCheckingRegime.Lenient)),
-      "coercions_strict.wdl" -> TResult(true),
-      "bad_stdlib_calls.wdl" -> TResult(false),
-      "scatter_II.wdl" -> TResult(false),
-      "scatter_I.wdl" -> TResult(false),
-      "shadow_II.wdl" -> TResult(false),
-      "shadow.wdl" -> TResult(false),
+      "census.wdl" -> TResult(correct = true),
+      "compound_expr_bug.wdl" -> TResult(correct = true),
+      "imports.wdl" -> TResult(correct = true),
+      "linear.wdl" -> TResult(correct = true),
+      "nested.wdl" -> TResult(correct = true),
+      "types.wdl" -> TResult(correct = true),
+      "coercions_questionable.wdl" -> TResult(correct = true, Some(TypeCheckingRegime.Lenient)),
+      "coercions_strict.wdl" -> TResult(correct = true),
+      "bad_stdlib_calls.wdl" -> TResult(correct = false),
+      "scatter_II.wdl" -> TResult(correct = false),
+      "scatter_I.wdl" -> TResult(correct = false),
+      "shadow_II.wdl" -> TResult(correct = false),
+      "shadow.wdl" -> TResult(correct = false),
       // correct tasks
-      "command_string.wdl" -> TResult(true),
-      "comparisons.wdl" -> TResult(true),
-      "library.wdl" -> TResult(true),
-      "null.wdl" -> TResult(true),
-      "simple.wdl" -> TResult(true),
-      "stdlib.wdl" -> TResult(true),
+      "command_string.wdl" -> TResult(correct = true),
+      "comparisons.wdl" -> TResult(correct = true),
+      "library.wdl" -> TResult(correct = true),
+      "null.wdl" -> TResult(correct = true),
+      "simple.wdl" -> TResult(correct = true),
+      "stdlib.wdl" -> TResult(correct = true),
       // incorrect tasks
-      "comparison1.wdl" -> TResult(false),
-      "comparison2.wdl" -> TResult(false),
-      "comparison4.wdl" -> TResult(false),
-      "declaration_shadowing.wdl" -> TResult(false),
-      "simple.wdl" -> TResult(false),
+      "comparison1.wdl" -> TResult(correct = false),
+      "comparison2.wdl" -> TResult(correct = false),
+      "comparison4.wdl" -> TResult(correct = false),
+      "declaration_shadowing.wdl" -> TResult(correct = false),
+      "simple.wdl" -> TResult(correct = false),
       // expressions
-      "expressions.wdl" -> TResult(true),
-      "expressions_bad.wdl" -> TResult(false)
+      "expressions.wdl" -> TResult(correct = true),
+      "expressions_bad.wdl" -> TResult(correct = false)
   )
 
   // test to include/exclude
@@ -112,13 +110,13 @@ class TypeCheckerTest extends FlatSpec with Matchers {
 
   private def includeExcludeCheck(name: String): Boolean = {
     excludeList match {
-      case Some(l) if (l contains name) => return false
-      case _                            => ()
+      case Some(l) if l contains name => return false
+      case _                          => ()
     }
     includeList match {
-      case None                         => return true
-      case Some(l) if (l contains name) => return true
-      case Some(_)                      => return false
+      case None                       => true
+      case Some(l) if l contains name => true
+      case Some(_)                    => false
     }
   }
 
@@ -128,18 +126,17 @@ class TypeCheckerTest extends FlatSpec with Matchers {
     )
 
     // filter out files that do not appear in the control table
-    val testFiles2 = testFiles.flatMap {
-      case testFile =>
-        val name = testFile.getFileName().toString
-        if (!includeExcludeCheck(name)) {
-          None
-        } else {
-          controlTable.get(name) match {
-            case None => None
-            case Some(tResult) =>
-              Some(testFile, tResult)
-          }
+    val testFiles2 = testFiles.flatMap { testFile =>
+      val name = testFile.getFileName.toString
+      if (!includeExcludeCheck(name)) {
+        None
+      } else {
+        controlTable.get(name) match {
+          case None => None
+          case Some(tResult) =>
+            Some(testFile, tResult)
         }
+      }
     }
 
     testFiles2.foreach {
@@ -150,7 +147,7 @@ class TypeCheckerTest extends FlatSpec with Matchers {
     }
   }
 
-  it should "be able to handle GATK" taggedAs (Edge) in {
+  it should "be able to handle GATK" taggedAs Edge in {
     val opts2 = opts.copy(typeChecking = TypeCheckingRegime.Lenient)
     val stdlib = Stdlib(opts2)
     val checker = TypeChecker(stdlib)


### PR DESCRIPTION
I am improving the formatter to handle in-line comments. Both this and the linter require more details about the location of elements in the source file. That is what (most of) these changes are supporting.

* Make ExprMap and ExprObject have element-type members rather than maps
* Make ImportDoc address an element (ImportAddr) rather than a URL: when the formatter re-writes the WDL it needs to know the address in the original file.
* Put docSourceURL in Document rather than TextSource: the URL is the same for all TextSources in a document, so it makes more sense to just put the URL at the top-level.
* Add endLine and endCol to TextSource
* Fix misnamed method getSourceText -> getTextSource
* Improve grammar to allow any whitespace between 'command' and '{'/'<<<'
* Few other cleanups