### PR TITLE
Linter

### DIFF
--- a/doc/Commands/Lint.md
+++ b/doc/Commands/Lint.md
@@ -1,0 +1,14 @@
+# Lint
+
+Checks a WDL document for common errors and code "smells." The linter applies a set of rules to the document - any rule that fails generates either a warning or an error, depending on how the rule is configured.
+
+## Usage
+
+## Rules
+
+# White space
+
+* (P001) whitespace_tabs: Use of tabs in whitespace
+* (P002) odd_indent: Indent by odd number of whitespace characters
+* (P003) multiple_blank_lines: More than one blank line between sections
+* (P004) top_level_indent: A top-level element is indented

--- a/doc/Commands/Lint.md
+++ b/doc/Commands/Lint.md
@@ -4,11 +4,45 @@ Checks a WDL document for common errors and code "smells." The linter applies a 
 
 ## Usage
 
+```commandline
+Usage: wdlTools lint [OPTIONS] <path|uri>
+Check WDL file for common mistakes and bad code smells
+
+Options:
+
+  -c, --config  <arg>             Path to lint config file
+  -e, --exclude-rules  <arg>...   Lint rules to exclude
+  -f, --follow-imports            (Default) format imported files in addition to
+                                  the main file
+      --nofollow-imports          only format the main file
+  -i, --include-rules  <arg>...   Lint rules to include; may be of the form
+                                  '<rule>=<level>' to change the default level
+  -j, --json                      Output lint errors as JSON
+      --nojson                    Output lint errors as plain text
+  -l, --local-dir  <arg>...       directory in which to search for imports;
+                                  ignored if --nofollow-imports is specified
+  -o, --output-file  <arg>        File in which to write lint errors; if not
+                                  specified, errors are written to stdout
+      --overwrite                 Overwrite existing files
+      --nooverwrite               (Default) Do not overwrite existing files
+  -h, --help                      Show help message
+
+ trailing arguments:
+  url (required)   path or URL (file:// or http(s)://) to the main WDL file
+```
+
 ## Rules
 
-# White space
+### White space
 
 * (P001) whitespace_tabs: Use of tabs in whitespace
 * (P002) odd_indent: Indent by odd number of whitespace characters
 * (P003) multiple_blank_lines: More than one blank line between sections
 * (P004) top_level_indent: A top-level element is indented
+* (P005) deprecated_command_style: Deprecated command block style - use ~{} instead
+
+### Other
+
+* (A001) non_portable_task: A task with no runtime section, or with a runtime section that lacks a container definition
+* (A002) no_task_inputs: Suspicious lack of task inputs (is this task really idempotent and portable?)
+* (A003) no_task_outputs: Suspicious lack of task outputs (is this task really idempotent and portable?)

--- a/src/main/antlr4/v1/WdlV1Parser.g4
+++ b/src/main/antlr4/v1/WdlV1Parser.g4
@@ -186,7 +186,7 @@ task_command_string_part
 	;
 
 task_command_expr_part
-	: StringCommandStart	(expression_placeholder_option)* expr RBRACE
+	: StringCommandStart (expression_placeholder_option)* expr RBRACE
 	;
 
 task_command_expr_with_string

--- a/src/main/resources/rules/lint_rules.json
+++ b/src/main/resources/rules/lint_rules.json
@@ -1,0 +1,36 @@
+{
+  "P001": {
+    "name": "whitespace_tabs",
+    "description": "Use of tabs in whitespace"
+  },
+  "P002": {
+    "name": "odd_indent",
+    "description": "Indent by odd number of whitespace characters"
+  },
+  "P003": {
+    "name": "multiple_blank_lines",
+    "description": "More than one blank line between sections"
+  },
+  "P004": {
+    "name": "top_level_indent",
+    "description": "A top-level element is indented"
+  },
+  "P005": {
+    "name": "deprecated_command_style",
+    "description": "Deprecated command block style - use ~{} instead"
+  },
+  "A001": {
+    "name": "non_portable_task",
+    "description": "Non-portable task"
+  },
+  "A002": {
+    "name": "no_task_inputs",
+    "description": "Suspicious lack of task inputs (is this task really idempotent and portable?",
+    "severity": "Warning"
+  },
+  "A003": {
+    "name": "no_task_outputs",
+    "description": "Suspicious lack of task outputs (is this task really idempotent and portable?",
+    "severity": "Warning"
+  }
+}

--- a/src/main/resources/rules/lint_rules.json
+++ b/src/main/resources/rules/lint_rules.json
@@ -25,12 +25,12 @@
   },
   "A002": {
     "name": "no_task_inputs",
-    "description": "Suspicious lack of task inputs (is this task really idempotent and portable?",
+    "description": "Suspicious lack of task inputs (is this task really idempotent and portable?)",
     "severity": "Warning"
   },
   "A003": {
     "name": "no_task_outputs",
-    "description": "Suspicious lack of task outputs (is this task really idempotent and portable?",
+    "description": "Suspicious lack of task outputs (is this task really idempotent and portable?)",
     "severity": "Warning"
   }
 }

--- a/src/main/scala/wdlTools/cli/Format.scala
+++ b/src/main/scala/wdlTools/cli/Format.scala
@@ -12,13 +12,17 @@ case class Format(conf: WdlToolsConf) extends Command {
   override def apply(): Unit = {
     val url = conf.format.url()
     val opts = conf.format.getOptions
+    val outputDir = conf.format.outputDir.toOption
+    val overwrite = conf.format.overwrite()
     val formatter = WdlV1Formatter(opts)
     formatter.formatDocuments(url)
     formatter.documents.foreach {
       case (uri, lines) =>
-        val outputPath =
-          Util.getLocalPath(uri, conf.format.outputDir.toOption, conf.format.overwrite())
-        Files.write(outputPath, lines.asJava)
+        if (outputDir.isDefined || overwrite) {
+          Files.write(Util.getLocalPath(uri, outputDir, overwrite), lines.asJava)
+        } else {
+          println(lines.mkString(System.lineSeparator()))
+        }
     }
   }
 }

