### PR TITLE
Handle WDL versions inside the types module

### DIFF
--- a/src/main/scala/wdlTools/cli/TypeCheck.scala
+++ b/src/main/scala/wdlTools/cli/TypeCheck.scala
@@ -1,7 +1,7 @@
 package wdlTools.cli
 
 import wdlTools.syntax.Parsers
-import wdlTools.types.{Context, Stdlib, TypeInfer}
+import wdlTools.types.{Context, TypeInfer}
 
 // TODO: nicely format errors, including JSON output
 case class TypeCheck(conf: WdlToolsConf) extends Command {
@@ -10,7 +10,7 @@ case class TypeCheck(conf: WdlToolsConf) extends Command {
     val opts = conf.check.getOptions
     require(opts.followImports)
     val parsers = Parsers(opts)
-    val checker = TypeInfer(Stdlib(opts))
+    val checker = TypeInfer(opts)
 
     parsers.getDocumentWalker[Context](url).walk { (_, doc, _) =>
       // TODO: rather than throw an exception as soon as a type error is encountered, accumulate all errors

--- a/src/main/scala/wdlTools/linter/Linter.scala
+++ b/src/main/scala/wdlTools/linter/Linter.scala
@@ -6,7 +6,7 @@ import org.antlr.v4.runtime.tree.ParseTreeListener
 import wdlTools.linter.Severity.Severity
 import wdlTools.syntax.Antlr4Util.ParseTreeListenerFactory
 import wdlTools.syntax.{Antlr4Util, Parsers}
-import wdlTools.types.{Stdlib, TypeInfer}
+import wdlTools.types.TypeInfer
 import wdlTools.util.Options
 
 import scala.collection.mutable
@@ -47,8 +47,7 @@ case class Linter(opts: Options,
           events(url) = docEvents
         }
         // First run the TypeChecker to infer the types of all expressions
-        val stdlib = Stdlib(opts)
-        val typeChecker = TypeInfer(stdlib)
+        val typeChecker = TypeInfer(opts)
         val (_, typesContext) = typeChecker.apply(doc)
         // Now execute the linter rules
         val visitors = astRules.map {
@@ -58,7 +57,6 @@ case class Linter(opts: Options,
                 severity,
                 doc.version.value,
                 typesContext,
-                stdlib,
                 events(url),
                 Some(url)
             )

--- a/src/main/scala/wdlTools/linter/Rules.scala
+++ b/src/main/scala/wdlTools/linter/Rules.scala
@@ -212,7 +212,6 @@ object Rules {
       Severity,
       WdlVersion,
       types.Context,
-      types.Stdlib,
       mutable.Buffer[LintEvent],
       Option[URL]
   ) => LinterAstRule
@@ -323,7 +322,6 @@ object Rules {
                                  severity: Severity,
                                  version: WdlVersion,
                                  typesContext: types.Context,
-                                 stdlib: types.Stdlib,
                                  events: mutable.Buffer[LintEvent],
                                  docSourceUrl: Option[URL])
       extends LinterAstRule(id, severity, docSourceUrl, events) {
@@ -342,7 +340,6 @@ object Rules {
                               severity: Severity,
                               version: WdlVersion,
                               typesContext: types.Context,
-                              stdlib: types.Stdlib,
                               events: mutable.Buffer[LintEvent],
                               docSourceUrl: Option[URL])
       extends LinterAstRule(id, severity, docSourceUrl, events) {
@@ -357,7 +354,6 @@ object Rules {
                                severity: Severity,
                                version: WdlVersion,
                                typesContext: types.Context,
-                               stdlib: types.Stdlib,
                                events: mutable.Buffer[LintEvent],
                                docSourceUrl: Option[URL])
       extends LinterAstRule(id, severity, docSourceUrl, events) {

--- a/src/main/scala/wdlTools/types/Context.scala
+++ b/src/main/scala/wdlTools/types/Context.scala
@@ -1,7 +1,7 @@
 package wdlTools.types
 
 import java.net.URL
-import wdlTools.syntax.{AbstractSyntax => AST}
+import wdlTools.syntax.{AbstractSyntax => AST, WdlVersion}
 import wdlTools.syntax.TextSource
 import wdlTools.types.WdlTypes._
 import wdlTools.types.{TypedAbstractSyntax => TAT}
@@ -10,7 +10,9 @@ import wdlTools.types.{TypedAbstractSyntax => TAT}
 //
 // There are separate namespaces for variables, struct definitions, and callables (tasks/workflows).
 // An additional variable holds a list of all imported namespaces.
-case class Context(docSourceUrl: Option[URL] = None,
+case class Context(version: WdlVersion,
+                   stdlib: Stdlib,
+                   docSourceUrl: Option[URL] = None,
                    inputs: Map[String, WdlTypes.T] = Map.empty,
                    declarations: Map[String, WdlTypes.T] = Map.empty,
                    structs: Map[String, T_Struct] = Map.empty,

--- a/src/main/scala/wdlTools/types/Stdlib.scala
+++ b/src/main/scala/wdlTools/types/Stdlib.scala
@@ -5,12 +5,67 @@ import java.net.URL
 import WdlTypes._
 import wdlTools.util.Options
 //import wdlTools.util.Verbosity._
-import wdlTools.syntax.TextSource
+import wdlTools.syntax.{TextSource, WdlVersion}
 
-case class Stdlib(conf: Options) {
+case class Stdlib(conf: Options, version: WdlVersion) {
   private val unify = Unification(conf)
 
-  private val stdlibV1_0: Vector[T_StdlibFunc] = Vector(
+  private val draft2Prototypes: Vector[T_StdlibFunc] = Vector(
+      T_Function0("stdout", T_File),
+      T_Function0("stderr", T_File),
+      T_Function1("read_lines", T_File, T_Array(T_String)),
+      T_Function1("read_tsv", T_File, T_Array(T_Array(T_String))),
+      T_Function1("read_map", T_File, T_Map(T_String, T_String)),
+      T_Function1("read_object", T_File, T_Object),
+      T_Function1("read_objects", T_File, T_Array(T_Object)),
+      T_Function1("read_json", T_File, T_Any),
+      T_Function1("read_int", T_File, T_Int),
+      T_Function1("read_string", T_File, T_String),
+      T_Function1("read_float", T_File, T_Float),
+      T_Function1("read_boolean", T_File, T_Boolean),
+      T_Function1("write_lines", T_Array(T_String), T_File),
+      T_Function1("write_tsv", T_Array(T_Array(T_String)), T_File),
+      T_Function1("write_map", T_Map(T_String, T_String), T_File),
+      T_Function1("write_object", T_Object, T_File),
+      T_Function1("write_objects", T_Array(T_Object), T_File),
+      T_Function1("write_json", T_Any, T_File),
+      // Size can take several kinds of arguments.
+      T_Function1("size", T_File, T_Float),
+      T_Function1("size", T_Optional(T_File), T_Float),
+      // Size takes an optional units parameter (KB, KiB, MB, GiB, ...)
+      T_Function2("size", T_File, T_String, T_Float),
+      T_Function2("size", T_Optional(T_File), T_String, T_Float),
+      T_Function3("sub", T_String, T_String, T_String, T_String),
+      T_Function1("range", T_Int, T_Array(T_Int)),
+      // Array[Array[X]] transpose(Array[Array[X]])
+      T_Function1("transpose", T_Array(T_Array(T_Var(0))), T_Array(T_Array(T_Var(0)))),
+      // Array[Pair(X,Y)] zip(Array[X], Array[Y])
+      T_Function2("zip", T_Array(T_Var(0)), T_Array(T_Var(1)), T_Array(T_Pair(T_Var(0), T_Var(1)))),
+      // Array[Pair(X,Y)] cross(Array[X], Array[Y])
+      T_Function2("cross",
+                  T_Array(T_Var(0)),
+                  T_Array(T_Var(1)),
+                  T_Array(T_Pair(T_Var(0), T_Var(1)))),
+      // Integer length(Array[X])
+      T_Function1("length", T_Array(T_Var(0)), T_Int),
+      // Array[X] flatten(Array[Array[X]])
+      T_Function1("flatten", T_Array(T_Array(T_Var(0))), T_Array(T_Var(0))),
+      T_Function2("prefix", T_String, T_Array(T_Var(0)), T_Array(T_String)),
+      T_Function1("select_first", T_Array(T_Optional(T_Var(0))), T_Var(0)),
+      T_Function1("select_all", T_Array(T_Optional(T_Var(0))), T_Array(T_Var(0))),
+      T_Function1("defined", T_Optional(T_Var(0)), T_Boolean),
+      // simple functions again
+      // basename has two variants
+      T_Function1("basename", T_String, T_String),
+      T_Function1("floor", T_Float, T_Int),
+      T_Function1("ceil", T_Float, T_Int),
+      T_Function1("round", T_Float, T_Int),
+      // not mentioned in the specification
+      T_Function1("glob", T_String, T_Array(T_File))
+  )
+
+  // Add the signatures for draft2 and v2 here
+  private val v1Prototypes: Vector[T_StdlibFunc] = Vector(
       T_Function0("stdout", T_File),
       T_Function0("stderr", T_File),
       T_Function1("read_lines", T_File, T_Array(T_String)),
@@ -69,10 +124,17 @@ case class Stdlib(conf: Options) {
       T_Function1("glob", T_String, T_Array(T_File))
   )
 
+  // choose the standard library prototypes according to the WDL version
+  private val protoTable: Vector[T_StdlibFunc] = version match {
+    case WdlVersion.Draft_2 => draft2Prototypes
+    case WdlVersion.V1      => v1Prototypes
+    case WdlVersion.V2      => throw new Exception("Wdl version 2 not implemented yet")
+  }
+
   // build a mapping from a function name to all of its prototypes.
   // Some functions are overloaded, so they may have several.
   private val funcProtoMap: Map[String, Vector[T_StdlibFunc]] = {
-    stdlibV1_0.foldLeft(Map.empty[String, Vector[T_StdlibFunc]]) {
+    protoTable.foldLeft(Map.empty[String, Vector[T_StdlibFunc]]) {
       case (accu, funcDesc: T_StdlibFunc) =>
         accu.get(funcDesc.name) match {
           case None =>

--- a/src/test/scala/wdlTools/eval/EvalTest.scala
+++ b/src/test/scala/wdlTools/eval/EvalTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 import wdlTools.eval.WdlValues._
 import wdlTools.syntax.v1.ParseAll
 import wdlTools.util.{EvalConfig, Options, Util => UUtil, TypeCheckingRegime, Verbosity}
-import wdlTools.types.{Stdlib => TypeStdlib, TypeInfer, TypedAbstractSyntax => TAT}
+import wdlTools.types.{TypeInfer, TypedAbstractSyntax => TAT}
 
 class EvalTest extends AnyFlatSpec with Matchers with Inside {
   private val srcDir = Paths.get(getClass.getResource("/wdlTools/eval/v1").getPath)
@@ -19,8 +19,7 @@ class EvalTest extends AnyFlatSpec with Matchers with Inside {
             localDirectories = Vector(srcDir),
             verbosity = Verbosity.Normal)
   private val parser = ParseAll(opts)
-  private val stdlib = TypeStdlib(opts)
-  private val typeInfer = TypeInfer(stdlib)
+  private val typeInfer = TypeInfer(opts)
 
   def safeMkdir(path: Path): Unit = {
     if (!Files.exists(path)) {

--- a/src/test/scala/wdlTools/types/TypeInferTest.scala
+++ b/src/test/scala/wdlTools/types/TypeInferTest.scala
@@ -79,8 +79,7 @@ class TypeInferTest extends AnyFlatSpec with Matchers {
       case None    => opts
       case Some(x) => opts.copy(typeChecking = x)
     }
-    val stdlib = Stdlib(opts2)
-    val checker = TypeInfer(stdlib)
+    val checker = TypeInfer(opts2)
     try {
       val doc = parser.parseDocument(UUtil.pathToUrl(file))
       checker.apply(doc)
@@ -96,8 +95,7 @@ class TypeInferTest extends AnyFlatSpec with Matchers {
       case None    => opts
       case Some(x) => opts.copy(typeChecking = x)
     }
-    val stdlib = Stdlib(opts2)
-    val checker = TypeInfer(stdlib)
+    val checker = TypeInfer(opts2)
     val checkVal =
       try {
         val doc = parser.parseDocument(UUtil.pathToUrl(file))
@@ -162,8 +160,7 @@ class TypeInferTest extends AnyFlatSpec with Matchers {
 
   it should "be able to handle GATK" in {
     val opts2 = opts.copy(typeChecking = TypeCheckingRegime.Lenient)
-    val stdlib = Stdlib(opts2)
-    val checker = TypeInfer(stdlib)
+    val checker = TypeInfer(opts2)
 
     val sources = Vector(
         "https://raw.githubusercontent.com/gatk-workflows/gatk4-germline-snps-indels/master/JointGenotyping-terra.wdl",


### PR DESCRIPTION
The types Stdlib module handles handles variations in the standard library between WDL versions. Make it internal to type checking, so it isn't visible to the outside. This simplifies setting up and running the type-checker. 