### PR TITLE
Additions to Type Syntax Tree and type inference

### DIFF
--- a/src/main/scala/wdlTools/types/Context.scala
+++ b/src/main/scala/wdlTools/types/Context.scala
@@ -14,6 +14,7 @@ case class Context(version: WdlVersion,
                    stdlib: Stdlib,
                    docSourceUrl: Option[URL] = None,
                    inputs: Map[String, WdlTypes.T] = Map.empty,
+                   outputs: Map[String, WdlTypes.T] = Map.empty,
                    declarations: Map[String, WdlTypes.T] = Map.empty,
                    structs: Map[String, T_Struct] = Map.empty,
                    callables: Map[String, T_Callable] = Map.empty,
@@ -22,12 +23,16 @@ case class Context(version: WdlVersion,
 
   def lookup(varName: String,
              bindings: Map[String, WdlType],
-             srcText: TextSource): Option[WdlType] = {
+             textSource: TextSource): Option[WdlType] = {
     inputs.get(varName) match {
       case None    => ()
       case Some(t) => return Some(t)
     }
     declarations.get(varName) match {
+      case None    => ()
+      case Some(t) => return Some(t)
+    }
+    outputs.get(varName) match {
       case None    => ()
       case Some(t) => return Some(t)
     }
@@ -46,48 +51,56 @@ case class Context(version: WdlVersion,
     this.copy(inputs = bindings)
   }
 
-  def bindVar(varName: String, wdlType: WdlType, srcText: TextSource): Context = {
+  def bindOutputSection(oututSection: TAT.OutputSection): Context = {
+    // building bindings
+    val bindings = oututSection.declarations.map { tDecl =>
+      tDecl.name -> tDecl.wdlType
+    }.toMap
+    this.copy(outputs = bindings)
+  }
+
+  def bindVar(varName: String, wdlType: WdlType, textSource: TextSource): Context = {
     declarations.get(varName) match {
       case None =>
         this.copy(declarations = declarations + (varName -> wdlType))
       case Some(_) =>
         throw new TypeException(s"variable ${varName} shadows an existing variable",
-                                srcText,
+                                textSource,
                                 docSourceUrl)
     }
   }
 
-  def bindStruct(s: T_Struct, srcText: TextSource): Context = {
+  def bindStruct(s: T_Struct, textSource: TextSource): Context = {
     structs.get(s.name) match {
       case None =>
         this.copy(structs = structs + (s.name -> s))
       case Some(existingStruct: T_Struct) =>
         if (s != existingStruct)
-          throw new TypeException(s"struct ${s.name} is already declared", srcText, docSourceUrl)
+          throw new TypeException(s"struct ${s.name} is already declared", textSource, docSourceUrl)
         // The struct is defined a second time, with the exact same definition. Ignore.
         this
     }
   }
 
   // add a callable (task/workflow)
-  def bindCallable(callable: T_Callable, srcText: TextSource): Context = {
+  def bindCallable(callable: T_Callable, textSource: TextSource): Context = {
     callables.get(callable.name) match {
       case None =>
         this.copy(callables = callables + (callable.name -> callable))
       case Some(_) =>
         throw new TypeException(s"a callable named ${callable.name} is already declared",
-                                srcText,
+                                textSource,
                                 docSourceUrl)
     }
   }
 
   // add a bunch of bindings
-  def bindVarList(bindings: Map[String, WdlType], srcText: TextSource): Context = {
+  def bindVarList(bindings: Map[String, WdlType], textSource: TextSource): Context = {
     val existingVarNames = declarations.keys.toSet
     val newVarNames = bindings.keys.toSet
     val both = existingVarNames intersect newVarNames
     if (both.nonEmpty)
-      throw new TypeException(s"Variables ${both} are being redeclared", srcText, docSourceUrl)
+      throw new TypeException(s"Variables ${both} are being redeclared", textSource, docSourceUrl)
     this.copy(declarations = declarations ++ bindings)
   }
 
@@ -106,9 +119,11 @@ case class Context(version: WdlVersion,
   def bindImportedDoc(namespace: String,
                       iCtx: Context,
                       aliases: Vector[AST.ImportAlias],
-                      srcText: TextSource): Context = {
+                      textSource: TextSource): Context = {
     if (this.namespaces contains namespace)
-      throw new TypeException(s"namespace ${namespace} already exists", srcText, iCtx.docSourceUrl)
+      throw new TypeException(s"namespace ${namespace} already exists",
+                              textSource,
+                              iCtx.docSourceUrl)
 
     // There cannot be any collisions because this is a new namespace
     val iCallables = iCtx.callables.map {
@@ -145,7 +160,7 @@ case class Context(version: WdlVersion,
     for (sname <- doublyDefinedStructs) {
       if (this.structs(sname) != iStructs(sname))
         throw new TypeException(s"Struct ${sname} is already defined in a different way",
-                                srcText,
+                                textSource,
                                 iCtx.docSourceUrl)
     }
 

--- a/src/main/scala/wdlTools/types/TypeInfer.scala
+++ b/src/main/scala/wdlTools/types/TypeInfer.scala
@@ -230,12 +230,10 @@ case class TypeInfer(conf: Options) {
       // an identifier has to be bound to a known type. Lookup the the type,
       // and add it to the expression.
       case AST.ExprIdentifier(id, text) =>
-        val binding = ctx.lookup(id, bindings, text)
-        binding match {
+        ctx.lookup(id, bindings, text) match {
           case None =>
             throw new TypeException(s"Identifier ${id} is not defined", expr.text, ctx.docSourceUrl)
           case Some(t) =>
-            // TODO: can we get the actual binding value here, rather than just the type?
             TAT.ExprIdentifier(id, t, text)
         }
 

--- a/src/main/scala/wdlTools/types/TypeInfer.scala
+++ b/src/main/scala/wdlTools/types/TypeInfer.scala
@@ -900,7 +900,7 @@ case class TypeInfer(conf: Options) {
         case Some(c: T_Call) => c
         case Some(_) =>
           throw new TypeException(
-              s"call ${actualName} after clause refers non-call declaration ${after.name}",
+              s"call ${actualName} after clause refers to non-call declaration ${after.name}",
               after.text,
               ctx.docSourceUrl
           )

--- a/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
+++ b/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
@@ -1,8 +1,8 @@
 package wdlTools.types
 
 import java.net.URL
+
 import wdlTools.syntax.{CommentMap, TextSource, WdlVersion}
-import wdlTools.types.WdlTypes
 
 // A tree representing a WDL program with all of the types in place.
 object TypedAbstractSyntax {
@@ -26,12 +26,13 @@ object TypedAbstractSyntax {
 
   // values
   case class ValueNull(wdlType: WdlType, text: TextSource) extends Expr
+  case class ValueNone(wdlType: WdlType, text: TextSource) extends Expr
   case class ValueBoolean(value: Boolean, wdlType: WdlType, text: TextSource) extends Expr
   case class ValueInt(value: Int, wdlType: WdlType, text: TextSource) extends Expr
   case class ValueFloat(value: Double, wdlType: WdlType, text: TextSource) extends Expr
   case class ValueString(value: String, wdlType: WdlType, text: TextSource) extends Expr
   case class ValueFile(value: String, wdlType: WdlType, text: TextSource) extends Expr
-
+  case class ValueDirectory(value: String, wdlType: WdlType, text: TextSource) extends Expr
   case class ExprIdentifier(id: String, wdlType: WdlType, text: TextSource) extends Expr
 
   // represents strings with interpolation. These occur only in command blocks.
@@ -129,6 +130,7 @@ object TypedAbstractSyntax {
   // >>>
   case class CommandSection(parts: Vector[Expr], text: TextSource) extends Element
   case class RuntimeSection(kvs: Map[String, Expr], text: TextSource) extends Element
+  case class HintsSection(kvs: Map[String, Expr], text: TextSource) extends Element
 
   // A specialized JSON-like object language for meta values only.
   sealed trait MetaValue
@@ -144,10 +146,11 @@ object TypedAbstractSyntax {
   case class ParameterMetaSection(kvs: Map[String, MetaValue], text: TextSource) extends Element
   case class MetaSection(kvs: Map[String, MetaValue], text: TextSource) extends Element
 
-  case class Version(value: WdlVersion, text: TextSource) extends DocumentElement
+  case class Version(value: WdlVersion, text: TextSource) extends Element
 
   // import statement with the typed-AST for the referenced document
-  case class ImportAlias(id1: String, id2: String, text: TextSource) extends Element
+  case class ImportAlias(id1: String, id2: String, referee: WdlTypes.T_Struct, text: TextSource)
+      extends Element
   case class ImportDoc(name: Option[String],
                        aliases: Vector[ImportAlias],
                        addr: String,
@@ -169,9 +172,12 @@ object TypedAbstractSyntax {
                   meta: Option[MetaSection],
                   parameterMeta: Option[ParameterMetaSection],
                   runtime: Option[RuntimeSection],
+                  hints: Option[HintsSection],
                   text: TextSource)
       extends DocumentElement
       with Callable
+
+  case class CallAfter(name: String, text: TextSource) extends Element
 
   // The name of the call may not contain dots. Examples:
   //
@@ -185,7 +191,7 @@ object TypedAbstractSyntax {
                   wdlType: WdlTypes.T_Call,
                   callee: WdlTypes.T_Callable,
                   alias: Option[String],
-                  afters: Vector[Call],
+                  afters: Vector[WdlTypes.T_Call],
                   actualName: String,
                   inputs: Map[String, Expr],
                   text: TextSource)

--- a/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
+++ b/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
@@ -185,6 +185,7 @@ object TypedAbstractSyntax {
                   wdlType: WdlTypes.T_Call,
                   callee: WdlTypes.T_Callable,
                   alias: Option[String],
+                  afters: Vector[Call],
                   actualName: String,
                   inputs: Map[String, Expr],
                   text: TextSource)

--- a/src/main/scala/wdlTools/types/Util.scala
+++ b/src/main/scala/wdlTools/types/Util.scala
@@ -107,11 +107,13 @@ object Util {
   def exprToString(expr: TAT.Expr): String = {
     expr match {
       case TAT.ValueNull(_, _)                    => "null"
+      case TAT.ValueNone(_, _)                    => "None"
       case TAT.ValueBoolean(value: Boolean, _, _) => value.toString
       case TAT.ValueInt(value, _, _)              => value.toString
       case TAT.ValueFloat(value, _, _)            => value.toString
       case TAT.ValueString(value, _, _)           => value
       case TAT.ValueFile(value, _, _)             => value
+      case TAT.ValueDirectory(value, _, _)        => value
       case TAT.ExprIdentifier(id: String, _, _)   => id
 
       case TAT.ExprCompoundString(value, _, _) =>

--- a/src/test/resources/wdlTools/types/v1/invalid_param_meta.wdl
+++ b/src/test/resources/wdlTools/types/v1/invalid_param_meta.wdl
@@ -1,0 +1,21 @@
+version 1.0
+
+task foo {
+  input {
+    String s
+  }
+
+  command <<<
+  echo ~{s}
+  >>>
+
+  output {
+    String t = s
+  }
+
+  parameter_meta {
+    s: "A string input"
+    t: "A string output"
+    u: "A non-existant parameter"
+  }
+}

--- a/src/test/scala/wdlTools/types/TypeInferTest.scala
+++ b/src/test/scala/wdlTools/types/TypeInferTest.scala
@@ -65,6 +65,7 @@ class TypeInferTest extends AnyFlatSpec with Matchers {
       // metadata
       "meta_null_value.wdl" -> TResult(correct = true),
       "meta_section_compound.wdl" -> TResult(correct = true),
+      "invalid_param_meta.wdl" -> TResult(correct = false),
       // runtime section
       "runtime_section_I.wdl" -> TResult(correct = true),
       "runtime_section_bad.wdl" -> TResult(correct = false)
@@ -130,7 +131,7 @@ class TypeInferTest extends AnyFlatSpec with Matchers {
     )
 
     // check that all results have a corresponding file
-    val fileNames = testFiles.map(_.getFileName().toString).toSet
+    val fileNames = testFiles.map(_.getFileName.toString).toSet
     val controlNames = controlTable.keys.toSet
     val diff1 = fileNames.diff(controlNames)
     if (diff1.nonEmpty)


### PR DESCRIPTION
* Add new elements to TST for WDL 2: None, Directory type, Call.afters, Hints
* Check parameter_meta keys against input and output declarations and throw exception if there is no match (this required adding an outputs Map to Context)
* Add to ImportAlias the T_Struct to which it refers

Note that this is just the second step in WDL 2.0 support (the first was adding the parser). There is still a third step of implementing type-checking and expression evaluation for these new types.