--- a/src/main/scala/wdlTools/cli/Lint.scala
+++ b/src/main/scala/wdlTools/cli/Lint.scala
@@ -1,0 +1,213 @@
+package wdlTools.cli
+
+import java.io.{FileOutputStream, PrintStream}
+import java.net.URL
+import java.nio.file.{Files, Path}
+
+import spray.json.{JsObject, JsString, JsValue}
+import spray.json._
+import wdlTools.linter.Severity.Severity
+import wdlTools.linter.{LintEvent, Linter, Rules, Severity}
+
+import scala.io.{AnsiColor, Source}
+import scala.language.reflectiveCalls
+
+case class Lint(conf: WdlToolsConf) extends Command {
+  private val RULES_RESOURCE = "rules/lint_rules.json"
+
+  override def apply(): Unit = {
+    val url = conf.lint.url()
+    val opts = conf.lint.getOptions
+    val rules =
+      if (conf.lint.config.isDefined) {
+        val (incl, excl) = rulesFromFile(conf.lint.config())
+        incl.getOrElse(Rules.defaultRules).removedAll(excl.getOrElse(Set.empty))
+      } else if (conf.lint.includeRules.isDefined || conf.lint.excludeRules.isDefined) {
+        val incl = conf.lint.includeRules.map(rulesFromOptions)
+        val excl = conf.lint.excludeRules.map(_.toSet)
+        incl.getOrElse(Rules.defaultRules).removedAll(excl.getOrElse(Set.empty))
+      } else {
+        Rules.defaultRules
+      }
+    val linter = Linter(opts, rules)
+    linter.apply(url)
+
+    if (linter.hasEvents) {
+      // Load rule descriptions
+      val rules = readJsonSource(Source.fromResource(RULES_RESOURCE))
+      val outputFile = conf.lint.outputFile.toOption
+      val toFile = outputFile.isDefined
+      val printer: PrintStream = if (toFile) {
+        val resolved = outputFile.get
+        if (!conf.lint.overwrite() && Files.exists(resolved)) {
+          throw new Exception(s"File already exists: ${resolved}")
+        }
+        val fos = new FileOutputStream(outputFile.get.toFile)
+        new PrintStream(fos, true)
+      } else {
+        System.out
+      }
+      if (conf.lint.json()) {
+        val js = eventsToJson(linter.getOrderedEvents, rules).prettyPrint
+        printer.println(js)
+      } else {
+        printEvents(linter.getOrderedEvents, rules, printer, effects = !toFile)
+      }
+      if (toFile) {
+        printer.close()
+      }
+    }
+  }
+
+  private def readJsonSource(src: Source): Map[String, JsValue] = {
+    val jsObj =
+      try {
+        src.getLines.mkString(System.lineSeparator).parseJson
+      } catch {
+        case _: NullPointerException =>
+          throw new Exception(s"Could not open resource ${RULES_RESOURCE}")
+      }
+    jsObj match {
+      case JsObject(fields) => fields
+      case _                => throw new Exception("Invalid lint_rules.json file")
+    }
+  }
+
+  private def rulesFromFile(path: Path): (Option[Map[String, Severity]], Option[Set[String]]) = {
+    val rules = readJsonSource(Source.fromFile(path.toFile))
+
+    def rulesToSet(key: String): Option[Vector[JsValue]] = {
+      if (rules.contains(key)) {
+        rules(key) match {
+          case JsArray(values) => Some(values)
+          case _               => throw new Exception(s"Invalid lint config file ${path}")
+        }
+      } else {
+        None
+      }
+    }
+
+    val include = rulesToSet("include").map { rules =>
+      rules.map {
+        case JsString(value) => value -> Severity.Default
+        case JsObject(fields) =>
+          val severity = if (fields.contains("severity")) {
+            Severity.withName(getString(fields("severity")))
+          } else {
+            Severity.Default
+          }
+          getString(fields("ruleId")) -> severity
+        case _ => throw new Exception(s"Invalid lint config file ${path}")
+      }.toMap
+    }
+    val exclude = rulesToSet("exclude").map { rules =>
+      rules.map {
+        case JsString(value) => value
+        case _               => throw new Exception(s"Invalid lint config file ${path}")
+      }.toSet
+    }
+    (include, exclude)
+  }
+
+  private def rulesFromOptions(options: Seq[String]): Map[String, Severity] = {
+    options.map { opt =>
+      val parts = opt.split("=", 1)
+      if (parts.length == 2) {
+        parts(0) -> Severity.withName(parts(1))
+      } else {
+        parts(0) -> Severity.Default
+      }
+    }.toMap
+  }
+
+  private def getFields(js: JsValue): Map[String, JsValue] = {
+    js match {
+      case JsObject(fields) => fields
+      case _                => throw new Exception("Invalid linter_rules.json format")
+    }
+  }
+
+  private def getString(js: JsValue): String = {
+    js match {
+      case JsString(value) => value
+      case other           => throw new Exception(s"Expected JsString, got ${other}")
+    }
+  }
+
+  private def eventsToJson(events: Map[URL, Vector[LintEvent]],
+                           rules: Map[String, JsValue]): JsObject = {
+    def eventToJson(err: LintEvent): JsObject = {
+      val rule = getFields(rules(err.ruleId))
+      JsObject(
+          Map(
+              "ruleId" -> JsString(err.ruleId),
+              "ruleName" -> JsString(getString(rule("name"))),
+              "ruleDescription" -> JsString(getString(rule("description"))),
+              "severity" -> JsString(err.severity.toString),
+              "startLine" -> JsNumber(err.textSource.line),
+              "startCol" -> JsNumber(err.textSource.col),
+              "endLine" -> JsNumber(err.textSource.endLine),
+              "endCol" -> JsNumber(err.textSource.endCol)
+          )
+      )
+    }
+
+    JsObject(Map("sources" -> JsArray(events.map {
+      case (url, events) =>
+        JsObject(
+            Map("source" -> JsString(url.toString), "events" -> JsArray(events.map(eventToJson)))
+        )
+    }.toVector)))
+  }
+
+  private def severityToColor(severity: Severity): String = {
+    severity match {
+      case Severity.Error   => AnsiColor.RED
+      case Severity.Warning => AnsiColor.YELLOW
+      case Severity.Ignore  => AnsiColor.REVERSED
+    }
+  }
+
+  private def printEvents(events: Map[URL, Vector[LintEvent]],
+                          rules: Map[String, JsValue],
+                          printer: PrintStream,
+                          effects: Boolean): Unit = {
+    def colorMsg(msg: String, color: String): String = {
+      if (effects) {
+        s"${color}${msg}${AnsiColor.RESET}"
+      } else {
+        msg
+      }
+    }
+    events.foreach { item =>
+      val (msg, events) = item match {
+        case (url, events) => (s"Lint in ${url}", events)
+      }
+      val border1 = "=" * msg.length
+      val border2 = "-" * msg.length
+      printer.println(border1)
+      printer.println(colorMsg(msg, AnsiColor.BLUE))
+      printer.println(border1)
+      printer.println(colorMsg("Line:Col | Rule | Description", AnsiColor.BOLD))
+      printer.println(border2)
+      events.sortWith(_.textSource < _.textSource).foreach { event =>
+        val ruleDesc = rules(event.ruleId) match {
+          case JsObject(fields) =>
+            val desc = getString(fields("description"))
+            val eventMsg = if (event.message.isDefined) {
+              s"${desc}: ${event.message.get}"
+            } else {
+              desc
+            }
+            if (effects) {
+              colorMsg(eventMsg, severityToColor(event.severity))
+            } else {
+              s"${event.severity.toString}: ${eventMsg}"
+            }
+          case _ => throw new Exception("Invalid linter_rules.json format")
+        }
+        printer.println(f"${event.textSource}%-9s| ${event.ruleId} | ${ruleDesc}")
+      }
+    }
+  }
+}

--- a/src/main/scala/wdlTools/cli/Main.scala
+++ b/src/main/scala/wdlTools/cli/Main.scala
@@ -9,6 +9,7 @@ object Main extends App {
       val command: Command = subcommand match {
         case conf.check    => TypeCheck(conf)
         case conf.format   => Format(conf)
+        case conf.lint     => Lint(conf)
         case conf.upgrade  => Upgrade(conf)
         case conf.generate => Generate(conf)
         case conf.readmes  => Readmes(conf)

--- a/src/main/scala/wdlTools/cli/TypeCheck.scala
+++ b/src/main/scala/wdlTools/cli/TypeCheck.scala
@@ -3,6 +3,7 @@ package wdlTools.cli
 import wdlTools.syntax.Parsers
 import wdlTools.types.{Context, Stdlib, TypeChecker}
 
+// TODO: nicely format errors, including JSON output
 case class TypeCheck(conf: WdlToolsConf) extends Command {
   override def apply(): Unit = {
     val url = conf.check.url()

--- a/src/main/scala/wdlTools/cli/TypeCheck.scala
+++ b/src/main/scala/wdlTools/cli/TypeCheck.scala
@@ -7,6 +7,7 @@ case class TypeCheck(conf: WdlToolsConf) extends Command {
   override def apply(): Unit = {
     val url = conf.check.url()
     val opts = conf.check.getOptions
+    require(opts.followImports)
     val parsers = Parsers(opts)
     val checker = TypeChecker(Stdlib(opts))
 

--- a/src/main/scala/wdlTools/cli/Upgrade.scala
+++ b/src/main/scala/wdlTools/cli/Upgrade.scala
@@ -12,16 +12,19 @@ case class Upgrade(conf: WdlToolsConf) extends Command {
   override def apply(): Unit = {
     val url = conf.upgrade.url()
     val opts = conf.upgrade.getOptions
+    val outputDir = conf.format.outputDir.toOption
+    val overwrite = conf.format.overwrite()
     val upgrader = Upgrader(opts)
-
     // write out upgraded versions
     val documents =
       upgrader.upgrade(url, conf.upgrade.srcVersion.toOption, conf.upgrade.destVersion())
     documents.foreach {
       case (uri, lines) =>
-        val outputPath =
-          Util.getLocalPath(uri, conf.format.outputDir.toOption, conf.format.overwrite())
-        Files.write(outputPath, lines.asJava)
+        if (outputDir.isDefined || overwrite) {
+          Files.write(Util.getLocalPath(uri, outputDir, overwrite), lines.asJava)
+        } else {
+          println(lines.mkString(System.lineSeparator()))
+        }
     }
   }
 }

--- a/src/main/scala/wdlTools/cli/package.scala
+++ b/src/main/scala/wdlTools/cli/package.scala
@@ -165,19 +165,16 @@ class WdlToolsConf(args: Seq[String]) extends ScallopConf(args) {
         Left("Only WDL v1.0 is supported currently")
       case _ => Right(())
     }
-    val outputDir: ScallopOption[Path] = opt[Path](descr =
-      "Directory in which to output formatted WDL files; if not specified, the input files are overwritten"
+    val outputDir: ScallopOption[Path] = opt[Path](
+        descr =
+          "Directory in which to output formatted WDL files; if not specified, the input files are overwritten",
+        short = 'O'
     )
     val overwrite: ScallopOption[Boolean] = toggle(
         descrYes = "Overwrite existing files",
         descrNo = "(Default) Do not overwrite existing files",
         default = Some(false)
     )
-    validateOpt(outputDir, overwrite) {
-      case (None, Some(false) | None) =>
-        Left("--output-dir is required unless --overwrite is specified")
-      case _ => Right(())
-    }
   }
   addSubcommand(format)
 
@@ -236,19 +233,16 @@ class WdlToolsConf(args: Seq[String]) extends ScallopConf(args) {
       case (None, _) => Right(())
       case _         => Left("Source version must be earlier than destination version")
     }
-    val outputDir: ScallopOption[Path] = opt[Path](descr =
-      "Directory in which to output upgraded WDL file(s); if not specified, the input files are overwritten"
+    val outputDir: ScallopOption[Path] = opt[Path](
+        descr =
+          "Directory in which to output upgraded WDL file(s); if not specified, the input files are overwritten",
+        short = 'O'
     )
     val overwrite: ScallopOption[Boolean] = toggle(
         descrYes = "Overwrite existing files",
         descrNo = "(Default) Do not overwrite existing files",
         default = Some(false)
     )
-    validateOpt(outputDir, overwrite) {
-      case (None, Some(false) | None) =>
-        Left("--output-dir is required unless --overwrite is specified")
-      case _ => Right(())
-    }
   }
   addSubcommand(upgrade)
 

--- a/src/main/scala/wdlTools/linter/Linter.scala
+++ b/src/main/scala/wdlTools/linter/Linter.scala
@@ -1,0 +1,72 @@
+package wdlTools.linter
+
+import java.net.URL
+
+import org.antlr.v4.runtime.tree.ParseTreeListener
+import wdlTools.linter.Severity.Severity
+import wdlTools.syntax.Antlr4Util.ParseTreeListenerFactory
+import wdlTools.syntax.{Antlr4Util, Parsers}
+import wdlTools.types.{Stdlib, TypeChecker}
+import wdlTools.util.Options
+
+import scala.collection.mutable
+
+case class LinterParserRuleFactory(
+    rules: Map[String, Severity],
+    events: mutable.Map[URL, mutable.Buffer[LintEvent]]
+) extends ParseTreeListenerFactory {
+  override def createParseTreeListeners(
+      grammar: Antlr4Util.Grammar
+  ): Vector[ParseTreeListener] = {
+    val docEvents: mutable.Buffer[LintEvent] = mutable.ArrayBuffer.empty
+    events(grammar.docSourceUrl.get) = docEvents
+    rules.collect {
+      case (id, severity) if Rules.parserRules.contains(id) =>
+        Rules.parserRules(id)(id, severity, docEvents, grammar)
+    }.toVector
+  }
+}
+
+case class Linter(opts: Options,
+                  rules: Map[String, Severity] = Rules.defaultRules,
+                  events: mutable.Map[URL, mutable.Buffer[LintEvent]] = mutable.HashMap.empty) {
+  def hasEvents: Boolean = events.nonEmpty
+
+  def getOrderedEvents: Map[URL, Vector[LintEvent]] =
+    events.map {
+      case (url, docEvents) => url -> docEvents.toVector.sortWith(_ < _)
+    }.toMap
+
+  def apply(url: URL): Unit = {
+    val parsers = Parsers(opts, listenerFactories = Vector(LinterParserRuleFactory(rules, events)))
+    parsers.getDocumentWalker[mutable.Buffer[LintEvent]](url, events, mayRevisit = true).walk {
+      (url, doc, _) =>
+        val astRules = rules.view.filterKeys(Rules.astRules.contains)
+        if (astRules.nonEmpty) {
+          if (!events.contains(url)) {
+            val docEvents = mutable.ArrayBuffer.empty[LintEvent]
+            events(url) = docEvents
+          }
+          // First run the TypeChecker to infer the types of all expressions
+          val stdlib = Stdlib(opts)
+          val typeChecker = TypeChecker(stdlib)
+          val typesContext = typeChecker.apply(doc)
+          // Now execute the linter rules
+          val visitors = astRules.map {
+            case (id, severity) =>
+              Rules.astRules(id)(
+                  id,
+                  severity,
+                  doc.version.value,
+                  typesContext,
+                  stdlib,
+                  events(url),
+                  Some(url)
+              )
+          }.toVector
+          val astWalker = LinterASTWalker(opts, visitors)
+          astWalker.apply(doc)
+        }
+    }
+  }
+}

--- a/src/main/scala/wdlTools/linter/LinterASTWalker.scala
+++ b/src/main/scala/wdlTools/linter/LinterASTWalker.scala
@@ -1,0 +1,167 @@
+package wdlTools.linter
+
+import wdlTools.syntax.ASTVisitor.Context
+import wdlTools.syntax.{ASTVisitor, ASTWalker}
+import wdlTools.syntax.AbstractSyntax._
+import wdlTools.util.Options
+
+case class LinterASTWalker(opts: Options, visitors: Vector[ASTVisitor]) extends ASTWalker(opts) {
+  def visitEveryRule(ctx: Context[Element]): Unit = {}
+
+  override def visitDocument(ctx: Context[Document]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitDocument(ctx))
+    super.visitDocument(ctx)
+  }
+
+  override def visitIdentifier[P <: Element](identifier: String, parent: Context[P]): Unit = {
+    visitors.foreach(_.visitIdentifier(identifier, parent))
+    super.visitIdentifier(identifier, parent)
+  }
+
+  override def visitVersion(ctx: Context[Version]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitVersion(ctx))
+    super.visitVersion(ctx)
+  }
+
+  override def visitImportAlias(ctx: Context[ImportAlias]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitImportAlias(ctx))
+    super.visitImportAlias(ctx)
+  }
+
+  override def visitImportDoc(ctx: Context[ImportDoc]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitImportDoc(ctx))
+    super.visitImportDoc(ctx)
+  }
+
+  override def visitStruct(ctx: Context[TypeStruct]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitStruct(ctx))
+    super.visitStruct(ctx)
+  }
+
+  override def visitDataType(ctx: Context[Type]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitDataType(ctx))
+    super.visitDataType(ctx)
+  }
+
+  override def visitStructMember(ctx: Context[StructMember]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitStructMember(ctx))
+    super.visitStructMember(ctx)
+  }
+
+  override def visitExpression(ctx: Context[Expr]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitExpression(ctx))
+    super.visitExpression(ctx)
+  }
+
+  override def visitDeclaration(ctx: Context[Declaration]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitDeclaration(ctx))
+    super.visitDeclaration(ctx)
+  }
+
+  override def visitInputSection(ctx: Context[InputSection]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitInputSection(ctx))
+    super.visitInputSection(ctx)
+  }
+
+  override def visitOutputSection(ctx: Context[OutputSection]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitOutputSection(ctx))
+    super.visitOutputSection(ctx)
+  }
+
+  override def visitCallAlias(ctx: Context[CallAlias]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitCallAlias(ctx))
+    super.visitCallAlias(ctx)
+  }
+
+  override def visitCallInput(ctx: Context[CallInput]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitCallInput(ctx))
+    super.visitCallInput(ctx)
+  }
+
+  override def visitCall(ctx: Context[Call]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitCall(ctx))
+    super.visitCall(ctx)
+  }
+
+  override def visitScatter(ctx: Context[Scatter]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitScatter(ctx))
+    super.visitScatter(ctx)
+  }
+
+  override def visitConditional(ctx: Context[Conditional]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitConditional(ctx))
+    super.visitConditional(ctx)
+  }
+
+  override def visitBody[P <: Element](body: Vector[WorkflowElement], ctx: Context[P]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitBody(body, ctx))
+    super.visitBody(body, ctx)
+  }
+
+  override def visitMetaKV(ctx: Context[MetaKV]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitMetaKV(ctx))
+    super.visitMetaKV(ctx)
+  }
+
+  override def visitMetaSection(ctx: Context[MetaSection]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitMetaSection(ctx))
+    super.visitMetaSection(ctx)
+  }
+
+  override def visitParameterMetaSection(
+      ctx: Context[ParameterMetaSection]
+  ): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitParameterMetaSection(ctx))
+    super.visitParameterMetaSection(ctx)
+  }
+
+  override def visitWorkflow(ctx: Context[Workflow]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitWorkflow(ctx))
+    super.visitWorkflow(ctx)
+  }
+
+  override def visitCommandSection(ctx: Context[CommandSection]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitCommandSection(ctx))
+    super.visitCommandSection(ctx)
+  }
+
+  override def visitRuntimeKV(ctx: Context[RuntimeKV]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitRuntimeKV(ctx))
+    super.visitRuntimeKV(ctx)
+  }
+
+  override def visitRuntimeSection(ctx: Context[RuntimeSection]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitRuntimeSection(ctx))
+    super.visitRuntimeSection(ctx)
+  }
+
+  override def visitTask(ctx: Context[Task]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitTask(ctx))
+    super.visitTask(ctx)
+  }
+}

--- a/src/main/scala/wdlTools/linter/Rules.scala
+++ b/src/main/scala/wdlTools/linter/Rules.scala
@@ -1,0 +1,380 @@
+package wdlTools.linter
+
+import java.net.URL
+
+import org.antlr.v4.runtime.{ParserRuleContext, Token}
+import wdlTools.linter.Severity.Severity
+import wdlTools.syntax
+import wdlTools.syntax.AbstractSyntax._
+import wdlTools.syntax.{ASTVisitor, AllParseTreeListener, Antlr4Util, TextSource, WdlVersion}
+import wdlTools.syntax.Antlr4Util.Grammar
+import wdlTools.types
+
+import scala.collection.mutable
+
+// TODO: shamelessly copy rules from
+//  * miniwdl: https://github.com/chanzuckerberg/miniwdl/blob/master/WDL/Lint.py
+//  * winstanley: https://github.com/broadinstitute/winstanley
+object Rules {
+  // Parser-level rules
+  // These are mostly to check things reated to whitespace, which is not
+  // accessible from the AST
+
+  // ideally we could provide the id as a class annotation, but dealing with annotations
+  // in Scala is currently horrendous - for how it would be done, see
+  // https://stackoverflow.com/questions/23046958/accessing-an-annotation-value-in-scala
+
+  type LinterParserRuleApplySig = (
+      String,
+      Severity,
+      mutable.Buffer[LintEvent],
+      Grammar
+  ) => LinterParserRule
+
+  class LinterParserRule(id: String,
+                         severity: Severity,
+                         docSourceUrl: Option[URL],
+                         events: mutable.Buffer[LintEvent])
+      extends AllParseTreeListener {
+    protected def addEventFromTokens(tok: Token,
+                                     stopToken: Option[Token] = None,
+                                     message: Option[String] = None): Unit = {
+      addEvent(Antlr4Util.getTextSource(tok, stopToken), message)
+    }
+
+    protected def addEvent(textSource: TextSource, message: Option[String] = None): Unit = {
+      events.append(LintEvent(id, severity, textSource, docSourceUrl, message))
+    }
+  }
+
+  abstract class HiddenTokensLinterParserRule(id: String,
+                                              severity: Severity,
+                                              events: mutable.Buffer[LintEvent],
+                                              grammar: Grammar)
+      extends LinterParserRule(id, severity, grammar.docSourceUrl, events) {
+    private val tokenIndexes: mutable.Set[Int] = mutable.HashSet.empty
+
+    protected def addEvent(tok: Token): Unit = {
+      val idx = tok.getTokenIndex
+      if (!tokenIndexes.contains(idx)) {
+        // properly construct TextSource to deal with newlines
+        val text = tok.getText
+        val lines = text.linesWithSeparators.toVector
+        val textSource = syntax.TextSource(
+            line = tok.getLine,
+            col = tok.getCharPositionInLine,
+            endLine = tok.getLine + math.max(lines.size, 1) - 1,
+            endCol = if (lines.size <= 1) {
+              tok.getCharPositionInLine + text.length
+            } else {
+              lines.last.length + 1
+            }
+        )
+        addEvent(textSource)
+        tokenIndexes.add(idx)
+      }
+    }
+  }
+
+  abstract class EveryRuleHiddenTokensLinterParserRule(id: String,
+                                                       severity: Severity,
+                                                       events: mutable.Buffer[LintEvent],
+                                                       grammar: Grammar)
+      extends HiddenTokensLinterParserRule(id, severity, events, grammar) {
+    override def exitEveryRule(ctx: ParserRuleContext): Unit = {
+      grammar
+        .getHiddenTokens(ctx, within = true)
+        .filter(isViolation)
+        .foreach(addEvent)
+    }
+
+    def isViolation(token: Token): Boolean
+  }
+
+  case class WhitespaceTabsRule(id: String,
+                                severity: Severity,
+                                events: mutable.Buffer[LintEvent],
+                                grammar: Grammar)
+      extends EveryRuleHiddenTokensLinterParserRule(id, severity, events, grammar) {
+    override def isViolation(token: Token): Boolean = {
+      token.getText.contains("\t")
+    }
+  }
+
+  case class OddIndentRule(id: String,
+                           severity: Severity,
+                           events: mutable.Buffer[LintEvent],
+                           grammar: Grammar)
+      extends EveryRuleHiddenTokensLinterParserRule(id, severity, events, grammar) {
+    private val indentRegex = "\n+([ \t]+)".r
+
+    override def isViolation(token: Token): Boolean = {
+      // find any tokens that contain a newline followed by an odd number of spaces
+      indentRegex.findAllMatchIn(token.getText).exists { ws =>
+        ws.group(1)
+          .map {
+            case ' '  => 1
+            case '\t' => 2
+          }
+          .sum % 2 == 1
+      }
+    }
+  }
+
+  case class MultipleBlankLineRule(id: String,
+                                   severity: Severity,
+                                   events: mutable.Buffer[LintEvent],
+                                   grammar: Grammar)
+      extends EveryRuleHiddenTokensLinterParserRule(id, severity, events, grammar) {
+    private val multipleReturns = "(\n\\s*){3,}".r
+
+    override def isViolation(token: Token): Boolean = {
+      multipleReturns.findFirstIn(token.getText).isDefined
+    }
+  }
+
+  case class TopLevelIndentRule(id: String,
+                                severity: Severity,
+                                events: mutable.Buffer[LintEvent],
+                                grammar: Grammar)
+      extends HiddenTokensLinterParserRule(id, severity, events, grammar) {
+    private val endWhitespaceRegex = "\\s$".r
+
+    def checkIndent(ctx: ParserRuleContext): Unit = {
+      grammar
+        .getHiddenTokens(ctx)
+        .collectFirst {
+          case tok
+              if tok.getTokenIndex == ctx.getStart.getTokenIndex - 1 &&
+                endWhitespaceRegex.findFirstIn(tok.getText).isDefined =>
+            tok
+        }
+        .foreach(addEvent)
+    }
+
+    override def enterVersion(ctx: ParserRuleContext): Unit = {
+      checkIndent(ctx)
+    }
+
+    override def enterImport_doc(ctx: ParserRuleContext): Unit = {
+      checkIndent(ctx)
+    }
+
+    override def enterTask(ctx: ParserRuleContext): Unit = {
+      checkIndent(ctx)
+    }
+
+    override def enterWorkflow(ctx: ParserRuleContext): Unit = {
+      checkIndent(ctx)
+    }
+  }
+
+  case class DeprecatedCommandStyleRule(id: String,
+                                        severity: Severity,
+                                        events: mutable.Buffer[LintEvent],
+                                        grammar: Grammar)
+      extends HiddenTokensLinterParserRule(id, severity, events, grammar) {
+
+    override def exitTask_command_expr_part(ctx: ParserRuleContext): Unit = {
+      if (grammar.version >= WdlVersion.V1) {
+        if (!ctx.start.getText.contains("~")) {
+          addEventFromTokens(ctx.start, Some(ctx.stop))
+        }
+      }
+    }
+  }
+
+  // TODO: load these dynamically from a file
+  val parserRules: Map[String, LinterParserRuleApplySig] = Map(
+      "P001" -> WhitespaceTabsRule.apply,
+      "P002" -> OddIndentRule.apply,
+      "P003" -> MultipleBlankLineRule.apply,
+      "P004" -> TopLevelIndentRule.apply,
+      "P005" -> DeprecatedCommandStyleRule.apply
+  )
+
+  // AST-level rules
+  // Note that most of these are caught by the type-checker, but it's
+  // still good to be able to warn the user
+
+  class LinterAstRule(id: String,
+                      severity: Severity,
+                      docSourceUrl: Option[URL],
+                      events: mutable.Buffer[LintEvent])
+      extends ASTVisitor {
+    protected def addEvent(element: Element, message: Option[String] = None): Unit = {
+      events.append(LintEvent(id, severity, element.text, docSourceUrl, message))
+    }
+  }
+
+  type LinterAstRuleApplySig = (
+      String,
+      Severity,
+      WdlVersion,
+      types.Context,
+      types.Stdlib,
+      mutable.Buffer[LintEvent],
+      Option[URL]
+  ) => LinterAstRule
+
+  // rules ported from miniwdl
+
+  /**
+    * Conversion from File-typed expression to String declaration/parameter
+    */
+//  case class StringCoersionRule(id: String,
+//                                severity: Severity,
+//                                version: WdlVersion,
+//                                typesContext: types.Context,
+//                                stdlib: types.Stdlib,
+//                                events: mutable.Buffer[LintEvent],
+//                                docSourceUrl: Option[URL])
+//      extends LinterAstRule(id, severity, docSourceUrl, events) {
+//
+//    // TODO: This can probably be replaced by a call to one of the functions
+//    //  in types.Util
+//    def isCompoundCoercion[T <: Type](to: Type, from: WT)(implicit tag: ClassTag[T]): Boolean = {
+//      (to, from) match {
+//        case (TypeArray(toType, _, _), WT_Array(fromType)) =>
+//          isCompoundCoercion[T](toType, fromType)
+//        case (TypeMap(toKey, toValue, _), WT_Map(fromKey, fromValue)) =>
+//          isCompoundCoercion[T](toKey, fromKey) || isCompoundCoercion[T](toValue, fromValue)
+//        case (TypePair(toLeft, toRight, _), WT_Pair(fromLeft, fromRight)) =>
+//          isCompoundCoercion(toLeft, fromLeft) || isCompoundCoercion(toRight, fromRight)
+//        case (_: T, _: T) => false
+//        case (_: T, _)    => true
+//        case _            => false
+//      }
+//    }
+//    def isCompoundCoercion[T <: WT](to: WT, from: WT)(implicit tag: ClassTag[T]): Boolean = {
+//      (to, from) match {
+//        case (WT_Array(toType), WT_Array(fromType)) =>
+//          isCompoundCoercion[T](toType, fromType)
+//        case (WT_Map(toKey, toValue), WT_Map(fromKey, fromValue)) =>
+//          isCompoundCoercion[T](toKey, fromKey) || isCompoundCoercion[T](toValue, fromValue)
+//        case (WT_Pair(toLeft, toRight), WT_Pair(fromLeft, fromRight)) =>
+//          isCompoundCoercion(toLeft, fromLeft) || isCompoundCoercion(toRight, fromRight)
+//        case (_: T, _: T) => false
+//        case (_: T, _)    => true
+//        case _            => false
+//      }
+//    }
+//
+//    override def visitExpression(ctx: ASTVisitor.Context[Expr]): Unit = {
+//      // File-to-String coercions are normal in tasks, but flagged at the workflow level.
+//      val isInWorkflow = ctx.getParentExecutable match {
+//        case Some(_: Workflow) => true
+//        case _                 => false
+//      }
+//      if (isInWorkflow) {
+//        // if this expression is the rhs of a declaration, check that it is coercible to the lhs type
+//        ctx.getParent.element match {
+//          case Declaration(name, wdlType, expr, _)
+//              if expr.isDefined && isCompoundCoercion[TypeString](
+//                  wdlType,
+//                  typesContext.declarations(name)
+//              ) =>
+//            addEvent(ctx.element)
+//          case _ => ()
+//        }
+//        // check compatible arguments for operations that take multiple string arguments
+//        // TODO: can't implement this until we have type inference
+//        ctx.element match {
+//          case ExprAdd(a, b, _) if ctx.findParent[ExprCompoundString].isEmpty =>
+//            // if either a or b is a non-literal string type while the other is a file type
+//            val wts = Vector(a, b).map(inferType)
+//            val areStrings = wts.map(isStringType)
+//            if (areStrings.exists(_) && !areStrings.forall(_) && !wts.exits(isStringLiteral)) {
+//              addEvent(ctx, Some(""))
+//            }
+//          case ExprApply(funcName, elements, _) =>
+//            // conversion of file-type expression to string-type function parameter
+//            val toTypes: Vector[WT] = stdlib.getFunction(funcName) match {
+//              case WT_Function1(_, arg1, _)             => Vector(arg1)
+//              case WT_Function2(_, arg1, arg2, _)       => Vector(arg1, arg2)
+//              case WT_Function3(_, arg1, arg2, arg3, _) => Vector(arg1, arg2, arg3)
+//              case _                                    => Vector.empty
+//            }
+//            val fromTypes: Vector[WT] = elements.map(inferType)
+//            toTypes.zip(fromTypes).foreach {
+//              case (to, from) if isCompoundCoercion[WT_String](to, from) => addEvent(ctx.element)
+//            }
+//          case ExprArray(values, _) =>
+//            // mixed string and file types in array
+//            val areStrings = values.apply(isStringType)
+//            if (areStrings.exists(_) && !areStrings.forall(_)) {
+//              addEvent(ctx, Some(""))
+//            }
+//        }
+//      }
+//    }
+//  }
+
+  // rules ported from winstanley
+  // rules not ported:
+  // * missing command section - a command section is required, so the parser throws a SyntaxException if
+  //   it doesn't find one
+  // * value/callable lookup - these are caught by the type-checker
+  // * no immediate declaration - the parser catches these
+  // * wildcard outputs - the parser does not allow these even in draft-2
+  // * unexpected/unsupplied inputs - the type-checker catches this
+
+  case class NonPortableTaskRule(id: String,
+                                 severity: Severity,
+                                 version: WdlVersion,
+                                 typesContext: types.Context,
+                                 stdlib: types.Stdlib,
+                                 events: mutable.Buffer[LintEvent],
+                                 docSourceUrl: Option[URL])
+      extends LinterAstRule(id, severity, docSourceUrl, events) {
+    private val containerKeys = Set("docker", "container")
+
+    override def visitTask(ctx: ASTVisitor.Context[Task]): Unit = {
+      if (ctx.element.runtime.isEmpty) {
+        addEvent(ctx.element, Some("add a runtime section specifying a container"))
+      } else if (!ctx.element.runtime.get.kvs.exists(kv => containerKeys.contains(kv.id))) {
+        addEvent(ctx.element, Some("add a container to the runtime section"))
+      }
+    }
+  }
+
+  case class NoTaskInputsRule(id: String,
+                              severity: Severity,
+                              version: WdlVersion,
+                              typesContext: types.Context,
+                              stdlib: types.Stdlib,
+                              events: mutable.Buffer[LintEvent],
+                              docSourceUrl: Option[URL])
+      extends LinterAstRule(id, severity, docSourceUrl, events) {
+    override def visitTask(ctx: ASTVisitor.Context[Task]): Unit = {
+      if (ctx.element.input.isEmpty || ctx.element.input.get.declarations.isEmpty) {
+        addEvent(ctx.element)
+      }
+    }
+  }
+
+  case class NoTaskOutputsRule(id: String,
+                               severity: Severity,
+                               version: WdlVersion,
+                               typesContext: types.Context,
+                               stdlib: types.Stdlib,
+                               events: mutable.Buffer[LintEvent],
+                               docSourceUrl: Option[URL])
+      extends LinterAstRule(id, severity, docSourceUrl, events) {
+
+    override def visitTask(ctx: ASTVisitor.Context[Task]): Unit = {
+      if (ctx.element.output.isEmpty || ctx.element.output.get.declarations.isEmpty) {
+        addEvent(ctx.element)
+      }
+    }
+  }
+
+  val astRules: Map[String, LinterAstRuleApplySig] = Map(
+      "A001" -> NonPortableTaskRule.apply,
+      "A002" -> NoTaskInputsRule.apply,
+      "A003" -> NoTaskOutputsRule.apply
+  )
+
+  lazy val defaultRules: Map[String, Severity] =
+    (parserRules.keys.toVector ++ astRules.keys.toVector).map(_ -> Severity.Default).toMap
+}

--- a/src/main/scala/wdlTools/linter/Rules.scala
+++ b/src/main/scala/wdlTools/linter/Rules.scala
@@ -17,7 +17,7 @@ import scala.collection.mutable
 //  * winstanley: https://github.com/broadinstitute/winstanley
 object Rules {
   // Parser-level rules
-  // These are mostly to check things reated to whitespace, which is not
+  // These are mostly to check things related to whitespace, which is not
   // accessible from the AST
 
   // ideally we could provide the id as a class annotation, but dealing with annotations

--- a/src/main/scala/wdlTools/linter/package.scala
+++ b/src/main/scala/wdlTools/linter/package.scala
@@ -1,0 +1,28 @@
+package wdlTools.linter
+
+import java.net.URL
+
+import wdlTools.linter.Severity.Severity
+import wdlTools.syntax.TextSource
+
+object Severity extends Enumeration {
+  type Severity = Value
+  val Error, Warning, Ignore = Value
+  val Default: Severity = Error
+}
+
+case class LintEvent(ruleId: String,
+                     severity: Severity,
+                     textSource: TextSource,
+                     docSourceUrl: Option[URL] = None,
+                     message: Option[String] = None)
+    extends Ordered[LintEvent] {
+  override def compare(that: LintEvent): Int = {
+    val cmp = textSource.compare(that.textSource)
+    if (cmp != 0) {
+      cmp
+    } else {
+      ruleId.compareTo(that.ruleId)
+    }
+  }
+}

--- a/src/main/scala/wdlTools/syntax/ASTWalker.scala
+++ b/src/main/scala/wdlTools/syntax/ASTWalker.scala
@@ -1,0 +1,317 @@
+package wdlTools.syntax
+
+import wdlTools.syntax.ASTVisitor.Context
+import wdlTools.syntax.AbstractSyntax._
+import wdlTools.util.Options
+
+import scala.annotation.tailrec
+import scala.reflect.ClassTag
+
+class ASTVisitor {
+  def visitDocument(ctx: Context[Document]): Unit = {}
+
+  def visitIdentifier[P <: Element](identifier: String, parent: Context[P]): Unit = {}
+
+  def visitVersion(ctx: Context[Version]): Unit = {}
+
+  def visitImportName(ctx: Context[ImportName]): Unit = {}
+
+  def visitImportAlias(ctx: Context[ImportAlias]): Unit = {}
+
+  def visitImportDoc(ctx: Context[ImportDoc]): Unit = {}
+
+  def visitStruct(ctx: Context[TypeStruct]): Unit = {}
+
+  def visitDataType(ctx: Context[Type]): Unit = {}
+
+  def visitStructMember(ctx: Context[StructMember]): Unit = {}
+
+  def visitExpression(ctx: Context[Expr]): Unit = {}
+
+  def visitDeclaration(ctx: Context[Declaration]): Unit = {}
+
+  def visitInputSection(ctx: Context[InputSection]): Unit = {}
+
+  def visitOutputSection(ctx: Context[OutputSection]): Unit = {}
+
+  def visitCallAlias(ctx: Context[CallAlias]): Unit = {}
+
+  def visitCallInput(ctx: Context[CallInput]): Unit = {}
+
+  def visitCall(ctx: Context[Call]): Unit = {}
+
+  def visitScatter(ctx: Context[Scatter]): Unit = {}
+
+  def visitConditional(ctx: Context[Conditional]): Unit = {}
+
+  def visitBody[P <: Element](body: Vector[WorkflowElement], ctx: Context[P]): Unit = {}
+
+  def visitMetaKV(ctx: Context[MetaKV]): Unit = {}
+
+  def visitMetaSection(ctx: Context[MetaSection]): Unit = {}
+
+  def visitParameterMetaSection(ctx: Context[ParameterMetaSection]): Unit = {}
+
+  def visitWorkflow(ctx: Context[Workflow]): Unit = {}
+
+  def visitCommandSection(ctx: Context[CommandSection]): Unit = {}
+
+  def visitRuntimeKV(ctx: Context[RuntimeKV]): Unit = {}
+
+  def visitRuntimeSection(ctx: Context[RuntimeSection]): Unit = {}
+
+  def visitTask(ctx: Context[Task]): Unit = {}
+}
+
+object ASTVisitor {
+  class Context[T <: Element](val element: T, val parent: Option[Context[_]] = None) {
+    def getParent[P <: Element]: Context[P] = {
+      if (parent.isDefined) {
+        parent.get.asInstanceOf[Context[P]]
+      } else {
+        throw new Exception("Context does not have a parent")
+      }
+    }
+
+    def getParentExecutable: Option[Element] = {
+      @tailrec
+      def getExecutable(ctx: Context[_]): Option[Element] = {
+        ctx.element match {
+          case t: Task                   => Some(t)
+          case w: Workflow               => Some(w)
+          case _ if ctx.parent.isDefined => getExecutable(ctx.parent.get)
+          case _                         => None
+        }
+      }
+      getExecutable(this)
+    }
+
+    def findParent[P <: Element](implicit tag: ClassTag[P]): Option[Context[P]] = {
+      if (parent.isDefined) {
+        @tailrec
+        def find(ctx: Context[_]): Option[Context[P]] = {
+          ctx.element match {
+            case _: P                      => Some(ctx.asInstanceOf[Context[P]])
+            case _ if ctx.parent.isDefined => find(ctx.parent.get)
+            case _                         => None
+          }
+        }
+        find(this.parent.get)
+      } else {
+        None
+      }
+    }
+  }
+}
+
+class ASTWalker(opts: Options) extends ASTVisitor {
+  override def visitDocument(ctx: Context[Document]): Unit = {
+    visitVersion(createContext[Version, Document](ctx.element.version, ctx))
+
+    ctx.element.elements.collect { case imp: ImportDoc => imp }.foreach { imp =>
+      visitImportDoc(createContext[ImportDoc, Document](imp, ctx))
+    }
+
+    ctx.element.elements.collect { case struct: TypeStruct => struct }.foreach { imp =>
+      visitStruct(createContext[TypeStruct, Document](imp, ctx))
+    }
+
+    if (ctx.element.workflow.isDefined) {
+      visitWorkflow(createContext[Workflow, Document](ctx.element.workflow.get, ctx))
+    }
+
+    ctx.element.elements.collect { case task: Task => task }.foreach { task =>
+      visitTask(createContext[Task, Document](task, ctx))
+    }
+  }
+
+  override def visitImportName(ctx: Context[ImportName]): Unit = {
+    visitIdentifier[ImportName](ctx.element.value, ctx)
+  }
+
+  override def visitImportAlias(ctx: Context[ImportAlias]): Unit = {
+    visitIdentifier[ImportAlias](ctx.element.id1, ctx)
+    visitIdentifier[ImportAlias](ctx.element.id2, ctx)
+  }
+
+  override def visitImportDoc(ctx: Context[ImportDoc]): Unit = {
+    if (ctx.element.name.isDefined) {
+      visitImportName(createContext[ImportName, ImportDoc](ctx.element.name.get, ctx))
+    }
+    ctx.element.aliases.foreach { alias =>
+      visitImportAlias(createContext[ImportAlias, ImportDoc](alias, ctx))
+    }
+    if (opts.followImports) {
+      visitDocument(createContext[Document, ImportDoc](ctx.element.doc.get, ctx))
+    }
+  }
+
+  override def visitStruct(ctx: Context[TypeStruct]): Unit = {
+    ctx.element.members.foreach { member =>
+      visitStructMember(createContext[StructMember, TypeStruct](member, ctx))
+    }
+  }
+
+  override def visitStructMember(ctx: Context[StructMember]): Unit = {
+    visitDataType(createContext[Type, StructMember](ctx.element.dataType, ctx))
+    visitIdentifier[StructMember](ctx.element.name, ctx)
+  }
+
+  override def visitDeclaration(ctx: Context[Declaration]): Unit = {
+    visitDataType(createContext[Type, Declaration](ctx.element.wdlType, ctx))
+    visitIdentifier[Declaration](ctx.element.name, ctx)
+    if (ctx.element.expr.isDefined) {
+      visitExpression(createContext[Expr, Declaration](ctx.element.expr.get, ctx))
+    }
+  }
+
+  override def visitInputSection(ctx: Context[InputSection]): Unit = {
+    ctx.element.declarations.foreach { decl =>
+      visitDeclaration(createContext[Declaration, InputSection](decl, ctx))
+    }
+  }
+
+  override def visitOutputSection(ctx: Context[OutputSection]): Unit = {
+    ctx.element.declarations.foreach { decl =>
+      visitDeclaration(createContext[Declaration, OutputSection](decl, ctx))
+    }
+  }
+
+  override def visitCallAlias(ctx: Context[CallAlias]): Unit = {
+    visitIdentifier[CallAlias](ctx.element.name, ctx)
+  }
+
+  override def visitCallInput(ctx: Context[CallInput]): Unit = {
+    visitIdentifier[CallInput](ctx.element.name, ctx)
+    visitExpression(createContext[Expr, CallInput](ctx.element.expr, ctx))
+  }
+
+  override def visitCall(ctx: Context[Call]): Unit = {
+    visitIdentifier[Call](ctx.element.name, ctx)
+    if (ctx.element.alias.isDefined) {
+      visitCallAlias(createContext[CallAlias, Call](ctx.element.alias.get, ctx))
+    }
+    if (ctx.element.inputs.isDefined) {
+      ctx.element.inputs.get.value.foreach { inp =>
+        visitCallInput(createContext[CallInput, Call](inp, ctx))
+      }
+    }
+  }
+
+  override def visitScatter(ctx: Context[Scatter]): Unit = {
+    visitIdentifier[Scatter](ctx.element.identifier, ctx)
+    visitExpression(createContext[Expr, Scatter](ctx.element.expr, ctx))
+    visitBody[Scatter](ctx.element.body, ctx)
+  }
+
+  override def visitConditional(ctx: Context[Conditional]): Unit = {
+    visitExpression(createContext[Expr, Conditional](ctx.element.expr, ctx))
+    visitBody[Conditional](ctx.element.body, ctx)
+  }
+
+  override def visitBody[P <: Element](body: Vector[WorkflowElement], ctx: Context[P]): Unit = {
+    body.foreach {
+      case decl: Declaration => visitDeclaration(createContext[Declaration, P](decl, ctx))
+      case call: Call        => visitCall(createContext[Call, P](call, ctx))
+      case scatter: Scatter  => visitScatter(createContext[Scatter, P](scatter, ctx))
+      case conditional: Conditional =>
+        visitConditional(createContext[Conditional, P](conditional, ctx))
+      case other => throw new Exception(s"Unexpected workflow element ${other}")
+    }
+  }
+
+  override def visitMetaKV(ctx: Context[MetaKV]): Unit = {
+    visitIdentifier[MetaKV](ctx.element.id, ctx)
+    visitExpression(createContext[Expr, MetaKV](ctx.element.expr, ctx))
+  }
+
+  override def visitMetaSection(ctx: Context[MetaSection]): Unit = {
+    ctx.element.kvs.foreach { kv =>
+      visitMetaKV(createContext[MetaKV, MetaSection](kv, ctx))
+    }
+  }
+
+  override def visitParameterMetaSection(ctx: Context[ParameterMetaSection]): Unit = {
+    ctx.element.kvs.foreach { kv =>
+      visitMetaKV(createContext[MetaKV, ParameterMetaSection](kv, ctx))
+    }
+  }
+
+  override def visitWorkflow(ctx: Context[Workflow]): Unit = {
+    if (ctx.element.input.isDefined) {
+      visitInputSection(createContext[InputSection, Workflow](ctx.element.input.get, ctx))
+    }
+
+    visitBody[Workflow](ctx.element.body, ctx)
+
+    if (ctx.element.output.isDefined) {
+      visitOutputSection(createContext[OutputSection, Workflow](ctx.element.output.get, ctx))
+    }
+
+    if (ctx.element.meta.isDefined) {
+      visitMetaSection(createContext[MetaSection, Workflow](ctx.element.meta.get, ctx))
+    }
+
+    if (ctx.element.parameterMeta.isDefined) {
+      visitParameterMetaSection(
+          createContext[ParameterMetaSection, Workflow](ctx.element.parameterMeta.get, ctx)
+      )
+    }
+  }
+
+  override def visitCommandSection(ctx: Context[CommandSection]): Unit = {
+    ctx.element.parts.foreach { expr =>
+      visitExpression(createContext[Expr, CommandSection](expr, ctx))
+    }
+  }
+
+  override def visitRuntimeKV(ctx: Context[RuntimeKV]): Unit = {
+    visitIdentifier[RuntimeKV](ctx.element.id, ctx)
+    visitExpression(createContext[Expr, RuntimeKV](ctx.element.expr, ctx))
+  }
+
+  override def visitRuntimeSection(ctx: Context[RuntimeSection]): Unit = {
+    ctx.element.kvs.foreach { kv =>
+      visitRuntimeKV(createContext[RuntimeKV, RuntimeSection](kv, ctx))
+    }
+  }
+
+  override def visitTask(ctx: Context[Task]): Unit = {
+    if (ctx.element.input.isDefined) {
+      visitInputSection(createContext[InputSection, Task](ctx.element.input.get, ctx))
+    }
+
+    visitCommandSection(createContext[CommandSection, Task](ctx.element.command, ctx))
+
+    if (ctx.element.output.isDefined) {
+      visitOutputSection(createContext[OutputSection, Task](ctx.element.output.get, ctx))
+    }
+
+    if (ctx.element.runtime.isDefined) {
+      visitRuntimeSection(createContext[RuntimeSection, Task](ctx.element.runtime.get, ctx))
+    }
+
+    if (ctx.element.meta.isDefined) {
+      visitMetaSection(createContext[MetaSection, Task](ctx.element.meta.get, ctx))
+    }
+
+    if (ctx.element.parameterMeta.isDefined) {
+      visitParameterMetaSection(
+          createContext[ParameterMetaSection, Task](ctx.element.parameterMeta.get, ctx)
+      )
+    }
+  }
+
+  def apply(doc: Document): Unit = {
+    val ctx = createContext[Document](doc)
+    visitDocument(ctx)
+  }
+
+  def createContext[T <: Element](element: T): Context[T] = {
+    new Context[T](element)
+  }
+
+  def createContext[T <: Element, P <: Element](element: T, parent: Context[P]): Context[T] = {
+    new Context[T](element, Some(parent.asInstanceOf[Context[Element]]))
+  }
+}

--- a/src/main/scala/wdlTools/syntax/AbstractSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/AbstractSyntax.scala
@@ -191,7 +191,7 @@ object AbstractSyntax {
                       text: TextSource)
       extends Element
 
-  case class Document(docSourceUrl: URL,
+  case class Document(sourceUrl: URL,
                       version: Version,
                       elements: Vector[DocumentElement],
                       workflow: Option[Workflow],

--- a/src/main/scala/wdlTools/syntax/Antlr4Util.scala
+++ b/src/main/scala/wdlTools/syntax/Antlr4Util.scala
@@ -129,8 +129,10 @@ object Antlr4Util {
   private val defaultListenerFactories = Vector(CommentListenerFactory)
 
   class Grammar(
+      val version: WdlVersion,
       val lexer: Lexer,
       val parser: Parser,
+      val listenerFactories: Vector[ParseTreeListenerFactory],
       val docSourceUrl: Option[URL] = None,
       val opts: Options,
       val comments: mutable.Map[Int, Comment] = mutable.HashMap.empty
@@ -155,7 +157,7 @@ object Antlr4Util {
     val hiddenChannel: Int = getChannel("HIDDEN")
     val commentChannel: Int = getChannel("COMMENTS")
 
-    defaultListenerFactories.foreach(
+    (defaultListenerFactories ++ listenerFactories).foreach(
         _.createParseTreeListeners(this).map(parser.addParseListener)
     )
 
@@ -265,6 +267,7 @@ object Antlr4Util {
       val result = visitor(ctx)
       afterParse()
       result
+
     }
   }
 }

--- a/src/main/scala/wdlTools/syntax/Parsers.scala
+++ b/src/main/scala/wdlTools/syntax/Parsers.scala
@@ -4,15 +4,17 @@ import java.net.URL
 import java.nio.file.Path
 
 import wdlTools.syntax.AbstractSyntax.Document
+import wdlTools.syntax.Antlr4Util.ParseTreeListenerFactory
 import wdlTools.util.{Options, SourceCode, Util}
 
 import scala.collection.mutable
 
-case class Parsers(opts: Options = Options()) {
+case class Parsers(opts: Options = Options(),
+                   listenerFactories: Vector[ParseTreeListenerFactory] = Vector.empty) {
   private lazy val parsers: Map[WdlVersion, WdlParser] = Map(
-      WdlVersion.Draft_2 -> draft_2.ParseAll(opts),
-      WdlVersion.V1 -> v1.ParseAll(opts),
-      WdlVersion.V2 -> v2.ParseAll(opts)
+      WdlVersion.Draft_2 -> draft_2.ParseAll(opts, listenerFactories),
+      WdlVersion.V1 -> v1.ParseAll(opts, listenerFactories),
+      WdlVersion.V2 -> v2.ParseAll(opts, listenerFactories)
   )
 
   def getParser(url: URL): WdlParser = {
@@ -47,10 +49,11 @@ case class Parsers(opts: Options = Options()) {
 
   def getDocumentWalker[T](
       url: URL,
-      results: mutable.Map[URL, T] = mutable.HashMap.empty[URL, T]
+      results: mutable.Map[URL, T] = mutable.HashMap.empty[URL, T],
+      mayRevisit: Boolean = false
   ): DocumentWalker[T] = {
     val sourceCode = SourceCode.loadFrom(url)
     val parser = getParser(sourceCode)
-    parser.Walker(sourceCode, results)
+    parser.Walker(sourceCode, results, mayRevisit)
   }
 }

--- a/src/main/scala/wdlTools/syntax/Parsers.scala
+++ b/src/main/scala/wdlTools/syntax/Parsers.scala
@@ -49,11 +49,10 @@ case class Parsers(opts: Options = Options(),
 
   def getDocumentWalker[T](
       url: URL,
-      results: mutable.Map[URL, T] = mutable.HashMap.empty[URL, T],
-      mayRevisit: Boolean = false
+      results: mutable.Map[URL, T] = mutable.HashMap.empty[URL, T]
   ): DocumentWalker[T] = {
     val sourceCode = SourceCode.loadFrom(url)
     val parser = getParser(sourceCode)
-    parser.Walker(sourceCode, results, mayRevisit)
+    parser.Walker(sourceCode, results)
   }
 }

--- a/src/main/scala/wdlTools/syntax/WdlParser.scala
+++ b/src/main/scala/wdlTools/syntax/WdlParser.scala
@@ -37,7 +37,7 @@ abstract class WdlParser(opts: Options) {
 
   def parseType(text: String): Type
 
-  def getDocSourceUrl(addr: String): URL = {
+  protected def getDocSourceUrl(addr: String): URL = {
     Util.getUrl(addr, opts.localDirectories)
   }
 
@@ -49,8 +49,7 @@ abstract class WdlParser(opts: Options) {
   }
 
   case class Walker[T](sourceCode: SourceCode,
-                       results: mutable.Map[URL, T] = mutable.HashMap.empty[URL, T],
-                       mayRevisit: Boolean = false)
+                       results: mutable.Map[URL, T] = mutable.HashMap.empty[URL, T])
       extends DocumentWalker[T] {
     def extractDependencies(document: Document): Map[URL, Document] = {
       document.elements.flatMap {
@@ -61,8 +60,11 @@ abstract class WdlParser(opts: Options) {
     }
 
     def walk(visitor: (URL, Document, mutable.Map[URL, T]) => Unit): Map[URL, T] = {
+      val visited: mutable.Set[URL] = mutable.HashSet.empty
+
       def addDocument(url: URL, doc: Document): Unit = {
-        if (mayRevisit || !results.contains(url)) {
+        if (!visited.contains(url)) {
+          visited.add(url)
           visitor(url, doc, results)
           if (opts.followImports) {
             extractDependencies(doc).foreach {

--- a/src/main/scala/wdlTools/syntax/WdlParser.scala
+++ b/src/main/scala/wdlTools/syntax/WdlParser.scala
@@ -49,7 +49,8 @@ abstract class WdlParser(opts: Options) {
   }
 
   case class Walker[T](sourceCode: SourceCode,
-                       results: mutable.Map[URL, T] = mutable.HashMap.empty[URL, T])
+                       results: mutable.Map[URL, T] = mutable.HashMap.empty[URL, T],
+                       mayRevisit: Boolean = false)
       extends DocumentWalker[T] {
     def extractDependencies(document: Document): Map[URL, Document] = {
       document.elements.flatMap {
@@ -61,7 +62,7 @@ abstract class WdlParser(opts: Options) {
 
     def walk(visitor: (URL, Document, mutable.Map[URL, T]) => Unit): Map[URL, T] = {
       def addDocument(url: URL, doc: Document): Unit = {
-        if (!results.contains(url)) {
+        if (mayRevisit || !results.contains(url)) {
           visitor(url, doc, results)
           if (opts.followImports) {
             extractDependencies(doc).foreach {

--- a/src/main/scala/wdlTools/syntax/draft_2/WdlDraft2Grammar.scala
+++ b/src/main/scala/wdlTools/syntax/draft_2/WdlDraft2Grammar.scala
@@ -5,21 +5,26 @@ import java.nio.ByteBuffer
 
 import org.antlr.v4.runtime.{CodePointBuffer, CodePointCharStream, CommonTokenStream}
 import org.openwdl.wdl.parser.draft_2.{WdlDraft2Lexer, WdlDraft2Parser}
-import wdlTools.syntax.Antlr4Util.Grammar
+import wdlTools.syntax.Antlr4Util.{Grammar, ParseTreeListenerFactory}
+import wdlTools.syntax.WdlVersion
 import wdlTools.util.{Options, SourceCode}
 
 case class WdlDraft2Grammar(override val lexer: WdlDraft2Lexer,
                             override val parser: WdlDraft2Parser,
+                            override val listenerFactories: Vector[ParseTreeListenerFactory],
                             override val docSourceUrl: Option[URL] = None,
                             override val opts: Options)
-    extends Grammar(lexer, parser, docSourceUrl, opts)
+    extends Grammar(WdlVersion.Draft_2, lexer, parser, listenerFactories, docSourceUrl, opts)
 
 object WdlDraft2Grammar {
-  def newInstance(sourceCode: SourceCode, opts: Options): WdlDraft2Grammar = {
-    newInstance(sourceCode.toString, Some(sourceCode.url), opts)
+  def newInstance(sourceCode: SourceCode,
+                  listenerFactories: Vector[ParseTreeListenerFactory],
+                  opts: Options): WdlDraft2Grammar = {
+    newInstance(sourceCode.toString, listenerFactories, Some(sourceCode.url), opts)
   }
 
   def newInstance(text: String,
+                  listenerFactories: Vector[ParseTreeListenerFactory],
                   docSourceUrl: Option[URL] = None,
                   opts: Options): WdlDraft2Grammar = {
     val codePointBuffer: CodePointBuffer =
@@ -27,6 +32,6 @@ object WdlDraft2Grammar {
     val charStream = CodePointCharStream.fromBuffer(codePointBuffer)
     val lexer = new WdlDraft2Lexer(charStream)
     val parser = new WdlDraft2Parser(new CommonTokenStream(lexer))
-    new WdlDraft2Grammar(lexer, parser, docSourceUrl, opts)
+    new WdlDraft2Grammar(lexer, parser, listenerFactories, docSourceUrl, opts)
   }
 }

--- a/src/main/scala/wdlTools/syntax/v1/WdlV1Grammar.scala
+++ b/src/main/scala/wdlTools/syntax/v1/WdlV1Grammar.scala
@@ -5,26 +5,33 @@ import java.nio.ByteBuffer
 
 import org.antlr.v4.runtime.{CodePointBuffer, CodePointCharStream, CommonTokenStream}
 import org.openwdl.wdl.parser.v1.{WdlV1Lexer, WdlV1Parser}
-import wdlTools.syntax.Antlr4Util.Grammar
+import wdlTools.syntax.Antlr4Util.{Grammar, ParseTreeListenerFactory}
+import wdlTools.syntax.WdlVersion
 import wdlTools.util.{Options, SourceCode}
 
 case class WdlV1Grammar(override val lexer: WdlV1Lexer,
                         override val parser: WdlV1Parser,
+                        override val listenerFactories: Vector[ParseTreeListenerFactory],
                         override val docSourceUrl: Option[URL] = None,
                         override val opts: Options)
-    extends Grammar(lexer, parser, docSourceUrl, opts)
+    extends Grammar(WdlVersion.V1, lexer, parser, listenerFactories, docSourceUrl, opts)
 
 object WdlV1Grammar {
-  def newInstance(sourceCode: SourceCode, opts: Options): WdlV1Grammar = {
-    newInstance(sourceCode.toString, Some(sourceCode.url), opts)
+  def newInstance(sourceCode: SourceCode,
+                  listenerFactories: Vector[ParseTreeListenerFactory],
+                  opts: Options): WdlV1Grammar = {
+    newInstance(sourceCode.toString, listenerFactories, Some(sourceCode.url), opts)
   }
 
-  def newInstance(text: String, docSourceUrl: Option[URL] = None, opts: Options): WdlV1Grammar = {
+  def newInstance(text: String,
+                  listenerFactories: Vector[ParseTreeListenerFactory],
+                  docSourceUrl: Option[URL] = None,
+                  opts: Options): WdlV1Grammar = {
     val codePointBuffer: CodePointBuffer =
       CodePointBuffer.withBytes(ByteBuffer.wrap(text.getBytes()))
     val charStream = CodePointCharStream.fromBuffer(codePointBuffer)
     val lexer = new WdlV1Lexer(charStream)
     val parser = new WdlV1Parser(new CommonTokenStream(lexer))
-    new WdlV1Grammar(lexer, parser, docSourceUrl, opts)
+    new WdlV1Grammar(lexer, parser, listenerFactories, docSourceUrl, opts)
   }
 }

--- a/src/main/scala/wdlTools/syntax/v2/WdlV2Grammar.scala
+++ b/src/main/scala/wdlTools/syntax/v2/WdlV2Grammar.scala
@@ -5,26 +5,33 @@ import java.nio.ByteBuffer
 
 import org.antlr.v4.runtime.{CodePointBuffer, CodePointCharStream, CommonTokenStream}
 import org.openwdl.wdl.parser.v2.{WdlV2Lexer, WdlV2Parser}
-import wdlTools.syntax.Antlr4Util.Grammar
+import wdlTools.syntax.Antlr4Util.{Grammar, ParseTreeListenerFactory}
+import wdlTools.syntax.WdlVersion
 import wdlTools.util.{Options, SourceCode}
 
 case class WdlV2Grammar(override val lexer: WdlV2Lexer,
                         override val parser: WdlV2Parser,
+                        override val listenerFactories: Vector[ParseTreeListenerFactory],
                         override val docSourceUrl: Option[URL] = None,
                         override val opts: Options)
-    extends Grammar(lexer, parser, docSourceUrl, opts)
+    extends Grammar(WdlVersion.V2, lexer, parser, listenerFactories, docSourceUrl, opts)
 
 object WdlV2Grammar {
-  def newInstance(sourceCode: SourceCode, opts: Options): WdlV2Grammar = {
-    newInstance(sourceCode.toString, Some(sourceCode.url), opts)
+  def newInstance(sourceCode: SourceCode,
+                  listenerFactories: Vector[ParseTreeListenerFactory],
+                  opts: Options): WdlV2Grammar = {
+    newInstance(sourceCode.toString, listenerFactories, Some(sourceCode.url), opts)
   }
 
-  def newInstance(text: String, docSourceUrl: Option[URL] = None, opts: Options): WdlV2Grammar = {
+  def newInstance(text: String,
+                  listenerFactories: Vector[ParseTreeListenerFactory],
+                  docSourceUrl: Option[URL] = None,
+                  opts: Options): WdlV2Grammar = {
     val codePointBuffer: CodePointBuffer =
       CodePointBuffer.withBytes(ByteBuffer.wrap(text.getBytes()))
     val charStream = CodePointCharStream.fromBuffer(codePointBuffer)
     val lexer = new WdlV2Lexer(charStream)
     val parser = new WdlV2Parser(new CommonTokenStream(lexer))
-    new WdlV2Grammar(lexer, parser, docSourceUrl, opts)
+    new WdlV2Grammar(lexer, parser, listenerFactories, docSourceUrl, opts)
   }
 }

--- a/src/main/scala/wdlTools/types/TypeChecker.scala
+++ b/src/main/scala/wdlTools/types/TypeChecker.scala
@@ -847,7 +847,7 @@ case class TypeChecker(stdlib: Stdlib) {
   // describing the problem in a human readable fashion.
   def apply(doc: Document, ctxOuter: Option[Context] = None): Context = {
     val context: Context =
-      doc.elements.foldLeft(ctxOuter.getOrElse(Context(Some(doc.docSourceUrl)))) {
+      doc.elements.foldLeft(ctxOuter.getOrElse(Context(Some(doc.sourceUrl)))) {
         case (accu: Context, task: Task) =>
           val tt = applyTask(task, accu)
           accu.bindCallable(tt, task.text)

--- a/src/main/scala/wdlTools/util/InteractiveConsole.scala
+++ b/src/main/scala/wdlTools/util/InteractiveConsole.scala
@@ -84,23 +84,27 @@ case class InteractiveConsole(promptColor: String = "",
                     default: Option[T] = None): Option[T] = {
     def promptOnce: Option[T] = {
       Console.print(prompt)
-      try {
-        reader.read match {
-          case v: Some[T]               => v
-          case None if default.nonEmpty => default
-          case _                        => None
-        }
-      } catch {
-        case e: InputException =>
-          error(s"You entered an invalid value: ${e.getMessage}; please try again")
-          None
+      reader.read match {
+        case v: Some[T]               => v
+        case None if default.nonEmpty => default
+        case _                        => None
       }
     }
-
-    var result = promptOnce
+    def promptWhileError: Option[T] = {
+      while (true) {
+        try {
+          return promptOnce
+        } catch {
+          case e: InputException =>
+            error(s"You entered an invalid value: ${e.getMessage}; please try again")
+        }
+      }
+      throw new Exception()
+    }
+    var result = promptWhileError
     while (result.isEmpty && !optional) {
       error("A non-empty value is required; please try again")
-      result = promptOnce
+      result = promptWhileError
     }
     if (afterEntry.isDefined) {
       Console.print(afterEntry.get)

--- a/src/main/scala/wdlTools/util/Util.scala
+++ b/src/main/scala/wdlTools/util/Util.scala
@@ -166,7 +166,8 @@ object Util {
     * @param indentSize Number of spaces for each indent.
     * @param maxElementWidth Largest element size before wrapping.
     * @param depth Initial depth to pretty print indents.
-    * @return
+    * @return the formatted object as a String
+    * TODO: add color
     */
   def prettyFormat(a: Any,
                    indentSize: Int = 2,

--- a/src/test/resources/lint/v1/simple.wdl
+++ b/src/test/resources/lint/v1/simple.wdl
@@ -1,0 +1,15 @@
+version	 1.0  # use of tab
+
+  task foo{  # indented top-level
+  input {
+  String i
+  }
+
+
+           # multiple blank lines
+   command {  # three spaces for indent
+   ${i}  # deprecated command syntax
+  }
+  # no output section
+  # no runtime section
+}

--- a/src/test/scala/wdlTools/linter/v1/BaseTest.scala
+++ b/src/test/scala/wdlTools/linter/v1/BaseTest.scala
@@ -1,0 +1,56 @@
+package wdlTools.linter.v1
+
+import java.net.URL
+import java.nio.file.{Path, Paths}
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import wdlTools.linter.{LintEvent, Linter, Severity}
+import wdlTools.syntax.TextSource
+import wdlTools.util.{Options, Util}
+
+class BaseTest extends AnyFlatSpec with Matchers {
+  private val opts = Options()
+
+  def getWdlPath(fname: String, subdir: String): Path = {
+    Paths.get(getClass.getResource(s"/lint/${subdir}/${fname}").getPath)
+  }
+
+  private def getWdlUrl(fname: String, subdir: String): URL = {
+    Util.pathToUrl(getWdlPath(fname, subdir))
+  }
+
+  it should "detect lints" in {
+    val linter = Linter(opts)
+    val url = getWdlUrl("simple.wdl", "v1")
+    linter.apply(url)
+
+    val lints = linter.getOrderedEvents(url)
+    lints.size shouldBe 8
+
+    lints(0) should matchPattern {
+      case LintEvent("P001", Severity.Error, TextSource(1, 7, 1, 9), Some(url), _) =>
+    }
+    lints(1) should matchPattern {
+      case LintEvent("P004", Severity.Error, TextSource(1, 26, 3, 3), Some(url), _) =>
+    }
+    lints(2) should matchPattern {
+      case LintEvent("A001", Severity.Error, TextSource(3, 2, 15, 1), Some(url), _) =>
+    }
+    lints(3) should matchPattern {
+      case LintEvent("A003", Severity.Error, TextSource(3, 2, 15, 1), Some(url), _) =>
+    }
+    lints(4) should matchPattern {
+      case LintEvent("P002", Severity.Error, TextSource(6, 3, 9, 12), Some(url), _) =>
+    }
+    lints(5) should matchPattern {
+      case LintEvent("P003", Severity.Error, TextSource(6, 3, 9, 12), Some(url), _) =>
+    }
+    lints(6) should matchPattern {
+      case LintEvent("P002", Severity.Error, TextSource(9, 33, 10, 4), Some(url), _) =>
+    }
+    lints(7) should matchPattern {
+      case LintEvent("P005", Severity.Error, TextSource(11, 3, 11, 7), Some(url), _) =>
+    }
+  }
+}

--- a/src/test/scala/wdlTools/syntax/draft_2/ConcreteSyntaxDraft2Test.scala
+++ b/src/test/scala/wdlTools/syntax/draft_2/ConcreteSyntaxDraft2Test.scala
@@ -29,7 +29,7 @@ class ConcreteSyntaxDraft2Test extends AnyFlatSpec with Matchers {
   }
 
   private def getDocument(sourceCode: SourceCode, conf: Options = opts): Document = {
-    ParseTop(conf, WdlDraft2Grammar.newInstance(sourceCode, opts)).parseDocument
+    ParseTop(conf, WdlDraft2Grammar.newInstance(sourceCode, Vector.empty, opts)).parseDocument
   }
 
   it should "handle various types" in {

--- a/src/test/scala/wdlTools/syntax/v1/ConcreteSyntaxV1Test.scala
+++ b/src/test/scala/wdlTools/syntax/v1/ConcreteSyntaxV1Test.scala
@@ -34,7 +34,7 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
   }
 
   private def getDocument(sourceCode: SourceCode, conf: Options = opts): Document = {
-    ParseTop(conf, WdlV1Grammar.newInstance(sourceCode, opts)).parseDocument
+    ParseTop(conf, WdlV1Grammar.newInstance(sourceCode, Vector.empty, opts)).parseDocument
   }
 
   it should "handle various types" in {


### PR DESCRIPTION
This PR adds the Linter and the Lint command. There are two different types of linter rules: parser-level and AST-level. Parser-level rules are implemented as listeners on the Antlr4 parser, and are mostly concerned with whitespace issues. AST rules are implemented as a `wdlTools.syntax.ASTVisitor` and operate on the AST (and eventually on the type-inferred AST) and can test more complex things. A rule has an ID that is tied to its description and default severity in resource/rules/lint_rules.json. The user can enable/disable rules as well as modify the severity of a lint via the command line or in a config file. The linter can print output to stdout or a file in either plain-text or JSON format.