### PR TITLE
Prettify check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ gen/
 
 # Jar file of the ANTLR4 parser generator
 antlr-*.jar
+
+# test corpora
+src/test/resources/corpora

--- a/src/main/scala/wdlTools/cli/Generate.scala
+++ b/src/main/scala/wdlTools/cli/Generate.scala
@@ -13,13 +13,12 @@ import scala.language.reflectiveCalls
 case class Generate(conf: WdlToolsConf) extends Command {
   override def apply(): Unit = {
     val generatedFiles: mutable.Map[URL, String] = mutable.HashMap.empty
-    val opts = conf.getOptions
     val args = conf.generate
     val name = args.name()
     val outputDir: Path = args.outputDir.getOrElse(Paths.get(name))
 
     val generator = ProjectGenerator(
-        opts,
+        conf.generate.getOptions,
         name,
         outputDir,
         wdlVersion = args.wdlVersion(),

--- a/src/main/scala/wdlTools/cli/PrintTree.scala
+++ b/src/main/scala/wdlTools/cli/PrintTree.scala
@@ -20,7 +20,9 @@ case class PrintTree(conf: WdlToolsConf) extends Command {
         }
       }
       val typeChecker = TypeInfer(
-          TypeOptions(opts.localDirectories, opts.verbosity, opts.antlr4Trace)
+          TypeOptions(localDirectories = opts.localDirectories,
+                      verbosity = opts.verbosity,
+                      antlr4Trace = opts.antlr4Trace)
       )
       println(Util.prettyFormat(typeChecker.apply(document)._1, callback = Some(ignoreImports)))
     } else {

--- a/src/main/scala/wdlTools/cli/PrintTree.scala
+++ b/src/main/scala/wdlTools/cli/PrintTree.scala
@@ -1,7 +1,7 @@
 package wdlTools.cli
 
-import wdlTools.syntax.Parsers
-import wdlTools.types.TypeInfer
+import wdlTools.syntax.{AbstractSyntax, Parsers}
+import wdlTools.types.{TypeInfer, TypeOptions, TypedAbstractSyntax}
 import wdlTools.util.Util
 
 import scala.language.reflectiveCalls
@@ -12,12 +12,25 @@ case class PrintTree(conf: WdlToolsConf) extends Command {
     val opts = conf.printTree.getOptions
     val parsers = Parsers(opts)
     val document = parsers.parseDocument(url)
-    val doc: Any = if (conf.printTree.typed()) {
-      val typeChecker = TypeInfer(opts)
-      typeChecker.apply(document)._1
+    if (conf.printTree.typed()) {
+      def ignoreImports(p: Product): Option[String] = {
+        p match {
+          case d: TypedAbstractSyntax.Document if d.docSourceUrl != url => Some("...")
+          case _                                                        => None
+        }
+      }
+      val typeChecker = TypeInfer(
+          TypeOptions(opts.localDirectories, opts.verbosity, opts.antlr4Trace)
+      )
+      println(Util.prettyFormat(typeChecker.apply(document)._1, callback = Some(ignoreImports)))
     } else {
-      document
+      def ignoreImports(p: Product): Option[String] = {
+        p match {
+          case d: AbstractSyntax.Document if d.sourceUrl != url => Some("...")
+          case _                                                => None
+        }
+      }
+      println(Util.prettyFormat(document, callback = Some(ignoreImports)))
     }
-    println(Util.prettyFormat(doc))
   }
 }

--- a/src/main/scala/wdlTools/cli/Readmes.scala
+++ b/src/main/scala/wdlTools/cli/Readmes.scala
@@ -9,8 +9,7 @@ import scala.language.reflectiveCalls
 case class Readmes(conf: WdlToolsConf) extends Command {
   override def apply(): Unit = {
     val url = conf.readmes.url()
-    val opts = conf.readmes.getOptions
-    val parsers = Parsers(opts)
+    val parsers = Parsers(conf.readmes.getOptions)
     val renderer = Renderer()
     val readmes = parsers.getDocumentWalker[String](url).walk { (doc, results) =>
       ReadmeGenerator(conf.readmes.developerReadmes(), renderer, results).apply(doc)

--- a/src/main/scala/wdlTools/cli/TypeCheck.scala
+++ b/src/main/scala/wdlTools/cli/TypeCheck.scala
@@ -1,20 +1,123 @@
 package wdlTools.cli
 
-import wdlTools.syntax.{Parsers, SyntaxException}
-import wdlTools.types.{TypeException, TypeInfer}
+import java.io.{FileOutputStream, PrintStream}
+import java.net.URL
+import java.nio.file.Files
+
+import spray.json.{JsArray, JsNumber, JsObject, JsString}
+import wdlTools.syntax.{Parsers, SyntaxException, TextSource}
+import wdlTools.types.TypedAbstractSyntax.Element
+import wdlTools.types.TypedAbstractSyntaxTreeVisitor.VisitorContext
+import wdlTools.types.WdlTypes.T
+import wdlTools.types.{TypeException, TypeInfer, TypedAbstractSyntax, TypedAbstractSyntaxTreeWalker}
+
+import scala.collection.mutable
+import scala.io.AnsiColor
 
 case class TypeCheck(conf: WdlToolsConf) extends Command {
+  private def errorsToJson(errors: Map[URL, Vector[(String, TextSource)]]): JsObject = {
+    def getError(reason: String, textSource: TextSource): JsObject = {
+      JsObject(
+          Map(
+              "reason" -> JsString(reason),
+              "startLine" -> JsNumber(textSource.line),
+              "startCol" -> JsNumber(textSource.col),
+              "endLine" -> JsNumber(textSource.endLine),
+              "endCol" -> JsNumber(textSource.endCol)
+          )
+      )
+    }
+    JsObject(Map("sources" -> JsArray(errors.map {
+      case (url, docErrors) =>
+        JsObject(
+            Map("source" -> JsString(url.toString),
+                "errors" -> JsArray(docErrors.map(err => getError(err._1, err._2))))
+        )
+    }.toVector)))
+  }
+
+  private def printErrors(errors: Map[URL, Vector[(String, TextSource)]],
+                          printer: PrintStream,
+                          effects: Boolean): Unit = {
+    def colorMsg(msg: String, color: String): String = {
+      if (effects) {
+        s"${color}${msg}${AnsiColor.RESET}"
+      } else {
+        msg
+      }
+    }
+    errors.foreach { item =>
+      val (msg, docErrors) = item match {
+        case (url, docErrors) => (s"Type-check errors in ${url}", docErrors)
+      }
+      val border1 = "=" * msg.length
+      val border2 = "-" * msg.length
+      printer.println(border1)
+      printer.println(colorMsg(msg, AnsiColor.BLUE))
+      printer.println(border1)
+      printer.println(colorMsg("Line:Col | Description", AnsiColor.BOLD))
+      printer.println(border2)
+      docErrors.sortWith(_._2 < _._2).foreach {
+        case (reason, textSource) =>
+          printer.println(f"${textSource}%-9s| ${reason} |")
+      }
+    }
+  }
+
   override def apply(): Unit = {
     val url = conf.check.url()
     val opts = conf.check.getOptions
     val parsers = Parsers(opts)
     val checker = TypeInfer(opts)
     try {
-      checker.apply(parsers.parseDocument(url))
+      val tDoc = checker.apply(parsers.parseDocument(url))._1
+      if (!opts.errorAsException) {
+        // traverse the tree to collect invalid nodes and display to the user
+        val errors: mutable.Map[URL, mutable.Buffer[(String, TextSource)]] = mutable.HashMap.empty
+        val walker = new TypedAbstractSyntaxTreeWalker(opts) {
+          override def visitDocument(ctx: VisitorContext[TypedAbstractSyntax.Document]): Unit = {
+            if (!errors.contains(ctx.docSourceUrl)) {
+              errors(ctx.docSourceUrl) = mutable.Buffer.empty
+            }
+            super.visitDocument(ctx)
+          }
+
+          override def visitInvalid[P <: Element](reason: String,
+                                                  originalType: Option[T],
+                                                  ctx: VisitorContext[P]): Unit = {
+            errors(ctx.docSourceUrl).append((reason, ctx.element.text))
+          }
+        }
+        walker.apply(tDoc)
+        if (errors.nonEmpty) {
+          // format as json or text and write to file or stdout
+          val outputFile = conf.check.outputFile.toOption
+          val toFile = outputFile.isDefined
+          val printer: PrintStream = if (toFile) {
+            val resolved = outputFile.get
+            if (!conf.check.overwrite() && Files.exists(resolved)) {
+              throw new Exception(s"File already exists: ${resolved}")
+            }
+            val fos = new FileOutputStream(outputFile.get.toFile)
+            new PrintStream(fos, true)
+          } else {
+            System.out
+          }
+          val finalErrors = errors.view.mapValues(_.toVector).toMap
+          if (conf.check.json()) {
+            val js = errorsToJson(finalErrors).prettyPrint
+            printer.println(js)
+          } else {
+            printErrors(finalErrors, printer, effects = !toFile)
+          }
+          if (toFile) {
+            printer.close()
+          }
+        }
+      }
     } catch {
       case e: SyntaxException => println(s"Failed to parse WDL document: ${e.getMessage}")
-      // TODO: accumulate all errors
-      case e: TypeException => println(s"Failed to type-check WDL document: ${e.getMessage}")
+      case e: TypeException   => println(s"Failed to type-check WDL document: ${e.getMessage}")
     }
   }
 }

--- a/src/main/scala/wdlTools/cli/package.scala
+++ b/src/main/scala/wdlTools/cli/package.scala
@@ -166,10 +166,28 @@ class WdlToolsConf(args: Seq[String]) extends ScallopConf(args) {
         descr = "Strictness of type checking",
         default = Some(TypeCheckingRegime.Moderate)
     )
+    val json: ScallopOption[Boolean] = toggle(
+        descrYes = "Output type-check errors as JSON",
+        descrNo = "Output type-check errors as plain text",
+        default = Some(false)
+    )
+    val outputFile: ScallopOption[Path] = opt[Path](
+        descr =
+          "File in which to write type-check errors; if not specified, errors are written to stdout"
+    )
+    val overwrite: ScallopOption[Boolean] = toggle(
+        descrYes = "Overwrite existing files",
+        descrNo = "(Default) Do not overwrite existing files",
+        default = Some(false)
+    )
 
     override def getOptions: TypeOptions = {
       val opts = super.getOptions
-      TypeOptions(opts.localDirectories, opts.verbosity, opts.antlr4Trace, regime())
+      TypeOptions(opts.localDirectories,
+                  opts.verbosity,
+                  opts.antlr4Trace,
+                  regime(),
+                  errorAsException = false)
     }
   }
   addSubcommand(check)

--- a/src/main/scala/wdlTools/eval/Coercion.scala
+++ b/src/main/scala/wdlTools/eval/Coercion.scala
@@ -86,7 +86,7 @@ case class Coercion(docSourceUrl: Option[URL]) {
       case (WdlTypes.T_Pair(lt, rt), WV_Pair(l, r)) =>
         WV_Pair(coerceTo(lt, l, text), coerceTo(rt, r, text))
 
-      case (WdlTypes.T_Struct(name1, _), WV_Struct(name2, _)) =>
+      case (WdlTypes.T_StructDef(name1, _), WV_Struct(name2, _)) =>
         if (name1 != name2)
           throw new EvalException(s"cannot coerce struct ${name2} to struct ${name1}",
                                   text,
@@ -94,10 +94,10 @@ case class Coercion(docSourceUrl: Option[URL]) {
         value
 
       // cast of an object to a struct. I think this is legal.
-      case (WdlTypes.T_Struct(name, memberDefs), WV_Object(members)) =>
+      case (WdlTypes.T_StructDef(name, memberDefs), WV_Object(members)) =>
         coerceToStruct(name, memberDefs, members, text)
 
-      case (WdlTypes.T_Struct(name, memberDefs), WV_Map(members)) =>
+      case (WdlTypes.T_StructDef(name, memberDefs), WV_Map(members)) =>
         // convert into a mapping from string to WdlValue
         val members2: Map[String, WV] = members.map {
           case (WV_String(k), v) => k -> v

--- a/src/main/scala/wdlTools/eval/Eval.scala
+++ b/src/main/scala/wdlTools/eval/Eval.scala
@@ -5,7 +5,7 @@ import java.net.URL
 import wdlTools.eval.WdlValues._
 import wdlTools.syntax.{TextSource, WdlVersion}
 import wdlTools.types.{TypedAbstractSyntax => TAT}
-import wdlTools.util.{EvalConfig, Options}
+import wdlTools.util.Options
 
 case class Eval(opts: Options,
                 evalCfg: EvalConfig,

--- a/src/main/scala/wdlTools/eval/IoSupp.scala
+++ b/src/main/scala/wdlTools/eval/IoSupp.scala
@@ -7,7 +7,7 @@ import java.nio.file.{Files, FileSystems, Path, Paths, PathMatcher}
 import scala.jdk.CollectionConverters._
 import scala.util.Random
 
-import wdlTools.util.{EvalConfig, Options, Util}
+import wdlTools.util.{Options, Util}
 import wdlTools.util.Verbosity._
 
 case class IoSupp(opts: Options, evalCfg: EvalConfig) {

--- a/src/main/scala/wdlTools/eval/StdlibDraft2.scala
+++ b/src/main/scala/wdlTools/eval/StdlibDraft2.scala
@@ -2,7 +2,7 @@ package wdlTools.eval
 
 import java.net.URL
 import wdlTools.syntax.TextSource
-import wdlTools.util.{EvalConfig, Options}
+import wdlTools.util.Options
 import WdlValues._
 
 case class StdlibDraft2(opts: Options, evalCfg: EvalConfig, docSourceUrl: Option[URL])

--- a/src/main/scala/wdlTools/eval/StdlibV1.scala
+++ b/src/main/scala/wdlTools/eval/StdlibV1.scala
@@ -5,7 +5,7 @@ import java.nio.file.{Path, Paths}
 import spray.json._
 import wdlTools.eval.WdlValues._
 import wdlTools.syntax.TextSource
-import wdlTools.util.{EvalConfig, Options}
+import wdlTools.util.Options
 import wdlTools.types.WdlTypes._
 
 case class StdlibV1(opts: Options, evalCfg: EvalConfig, docSourceUrl: Option[URL])

--- a/src/main/scala/wdlTools/eval/package.scala
+++ b/src/main/scala/wdlTools/eval/package.scala
@@ -1,6 +1,8 @@
 package wdlTools.eval
 
 import java.net.URL
+import java.nio.file.Path
+
 import wdlTools.syntax.TextSource
 
 case class Context(bindings: Map[String, WdlValues.WV]) {
@@ -14,6 +16,15 @@ case class Context(bindings: Map[String, WdlValues.WV]) {
 trait StandardLibraryImpl {
   def call(funcName: String, args: Vector[WdlValues.WV], text: TextSource): WdlValues.WV
 }
+
+/** Configuration for expression evaluation. Some operations perform file IO.
+  *
+  * @param homeDir  the root directory for relative paths, and the root directory for search (glob).
+  * @param tmpDir   directory for placing temporary files.
+  * @param stdout   the file that has a copy of standard output. This is used in the command section.
+  * @param stderr   as above for standard error.
+  */
+case class EvalConfig(homeDir: Path, tmpDir: Path, stdout: Path, stderr: Path)
 
 // A runtime error
 final class EvalException(message: String) extends Exception(message) {

--- a/src/main/scala/wdlTools/formatter/Upgrader.scala
+++ b/src/main/scala/wdlTools/formatter/Upgrader.scala
@@ -4,7 +4,7 @@ import java.net.URL
 
 import wdlTools.syntax
 import wdlTools.syntax.WdlVersion
-import wdlTools.util.Options
+import wdlTools.util.{BasicOptions, Options}
 
 case class Upgrader(opts: Options) {
   private val parsers = syntax.Parsers(opts)
@@ -19,7 +19,13 @@ case class Upgrader(opts: Options) {
     }
 
     // the parser will follow imports, so the formatter should not
-    val formatter = WdlV1Formatter(opts.copy(followImports = false))
+    val formatter = WdlV1Formatter(
+        BasicOptions(
+            opts.localDirectories,
+            verbosity = opts.verbosity,
+            antlr4Trace = opts.antlr4Trace
+        )
+    )
 
     // parse and format the document (and any imports)
     parser.getDocumentWalker[Seq[String]](url).walk { (doc, results) =>

--- a/src/main/scala/wdlTools/generators/DocumentationGenerator.scala
+++ b/src/main/scala/wdlTools/generators/DocumentationGenerator.scala
@@ -188,7 +188,7 @@ case class DocumentationGenerator(
               imp.addr.value,
               imp.name
                 .map(_.value)
-                .getOrElse(Util.getUrlFileName(imp.addr.value).replace(".wdl", "")),
+                .getOrElse(Util.getFilename(imp.addr.value).replace(".wdl", "")),
               imp.aliases.map(a => a.id1 -> a.id2).toMap,
               getDocumentationComment(imp)
           )
@@ -285,7 +285,7 @@ case class DocumentationGenerator(
     val renderer: Renderer = Renderer()
     docs.foreach {
       case (url, doc) =>
-        documentation(Util.getUrlFileName(url.getPath).replace(".wdl", ".md")) =
+        documentation(Util.getFilename(url.getPath).replace(".wdl", ".md")) =
           renderer.render(DOCUMENT_TEMPLATE, Map("doc" -> doc))
     }
     // All structs share the same namespace so we put them on a separate page

--- a/src/main/scala/wdlTools/generators/DocumentationGenerator.scala
+++ b/src/main/scala/wdlTools/generators/DocumentationGenerator.scala
@@ -1,13 +1,12 @@
 package wdlTools.generators
 
 import java.net.URL
-import java.nio.file.Paths
 
 import wdlTools.generators.DocumentationGenerator._
 import wdlTools.syntax.AbstractSyntax._
 import wdlTools.syntax.Util.exprToString
 import wdlTools.syntax.{Comment, Parsers}
-import wdlTools.util.Options
+import wdlTools.util.{Options, Util}
 
 import scala.collection.mutable
 
@@ -189,13 +188,7 @@ case class DocumentationGenerator(
               imp.addr.value,
               imp.name
                 .map(_.value)
-                .getOrElse(
-                    Paths
-                      .get(new URL(imp.addr.value).getPath)
-                      .getFileName
-                      .toString
-                      .replace(".wdl", "")
-                ),
+                .getOrElse(Util.getUrlFileName(imp.addr.value).replace(".wdl", "")),
               imp.aliases.map(a => a.id1 -> a.id2).toMap,
               getDocumentationComment(imp)
           )
@@ -292,7 +285,7 @@ case class DocumentationGenerator(
     val renderer: Renderer = Renderer()
     docs.foreach {
       case (url, doc) =>
-        documentation(Paths.get(url.getPath).getFileName.toString.replace(".wdl", ".md")) =
+        documentation(Util.getUrlFileName(url.getPath).replace(".wdl", ".md")) =
           renderer.render(DOCUMENT_TEMPLATE, Map("doc" -> doc))
     }
     // All structs share the same namespace so we put them on a separate page

--- a/src/main/scala/wdlTools/linter/Linter.scala
+++ b/src/main/scala/wdlTools/linter/Linter.scala
@@ -6,8 +6,8 @@ import org.antlr.v4.runtime.tree.ParseTreeListener
 import wdlTools.linter.Severity.Severity
 import wdlTools.syntax.Antlr4Util.ParseTreeListenerFactory
 import wdlTools.syntax.{Antlr4Util, Parsers}
-import wdlTools.types.TypeInfer
-import wdlTools.util.Options
+import wdlTools.types.{TypeInfer, TypeOptions}
+import wdlTools.util.{Options, TypeCheckingRegime}
 
 import scala.collection.mutable
 
@@ -47,7 +47,14 @@ case class Linter(opts: Options,
           events(doc.sourceUrl) = docEvents
         }
         // First run the TypeChecker to infer the types of all expressions
-        val typeChecker = TypeInfer(opts)
+        val typeChecker = TypeInfer(
+            TypeOptions(
+                opts.localDirectories,
+                opts.verbosity,
+                opts.antlr4Trace,
+                TypeCheckingRegime.Strict
+            )
+        )
         val (_, typesContext) = typeChecker.apply(doc)
         // Now execute the linter rules
         val visitors = astRules.map {

--- a/src/main/scala/wdlTools/syntax/Parsers.scala
+++ b/src/main/scala/wdlTools/syntax/Parsers.scala
@@ -5,16 +5,17 @@ import java.nio.file.Path
 
 import wdlTools.syntax.AbstractSyntax.Document
 import wdlTools.syntax.Antlr4Util.ParseTreeListenerFactory
-import wdlTools.util.{Options, SourceCode, Util}
+import wdlTools.util.{BasicOptions, Options, SourceCode, Util}
 
 import scala.collection.mutable
 
-case class Parsers(opts: Options = Options(),
-                   listenerFactories: Vector[ParseTreeListenerFactory] = Vector.empty) {
+case class Parsers(opts: Options = BasicOptions(),
+                   listenerFactories: Vector[ParseTreeListenerFactory] = Vector.empty,
+                   errorHandler: Option[(Option[URL], Exception) => Boolean] = None) {
   private lazy val parsers: Map[WdlVersion, WdlParser] = Map(
-      WdlVersion.Draft_2 -> draft_2.ParseAll(opts, listenerFactories),
-      WdlVersion.V1 -> v1.ParseAll(opts, listenerFactories),
-      WdlVersion.V2 -> v2.ParseAll(opts, listenerFactories)
+      WdlVersion.Draft_2 -> draft_2.ParseAll(opts, listenerFactories, errorHandler),
+      WdlVersion.V1 -> v1.ParseAll(opts, listenerFactories, errorHandler),
+      WdlVersion.V2 -> v2.ParseAll(opts, listenerFactories, errorHandler)
   )
 
   def getParser(url: URL): WdlParser = {

--- a/src/main/scala/wdlTools/syntax/Parsers.scala
+++ b/src/main/scala/wdlTools/syntax/Parsers.scala
@@ -11,7 +11,7 @@ import scala.collection.mutable
 
 case class Parsers(opts: Options = BasicOptions(),
                    listenerFactories: Vector[ParseTreeListenerFactory] = Vector.empty,
-                   errorHandler: Option[(Option[URL], Exception) => Boolean] = None) {
+                   errorHandler: Option[(Option[URL], Throwable) => Boolean] = None) {
   private lazy val parsers: Map[WdlVersion, WdlParser] = Map(
       WdlVersion.Draft_2 -> draft_2.ParseAll(opts, listenerFactories, errorHandler),
       WdlVersion.V1 -> v1.ParseAll(opts, listenerFactories, errorHandler),

--- a/src/main/scala/wdlTools/syntax/WdlParser.scala
+++ b/src/main/scala/wdlTools/syntax/WdlParser.scala
@@ -12,7 +12,7 @@ trait DocumentWalker[T] {
 }
 
 abstract class WdlParser(opts: Options,
-                         errorHandler: Option[(Option[URL], Exception) => Boolean] = None) {
+                         errorHandler: Option[(Option[URL], Throwable) => Boolean] = None) {
   // cache of documents that have already been fetched and parsed.
   private val docCache: mutable.Map[URL, Option[AbstractSyntax.Document]] = mutable.Map.empty
 
@@ -23,7 +23,7 @@ abstract class WdlParser(opts: Options,
           try {
             Some(parseDocument(SourceCode.loadFrom(url)))
           } catch {
-            case e: Exception if errorHandler.isDefined && errorHandler.get(Some(url), e) => None
+            case e: Throwable if errorHandler.isDefined && errorHandler.get(Some(url), e) => None
             case e: Throwable                                                             => throw e
           }
         docCache(url) = aDoc
@@ -85,7 +85,7 @@ abstract class WdlParser(opts: Options,
         val document = parseDocument(sourceCode)
         addDocument(sourceCode.url, document)
       } catch {
-        case e: Exception if errorHandler.isDefined && errorHandler.get(sourceCode.url, e) => ()
+        case e: Throwable if errorHandler.isDefined && errorHandler.get(sourceCode.url, e) => ()
         case e: Throwable                                                                  => throw e
       }
       results.toMap

--- a/src/main/scala/wdlTools/syntax/WdlParser.scala
+++ b/src/main/scala/wdlTools/syntax/WdlParser.scala
@@ -11,14 +11,21 @@ trait DocumentWalker[T] {
   def walk(visitor: (Document, mutable.Map[URL, T]) => Unit): Map[URL, T]
 }
 
-abstract class WdlParser(opts: Options) {
+abstract class WdlParser(opts: Options,
+                         errorHandler: Option[(Option[URL], Exception) => Boolean] = None) {
   // cache of documents that have already been fetched and parsed.
-  private val docCache: mutable.Map[URL, AbstractSyntax.Document] = mutable.Map.empty
+  private val docCache: mutable.Map[URL, Option[AbstractSyntax.Document]] = mutable.Map.empty
 
-  protected def followImport(url: URL): AbstractSyntax.Document = {
+  protected def followImport(url: URL): Option[AbstractSyntax.Document] = {
     docCache.get(url) match {
       case None =>
-        val aDoc = parseDocument(SourceCode.loadFrom(url))
+        val aDoc =
+          try {
+            Some(parseDocument(SourceCode.loadFrom(url)))
+          } catch {
+            case e: Exception if errorHandler.isDefined && errorHandler.get(Some(url), e) => None
+            case e: Throwable                                                             => throw e
+          }
         docCache(url) = aDoc
         aDoc
       case Some(aDoc) => aDoc
@@ -74,8 +81,13 @@ abstract class WdlParser(opts: Options) {
         }
       }
 
-      val document = parseDocument(sourceCode)
-      addDocument(sourceCode.url, document)
+      try {
+        val document = parseDocument(sourceCode)
+        addDocument(sourceCode.url, document)
+      } catch {
+        case e: Exception if errorHandler.isDefined && errorHandler.get(sourceCode.url, e) => ()
+        case e: Throwable                                                                  => throw e
+      }
       results.toMap
     }
   }

--- a/src/main/scala/wdlTools/syntax/draft_2/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/draft_2/ParseAll.scala
@@ -10,7 +10,7 @@ import wdlTools.util.{Options, SourceCode}
 // parse and follow imports
 case class ParseAll(opts: Options,
                     listenerFactories: Vector[ParseTreeListenerFactory] = Vector.empty,
-                    errorHandler: Option[(Option[URL], Exception) => Boolean] = None)
+                    errorHandler: Option[(Option[URL], Throwable) => Boolean] = None)
     extends WdlParser(opts, errorHandler) {
 
   private case class Translator(docSourceUrl: Option[URL] = None) {

--- a/src/main/scala/wdlTools/syntax/draft_2/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/draft_2/ParseAll.scala
@@ -9,8 +9,9 @@ import wdlTools.util.{Options, SourceCode}
 
 // parse and follow imports
 case class ParseAll(opts: Options,
-                    listenerFactories: Vector[ParseTreeListenerFactory] = Vector.empty)
-    extends WdlParser(opts) {
+                    listenerFactories: Vector[ParseTreeListenerFactory] = Vector.empty,
+                    errorHandler: Option[(Option[URL], Exception) => Boolean] = None)
+    extends WdlParser(opts, errorHandler) {
 
   private case class Translator(docSourceUrl: Option[URL] = None) {
     def translateType(t: CST.Type): AST.Type = {
@@ -262,7 +263,7 @@ case class ParseAll(opts: Options,
       val elems: Vector[AST.DocumentElement] = doc.elements.map {
         case importDoc: ConcreteSyntax.ImportDoc =>
           val importedDoc = if (opts.followImports) {
-            Some(followImport(getDocSourceUrl(importDoc.addr.value)))
+            followImport(getDocSourceUrl(importDoc.addr.value))
           } else {
             None
           }

--- a/src/main/scala/wdlTools/syntax/v1/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ParseAll.scala
@@ -9,8 +9,9 @@ import wdlTools.util.{Options, SourceCode}
 
 // parse and follow imports
 case class ParseAll(opts: Options,
-                    listenerFactories: Vector[ParseTreeListenerFactory] = Vector.empty)
-    extends WdlParser(opts) {
+                    listenerFactories: Vector[ParseTreeListenerFactory] = Vector.empty,
+                    errorHandler: Option[(Option[URL], Exception) => Boolean] = None)
+    extends WdlParser(opts, errorHandler) {
 
   private case class Translator(docSourceUrl: Option[URL] = None) {
     def translateType(t: CST.Type): AST.Type = {
@@ -330,7 +331,7 @@ case class ParseAll(opts: Options,
         case struct: ConcreteSyntax.TypeStruct => translateStruct(struct)
         case importDoc: ConcreteSyntax.ImportDoc =>
           val importedDoc = if (opts.followImports) {
-            Some(followImport(getDocSourceUrl(importDoc.addr.value)))
+            followImport(getDocSourceUrl(importDoc.addr.value))
           } else {
             None
           }

--- a/src/main/scala/wdlTools/syntax/v1/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ParseAll.scala
@@ -10,7 +10,7 @@ import wdlTools.util.{Options, SourceCode}
 // parse and follow imports
 case class ParseAll(opts: Options,
                     listenerFactories: Vector[ParseTreeListenerFactory] = Vector.empty,
-                    errorHandler: Option[(Option[URL], Exception) => Boolean] = None)
+                    errorHandler: Option[(Option[URL], Throwable) => Boolean] = None)
     extends WdlParser(opts, errorHandler) {
 
   private case class Translator(docSourceUrl: Option[URL] = None) {

--- a/src/main/scala/wdlTools/syntax/v2/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/v2/ParseAll.scala
@@ -9,8 +9,9 @@ import wdlTools.util.{Options, SourceCode}
 
 // parse and follow imports
 case class ParseAll(opts: Options,
-                    listenerFactories: Vector[ParseTreeListenerFactory] = Vector.empty)
-    extends WdlParser(opts) {
+                    listenerFactories: Vector[ParseTreeListenerFactory] = Vector.empty,
+                    errorHandler: Option[(Option[URL], Exception) => Boolean] = None)
+    extends WdlParser(opts, errorHandler) {
   private case class Translator(docSourceUrl: Option[URL] = None) {
     def translateType(t: CST.Type): AST.Type = {
       t match {
@@ -333,7 +334,7 @@ case class ParseAll(opts: Options,
         case struct: ConcreteSyntax.TypeStruct => translateStruct(struct)
         case importDoc: ConcreteSyntax.ImportDoc =>
           val importedDoc = if (opts.followImports) {
-            Some(followImport(getDocSourceUrl(importDoc.addr.value)))
+            followImport(getDocSourceUrl(importDoc.addr.value))
           } else {
             None
           }

--- a/src/main/scala/wdlTools/syntax/v2/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/v2/ParseAll.scala
@@ -10,7 +10,7 @@ import wdlTools.util.{Options, SourceCode}
 // parse and follow imports
 case class ParseAll(opts: Options,
                     listenerFactories: Vector[ParseTreeListenerFactory] = Vector.empty,
-                    errorHandler: Option[(Option[URL], Exception) => Boolean] = None)
+                    errorHandler: Option[(Option[URL], Throwable) => Boolean] = None)
     extends WdlParser(opts, errorHandler) {
   private case class Translator(docSourceUrl: Option[URL] = None) {
     def translateType(t: CST.Type): AST.Type = {

--- a/src/main/scala/wdlTools/types/Context.scala
+++ b/src/main/scala/wdlTools/types/Context.scala
@@ -12,7 +12,6 @@ import wdlTools.types.{TypedAbstractSyntax => TAT}
 // An additional variable holds a list of all imported namespaces.
 case class Context(version: WdlVersion,
                    stdlib: Stdlib,
-                   unify: Unification,
                    docSourceUrl: Option[URL] = None,
                    inputs: Map[String, WdlTypes.T] = Map.empty,
                    declarations: Map[String, WdlTypes.T] = Map.empty,

--- a/src/main/scala/wdlTools/types/Context.scala
+++ b/src/main/scala/wdlTools/types/Context.scala
@@ -2,7 +2,6 @@ package wdlTools.types
 
 import java.net.URL
 import wdlTools.syntax.{AbstractSyntax => AST, WdlVersion}
-import wdlTools.syntax.TextSource
 import wdlTools.types.WdlTypes._
 import wdlTools.types.{TypedAbstractSyntax => TAT}
 
@@ -21,9 +20,7 @@ case class Context(version: WdlVersion,
                    namespaces: Set[String] = Set.empty) {
   type WdlType = WdlTypes.T
 
-  def lookup(varName: String,
-             bindings: Map[String, WdlType],
-             textSource: TextSource): Option[WdlType] = {
+  def lookup(varName: String, bindings: Map[String, WdlType]): Option[WdlType] = {
     inputs.get(varName) match {
       case None    => ()
       case Some(t) => return Some(t)
@@ -59,49 +56,53 @@ case class Context(version: WdlVersion,
     this.copy(outputs = bindings)
   }
 
-  def bindVar(varName: String, wdlType: WdlType, textSource: TextSource): Context = {
+  def bindVar(varName: String, wdlType: WdlType): Either[Context, String] = {
     declarations.get(varName) match {
       case None =>
-        this.copy(declarations = declarations + (varName -> wdlType))
+        Left(this.copy(declarations = declarations + (varName -> wdlType)))
       case Some(_) =>
-        throw new TypeException(s"variable ${varName} shadows an existing variable",
-                                textSource,
-                                docSourceUrl)
-    }
-  }
-
-  def bindStruct(s: T_Struct, textSource: TextSource): Context = {
-    structs.get(s.name) match {
-      case None =>
-        this.copy(structs = structs + (s.name -> s))
-      case Some(existingStruct: T_Struct) =>
-        if (s != existingStruct)
-          throw new TypeException(s"struct ${s.name} is already declared", textSource, docSourceUrl)
-        // The struct is defined a second time, with the exact same definition. Ignore.
-        this
-    }
-  }
-
-  // add a callable (task/workflow)
-  def bindCallable(callable: T_Callable, textSource: TextSource): Context = {
-    callables.get(callable.name) match {
-      case None =>
-        this.copy(callables = callables + (callable.name -> callable))
-      case Some(_) =>
-        throw new TypeException(s"a callable named ${callable.name} is already declared",
-                                textSource,
-                                docSourceUrl)
+        Right(s"variable ${varName} shadows an existing variable")
     }
   }
 
   // add a bunch of bindings
-  def bindVarList(bindings: Map[String, WdlType], textSource: TextSource): Context = {
-    val existingVarNames = declarations.keys.toSet
-    val newVarNames = bindings.keys.toSet
-    val both = existingVarNames intersect newVarNames
-    if (both.nonEmpty)
-      throw new TypeException(s"Variables ${both} are being redeclared", textSource, docSourceUrl)
-    this.copy(declarations = declarations ++ bindings)
+  // the caller is responsible for ensuring that each binding is either
+  // not a duplicate of an existing variables or that its type extends Invalid
+  def bindVarList(bindings: Map[String, WdlType]): Context = {
+    val both = declarations.keys.toSet intersect bindings.keys.toSet
+    val keep = bindings.filter {
+      case (name, _: Invalid) if both.contains(name) =>
+        // ignore duplicate var if it is Invalid
+        false
+      case (name, _) if both.contains(name) =>
+        throw new RuntimeException(
+            "Trying to bind variables that have already been declared with non-error types"
+        )
+      case _ => true
+    }
+    this.copy(declarations = declarations ++ keep)
+  }
+
+  def bindStruct(s: T_Struct): Either[Context, String] = {
+    structs.get(s.name) match {
+      case None =>
+        Left(this.copy(structs = structs + (s.name -> s)))
+      case Some(existingStruct: T_Struct) if s != existingStruct =>
+        Right(s"struct ${s.name} is already declared")
+      case _ =>
+        // The struct is defined a second time, with the exact same definition. Ignore.
+        Left(this)
+    }
+  }
+
+  // add a callable (task/workflow)
+  def bindCallable(callable: T_Callable): Either[Context, String] = {
+    callables.get(callable.name) match {
+      case None =>
+        Left(this.copy(callables = callables + (callable.name -> callable)))
+      case Some(_) =>
+        Right(s"a callable named ${callable.name} is already declared")
+    }
   }
 
   // When we import another document all of its definitions are prefixed with the
@@ -118,23 +119,21 @@ case class Context(version: WdlVersion,
   // }
   def bindImportedDoc(namespace: String,
                       iCtx: Context,
-                      aliases: Vector[AST.ImportAlias],
-                      textSource: TextSource): Context = {
-    if (this.namespaces contains namespace)
-      throw new TypeException(s"namespace ${namespace} already exists",
-                              textSource,
-                              iCtx.docSourceUrl)
+                      aliases: Vector[AST.ImportAlias]): Either[Context, String] = {
+    if (this.namespaces contains namespace) {
+      return Right(s"namespace ${namespace} already exists")
+    }
 
     // There cannot be any collisions because this is a new namespace
     val iCallables = iCtx.callables.map {
-      case (name, taskSig: T_Task) =>
+      case (name, taskSig: T_TaskDef) =>
         val fqn = namespace + "." + name
         fqn -> taskSig.copy(name = fqn)
-      case (name, wfSig: T_Workflow) =>
+      case (name, wfSig: T_WorkflowDef) =>
         val fqn = namespace + "." + name
         fqn -> wfSig.copy(name = fqn)
       case other =>
-        throw new Exception(s"sanity: ${other.getClass}")
+        throw new RuntimeException(s"sanity: ${other.getClass}")
     }
 
     // rename the imported structs according to the aliases
@@ -151,21 +150,22 @@ case class Context(version: WdlVersion,
       case (name, iStruct) =>
         aliasesMap.get(name) match {
           case None          => name -> iStruct
-          case Some(altName) => altName -> T_Struct(altName, iStruct.members)
+          case Some(altName) => altName -> T_StructDef(altName, iStruct.members)
         }
     }
 
     // check that the imported structs do not step over existing definitions
-    val doublyDefinedStructs = this.structs.keys.toSet intersect iStructs.keys.toSet
-    for (sname <- doublyDefinedStructs) {
-      if (this.structs(sname) != iStructs(sname))
-        throw new TypeException(s"Struct ${sname} is already defined in a different way",
-                                textSource,
-                                iCtx.docSourceUrl)
+    val doublyDefinedStructs = this.structs.keys.toSet intersect iStructs.keys.toSet.filter(sname =>
+      this.structs(sname) != iStructs(sname)
+    )
+    if (doublyDefinedStructs.nonEmpty) {
+      Right(s"Struct(s) ${doublyDefinedStructs.mkString(",")} already defined in a different way")
+    } else {
+      Left(
+          this.copy(structs = structs ++ iStructs,
+                    callables = callables ++ iCallables,
+                    namespaces = namespaces + namespace)
+      )
     }
-
-    this.copy(structs = structs ++ iStructs,
-              callables = callables ++ iCallables,
-              namespaces = namespaces + namespace)
   }
 }

--- a/src/main/scala/wdlTools/types/Context.scala
+++ b/src/main/scala/wdlTools/types/Context.scala
@@ -12,6 +12,7 @@ import wdlTools.types.{TypedAbstractSyntax => TAT}
 // An additional variable holds a list of all imported namespaces.
 case class Context(version: WdlVersion,
                    stdlib: Stdlib,
+                   unify: Unification,
                    docSourceUrl: Option[URL] = None,
                    inputs: Map[String, WdlTypes.T] = Map.empty,
                    declarations: Map[String, WdlTypes.T] = Map.empty,
@@ -22,7 +23,7 @@ case class Context(version: WdlVersion,
 
   def lookup(varName: String,
              bindings: Map[String, WdlType],
-             srcText: TextSource): Option[WdlType] = {
+             textSource: TextSource): Option[WdlType] = {
     inputs.get(varName) match {
       case None    => ()
       case Some(t) => return Some(t)
@@ -46,48 +47,48 @@ case class Context(version: WdlVersion,
     this.copy(inputs = bindings)
   }
 
-  def bindVar(varName: String, wdlType: WdlType, srcText: TextSource): Context = {
+  def bindVar(varName: String, wdlType: WdlType, textSource: TextSource): Context = {
     declarations.get(varName) match {
       case None =>
         this.copy(declarations = declarations + (varName -> wdlType))
       case Some(_) =>
         throw new TypeException(s"variable ${varName} shadows an existing variable",
-                                srcText,
+                                textSource,
                                 docSourceUrl)
     }
   }
 
-  def bindStruct(s: T_Struct, srcText: TextSource): Context = {
+  def bindStruct(s: T_Struct, textSource: TextSource): Context = {
     structs.get(s.name) match {
       case None =>
         this.copy(structs = structs + (s.name -> s))
       case Some(existingStruct: T_Struct) =>
         if (s != existingStruct)
-          throw new TypeException(s"struct ${s.name} is already declared", srcText, docSourceUrl)
+          throw new TypeException(s"struct ${s.name} is already declared", textSource, docSourceUrl)
         // The struct is defined a second time, with the exact same definition. Ignore.
         this
     }
   }
 
   // add a callable (task/workflow)
-  def bindCallable(callable: T_Callable, srcText: TextSource): Context = {
+  def bindCallable(callable: T_Callable, textSource: TextSource): Context = {
     callables.get(callable.name) match {
       case None =>
         this.copy(callables = callables + (callable.name -> callable))
       case Some(_) =>
         throw new TypeException(s"a callable named ${callable.name} is already declared",
-                                srcText,
+                                textSource,
                                 docSourceUrl)
     }
   }
 
   // add a bunch of bindings
-  def bindVarList(bindings: Map[String, WdlType], srcText: TextSource): Context = {
+  def bindVarList(bindings: Map[String, WdlType], textSource: TextSource): Context = {
     val existingVarNames = declarations.keys.toSet
     val newVarNames = bindings.keys.toSet
     val both = existingVarNames intersect newVarNames
     if (both.nonEmpty)
-      throw new TypeException(s"Variables ${both} are being redeclared", srcText, docSourceUrl)
+      throw new TypeException(s"Variables ${both} are being redeclared", textSource, docSourceUrl)
     this.copy(declarations = declarations ++ bindings)
   }
 
@@ -106,9 +107,11 @@ case class Context(version: WdlVersion,
   def bindImportedDoc(namespace: String,
                       iCtx: Context,
                       aliases: Vector[AST.ImportAlias],
-                      srcText: TextSource): Context = {
+                      textSource: TextSource): Context = {
     if (this.namespaces contains namespace)
-      throw new TypeException(s"namespace ${namespace} already exists", srcText, iCtx.docSourceUrl)
+      throw new TypeException(s"namespace ${namespace} already exists",
+                              textSource,
+                              iCtx.docSourceUrl)
 
     // There cannot be any collisions because this is a new namespace
     val iCallables = iCtx.callables.map {
@@ -145,7 +148,7 @@ case class Context(version: WdlVersion,
     for (sname <- doublyDefinedStructs) {
       if (this.structs(sname) != iStructs(sname))
         throw new TypeException(s"Struct ${sname} is already defined in a different way",
-                                srcText,
+                                textSource,
                                 iCtx.docSourceUrl)
     }
 

--- a/src/main/scala/wdlTools/types/Context.scala
+++ b/src/main/scala/wdlTools/types/Context.scala
@@ -159,9 +159,10 @@ case class Context(version: WdlVersion,
     }
 
     // check that the imported structs do not step over existing definitions
-    val doublyDefinedStructs = this.aliases.keys.toSet intersect iAliases.keys.toSet.filter(sname =>
-      this.aliases(sname) != iAliases(sname)
-    )
+    val doublyDefinedStructs =
+      (this.aliases.keys.toSet intersect iAliases.keys.toSet).filter(sname =>
+        this.aliases(sname) != iAliases(sname)
+      )
     if (doublyDefinedStructs.nonEmpty) {
       Right(s"Struct(s) ${doublyDefinedStructs.mkString(",")} already defined in a different way")
     } else {

--- a/src/main/scala/wdlTools/types/Stdlib.scala
+++ b/src/main/scala/wdlTools/types/Stdlib.scala
@@ -7,7 +7,7 @@ import wdlTools.util.Options
 import wdlTools.syntax.{TextSource, WdlVersion}
 
 case class Stdlib(conf: Options, version: WdlVersion, docSourceUrl: Option[URL]) {
-  private val unify = Unification(conf, docSourceUrl)
+  private val unify = Unification(conf)
 
   // Some functions are overloaded and can take several kinds of arguments.
   // A particulary problematic one is size.
@@ -171,8 +171,8 @@ case class Stdlib(conf: Options, version: WdlVersion, docSourceUrl: Option[URL])
         return None
     }
     try {
-      val (_, ctx) = unify.unifyFunctionArguments(args, inputTypes, Map.empty, textSource)
-      val t = unify.substitute(funcDesc.output, ctx, textSource)
+      val (_, ctx) = unify.unifyFunctionArguments(args, inputTypes, Map.empty)
+      val t = unify.substitute(funcDesc.output, ctx, textSource, docSourceUrl)
       Some((t, funcDesc))
     } catch {
       case _: TypeUnificationException =>

--- a/src/main/scala/wdlTools/types/Stdlib.scala
+++ b/src/main/scala/wdlTools/types/Stdlib.scala
@@ -3,10 +3,9 @@ package wdlTools.types
 import java.net.URL
 
 import WdlTypes._
-import wdlTools.util.Options
 import wdlTools.syntax.{TextSource, WdlVersion}
 
-case class Stdlib(conf: Options, version: WdlVersion, docSourceUrl: Option[URL]) {
+case class Stdlib(conf: TypeOptions, version: WdlVersion, docSourceUrl: Option[URL]) {
   private val unify = Unification(conf)
 
   // Some functions are overloaded and can take several kinds of arguments.

--- a/src/main/scala/wdlTools/types/Stdlib.scala
+++ b/src/main/scala/wdlTools/types/Stdlib.scala
@@ -1,11 +1,9 @@
 package wdlTools.types
 
-import java.net.URL
-
 import WdlTypes._
-import wdlTools.syntax.{TextSource, WdlVersion}
+import wdlTools.syntax.WdlVersion
 
-case class Stdlib(conf: TypeOptions, version: WdlVersion, docSourceUrl: Option[URL]) {
+case class Stdlib(conf: TypeOptions, version: WdlVersion) {
   private val unify = Unification(conf)
 
   // Some functions are overloaded and can take several kinds of arguments.
@@ -158,8 +156,7 @@ case class Stdlib(conf: TypeOptions, version: WdlVersion, docSourceUrl: Option[U
   // evaluate the output type of a function. This may require calculation because
   // some functions are polymorphic in their inputs.
   private def evalOnePrototype(funcDesc: T_Function,
-                               inputTypes: Vector[T],
-                               textSource: TextSource): Option[(T, T_Function)] = {
+                               inputTypes: Vector[T]): Either[Option[(T, T_Function)], String] = {
     val arity = inputTypes.size
     val args = (arity, funcDesc) match {
       case (0, T_Function0(_, _))                   => Vector.empty
@@ -167,24 +164,24 @@ case class Stdlib(conf: TypeOptions, version: WdlVersion, docSourceUrl: Option[U
       case (2, T_Function2(_, arg1, arg2, _))       => Vector(arg1, arg2)
       case (3, T_Function3(_, arg1, arg2, arg3, _)) => Vector(arg1, arg2, arg3)
       case (_, _) =>
-        return None
+        return Left(None)
     }
     try {
       val (_, ctx) = unify.unifyFunctionArguments(args, inputTypes, Map.empty)
-      val t = unify.substitute(funcDesc.output, ctx, textSource, docSourceUrl)
-      Some((t, funcDesc))
+      unify.substitute(funcDesc.output, ctx) match {
+        case Left(t)         => Left(Some((t, funcDesc)))
+        case Right(errorMsg) => Right(errorMsg)
+      }
     } catch {
       case _: TypeUnificationException =>
-        None
+        Left(None)
     }
   }
 
-  def apply(funcName: String, inputTypes: Vector[T], textSource: TextSource): (T, T_Function) = {
+  def apply(funcName: String, inputTypes: Vector[T]): Either[(T, T_Function), String] = {
     val candidates = funcProtoMap.get(funcName) match {
       case None =>
-        throw new TypeException(s"No function named ${funcName} in the standard library",
-                                textSource,
-                                docSourceUrl)
+        return Right(s"No function named ${funcName} in the standard library")
       case Some(protoVec) =>
         protoVec
     }
@@ -192,19 +189,22 @@ case class Stdlib(conf: TypeOptions, version: WdlVersion, docSourceUrl: Option[U
     // The function may be overloaded, taking several types of inputs. Try to
     // match all of them against the input.
     val allCandidatePrototypes: Vector[Option[(T, T_Function)]] = candidates.map {
-      evalOnePrototype(_, inputTypes, textSource)
+      evalOnePrototype(_, inputTypes) match {
+        case Left(result)    => result
+        case Right(errorMsg) => return Right(errorMsg)
+      }
     }
     val results: Vector[(T, T_Function)] = allCandidatePrototypes.flatten
     results.size match {
       case 0 =>
         val inputsStr = inputTypes.map(Util.typeToString).mkString("\n")
         val candidatesStr = candidates.map(Util.typeToString(_)).mkString("\n")
-        throw new TypeException(s"""|Invoking stdlib function ${funcName} with badly typed arguments
-                                    |${candidatesStr}
-                                    |inputs: ${inputsStr}
-                                    |""".stripMargin, textSource, docSourceUrl)
+        Right(s"""|Invoking stdlib function ${funcName} with badly typed arguments
+                  |${candidatesStr}
+                  |inputs: ${inputsStr}
+                  |""".stripMargin)
       case 1 =>
-        results.head
+        Left(results.head)
       case n =>
         // Match more than one prototype. If they all have the same output type, then it doesn't matter
         // though.
@@ -214,13 +214,11 @@ case class Stdlib(conf: TypeOptions, version: WdlVersion, docSourceUrl: Option[U
               Util.typeToString(funcSig)
           }
           .mkString("\n")
-        val msg =
-          s"""|Call to ${funcName} matches ${n} prototypes
-              |inputTypes: ${inputTypes}
-              |prototypes:
-              |${prototypeDescriptions}
-              |""".stripMargin
-        throw new TypeException(msg, textSource, docSourceUrl)
+        Right(s"""|Call to ${funcName} matches ${n} prototypes
+                  |inputTypes: ${inputTypes}
+                  |prototypes:
+                  |${prototypeDescriptions}
+                  |""".stripMargin)
     }
   }
 }

--- a/src/main/scala/wdlTools/types/TypeInfer.scala
+++ b/src/main/scala/wdlTools/types/TypeInfer.scala
@@ -807,7 +807,7 @@ case class TypeInfer(conf: TypeOptions) {
         if (errorAsException) {
           throw new TypeException(msg, expr.text, ctx.docSourceUrl)
         } else {
-          TAT.MetaError(msg)
+          TAT.MetaInvalid(msg)
         }
     }
   }
@@ -831,7 +831,7 @@ case class TypeInfer(conf: TypeOptions) {
             if (errorAsException) {
               throw new TypeException(msg, kv.text, ctx.docSourceUrl)
             } else {
-              TAT.MetaError(msg)
+              TAT.MetaInvalid(msg)
             }
           }
           kv.id -> metaValue
@@ -1291,7 +1291,7 @@ case class TypeInfer(conf: TypeOptions) {
           }
           val name = iStat.name.map(_.value)
           val addr = iStat.addr.value
-          val actualName = name.getOrElse(UUtil.getUrlFileName(addr).replace(".wdl", ""))
+          val actualName = name.getOrElse(UUtil.getFilename(addr).replace(".wdl", ""))
           val importDoc =
             TAT.ImportDoc(name, T_DocumentDef(actualName), aliases, addr, iDoc, iStat.text)
 

--- a/src/main/scala/wdlTools/types/TypeInfer.scala
+++ b/src/main/scala/wdlTools/types/TypeInfer.scala
@@ -9,11 +9,14 @@ import wdlTools.types.WdlTypes._
 import wdlTools.types.Util.{isPrimitive, typeToString, exprToString}
 import wdlTools.types.{TypedAbstractSyntax => TAT}
 import wdlTools.util.TypeCheckingRegime._
-import wdlTools.util.{Options, Util => UUtil}
+import wdlTools.util.{Util => UUtil}
 
-case class TypeInfer(conf: Options) {
+case class TypeInfer(conf: TypeOptions) {
   private val unify = Unification(conf)
   private val regime = conf.typeChecking
+  // whether to throw an Exception when encountering a type error (true) or
+  // to generate a T_Error type (false)
+  //private val errorAsException = conf.errorAsException
 
   // A group of bindings. This is typically a part of the context. For example,
   // the body of a scatter.

--- a/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
+++ b/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
@@ -1,8 +1,9 @@
 package wdlTools.types
 
 import java.net.URL
+
 import wdlTools.syntax.{CommentMap, TextSource, WdlVersion}
-import wdlTools.types.WdlTypes
+import wdlTools.types.WdlTypes.T_Error
 
 // A tree representing a WDL program with all of the types in place.
 object TypedAbstractSyntax {
@@ -25,6 +26,7 @@ object TypedAbstractSyntax {
   }
 
   // values
+  case class ValueError(wdlType: T_Error, text: TextSource) extends Expr
   case class ValueNull(wdlType: WdlType, text: TextSource) extends Expr
   case class ValueBoolean(value: Boolean, wdlType: WdlType, text: TextSource) extends Expr
   case class ValueInt(value: Int, wdlType: WdlType, text: TextSource) extends Expr

--- a/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
+++ b/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
@@ -148,7 +148,7 @@ object TypedAbstractSyntax {
   case class MetaArray(value: Vector[MetaValue]) extends MetaValue
   // indicates the original meta value is invalid
   // this is only used when it not possible to generate a "real" Expr with a T_Error wdlType
-  case class MetaError(message: String) extends MetaValue
+  case class MetaInvalid(message: String) extends MetaValue
 
   // the parameter sections have mappings from keys to json-like objects
   case class ParameterMetaSection(kvs: Map[String, MetaValue], text: TextSource) extends Element

--- a/src/main/scala/wdlTools/types/TypedAbstractSyntaxTreeWalker.scala
+++ b/src/main/scala/wdlTools/types/TypedAbstractSyntaxTreeWalker.scala
@@ -1,0 +1,486 @@
+package wdlTools.types
+
+import java.net.URL
+
+import wdlTools.types.TypedAbstractSyntaxTreeVisitor.VisitorContext
+import wdlTools.types.TypedAbstractSyntax._
+import wdlTools.types.WdlTypes._
+import wdlTools.util.Options
+
+import scala.annotation.tailrec
+import scala.reflect.ClassTag
+
+class TypedAbstractSyntaxTreeVisitor {
+  type WdlType = WdlTypes.T
+
+  def visitInvalid[P <: Element](reason: String,
+                                 originalType: Option[T],
+                                 parent: VisitorContext[P]): Unit = {}
+
+  def visitDocument(ctx: VisitorContext[Document]): Unit = {}
+
+  /**
+    * Visit a name in the WDL document's namespace. Does not visit "hidden" names (e.g. a call name
+    * is hidden when it has an alias - the alias is the "visible" name in the document's namespace).
+    */
+  def visitName[P <: Element](name: String, parent: VisitorContext[P]): Unit = {}
+
+  /**
+    * Visit a key of a metadata, runtime, or hints section.
+    */
+  def visitKey[P <: Element](key: String, parent: VisitorContext[P]): Unit = {}
+
+  def visitVersion(ctx: VisitorContext[Version]): Unit = {}
+
+  /**
+    * `name` is the actual import name - either the alias or the name of the WDL file
+    * without the '.wdl' extension
+    */
+  def visitImportName(name: String, parent: VisitorContext[ImportDoc]): Unit = {}
+
+  def visitImportAlias(ctx: VisitorContext[ImportAlias]): Unit = {}
+
+  def visitImportDoc(ctx: VisitorContext[ImportDoc]): Unit = {}
+
+  def visitStructMember(name: String,
+                        wdlType: WdlType,
+                        parent: VisitorContext[StructDefinition]): Unit = {}
+
+  def visitStruct(ctx: VisitorContext[StructDefinition]): Unit = {}
+
+  def visitExpression(ctx: VisitorContext[Expr]): Unit = {}
+
+  /**
+    * By default, visitExpression does not traverse compound expressions.
+    * This method can be called from an overriding visitExpression to do so.
+    */
+  def traverseExpression(ctx: VisitorContext[Expr]): Unit = {
+    val exprs: Vector[Expr] = ctx.element match {
+      case ExprInvalid(T_Invalid(reason, originalType), _, _) =>
+        visitInvalid(reason, originalType, ctx)
+        Vector.empty
+      case e: Expr if e.wdlType.isInstanceOf[Invalid] =>
+        e.wdlType match {
+          case inv: Invalid =>
+            visitInvalid(inv.reason, inv.originalType, ctx)
+            Vector.empty
+        }
+      case ExprCompoundString(value, _, _)              => value
+      case ExprPair(l, r, _, _)                         => Vector(l, r)
+      case ExprArray(value, _, _)                       => value
+      case ExprMap(value, _, _)                         => value.keys.toVector ++ value.values.toVector
+      case ExprObject(value, _, _)                      => value.values.toVector
+      case ExprPlaceholderEqual(t, f, value, _, _)      => Vector(t, f, value)
+      case ExprPlaceholderDefault(default, value, _, _) => Vector(default, value)
+      case ExprPlaceholderSep(sep, value, _, _)         => Vector(sep, value)
+      case ExprUniraryPlus(value, _, _)                 => Vector(value)
+      case ExprUniraryMinus(value, _, _)                => Vector(value)
+      case ExprNegate(value, _, _)                      => Vector(value)
+      case ExprLor(a, b, _, _)                          => Vector(a, b)
+      case ExprLand(a, b, _, _)                         => Vector(a, b)
+      case ExprEqeq(a, b, _, _)                         => Vector(a, b)
+      case ExprLt(a, b, _, _)                           => Vector(a, b)
+      case ExprGte(a, b, _, _)                          => Vector(a, b)
+      case ExprNeq(a, b, _, _)                          => Vector(a, b)
+      case ExprLte(a, b, _, _)                          => Vector(a, b)
+      case ExprGt(a, b, _, _)                           => Vector(a, b)
+      case ExprAdd(a, b, _, _)                          => Vector(a, b)
+      case ExprSub(a, b, _, _)                          => Vector(a, b)
+      case ExprMod(a, b, _, _)                          => Vector(a, b)
+      case ExprMul(a, b, _, _)                          => Vector(a, b)
+      case ExprDivide(a, b, _, _)                       => Vector(a, b)
+      case ExprAt(array, index, _, _)                   => Vector(array, index)
+      case ExprIfThenElse(cond, tBranch, fBranch, _, _) => Vector(cond, tBranch, fBranch)
+      case ExprApply(_, _, elements, _, _)              => elements
+      case ExprGetName(e, _, _, _)                      => Vector(e)
+      case _                                            => Vector.empty
+    }
+    exprs.foreach { e =>
+      traverseExpression(ctx.createChildContext[Expr](e))
+    }
+  }
+
+  def visitDeclaration(ctx: VisitorContext[Declaration]): Unit = {}
+
+  def visitInputSection(ctx: VisitorContext[InputSection]): Unit = {}
+
+  def visitOutputSection(ctx: VisitorContext[OutputSection]): Unit = {}
+
+  def visitCallName(actualName: String,
+                    fullyQualifiedName: String,
+                    alias: Option[String],
+                    parent: VisitorContext[Call]): Unit = {}
+
+  def visitCall(ctx: VisitorContext[Call]): Unit = {}
+
+  def visitScatter(ctx: VisitorContext[Scatter]): Unit = {}
+
+  def visitConditional(ctx: VisitorContext[Conditional]): Unit = {}
+
+  def visitBody[P <: Element](body: Vector[WorkflowElement], parent: VisitorContext[P]): Unit = {}
+
+  def visitMetaValue(ctx: VisitorContext[MetaValue]): Unit = {}
+
+  def visitMetaKV(key: String, value: MetaValue, parent: VisitorContext[MetaSection]): Unit = {}
+
+  def visitMetaSection(ctx: VisitorContext[MetaSection]): Unit = {}
+
+  def visitParameterMetaKV(key: String,
+                           value: MetaValue,
+                           parent: VisitorContext[ParameterMetaSection]): Unit = {}
+
+  def visitParameterMetaSection(ctx: VisitorContext[ParameterMetaSection]): Unit = {}
+
+  def visitWorkflow(ctx: VisitorContext[Workflow]): Unit = {}
+
+  def visitCommandSection(ctx: VisitorContext[CommandSection]): Unit = {}
+
+  def visitRuntimeKV(key: String, value: Expr, parent: VisitorContext[RuntimeSection]): Unit = {}
+
+  def visitRuntimeSection(ctx: VisitorContext[RuntimeSection]): Unit = {}
+
+  def visitHintsKV(key: String, value: Expr, parent: VisitorContext[HintsSection]): Unit = {}
+
+  def visitHintsSection(ctx: VisitorContext[HintsSection]): Unit = {}
+
+  def visitTask(ctx: VisitorContext[Task]): Unit = {}
+}
+
+object TypedAbstractSyntaxTreeVisitor {
+  case class VisitorContext[T <: Element](element: T, parent: Option[VisitorContext[_]] = None) {
+    lazy val docSourceUrl: URL = element match {
+      case d: Document => d.docSourceUrl
+      case _           => findAncestor[Document].get.element.docSourceUrl
+    }
+
+    def createChildContext[C <: Element](element: C): VisitorContext[C] = {
+      VisitorContext[C](element, Some(this.asInstanceOf[VisitorContext[Element]]))
+    }
+
+    /**
+      * Get the immediate parent of this context, or throw an exception if this context
+      * doesn't have a parent
+      * @tparam P parent element type
+      * @return
+      */
+    def getParent[P <: Element]: VisitorContext[P] = {
+      if (parent.isDefined) {
+        parent.get.asInstanceOf[VisitorContext[P]]
+      } else {
+        throw new Exception("VisitorContext does not have a parent")
+      }
+    }
+
+    /**
+      * Finds the first ancestor of this context that is an executable type
+      * (task or workflow).
+      */
+    def findAncestorExecutable: Option[Callable] = {
+      @tailrec
+      def getExecutable(ctx: VisitorContext[_]): Option[Callable] = {
+        ctx.element match {
+          case t: Task                   => Some(t)
+          case w: Workflow               => Some(w)
+          case _ if ctx.parent.isDefined => getExecutable(ctx.parent.get)
+          case _                         => None
+        }
+      }
+      getExecutable(this)
+    }
+
+    /**
+      * Finds the first ancestor of this context of the specified type.
+      * @param tag class tag for P
+      * @tparam P ancestor element type to find
+      * @return
+      */
+    def findAncestor[P <: Element](implicit tag: ClassTag[P]): Option[VisitorContext[P]] = {
+      if (parent.isDefined) {
+        @tailrec
+        def find(ctx: VisitorContext[_]): Option[VisitorContext[P]] = {
+          ctx.element match {
+            case _: P                      => Some(ctx.asInstanceOf[VisitorContext[P]])
+            case _ if ctx.parent.isDefined => find(ctx.parent.get)
+            case _                         => None
+          }
+        }
+        find(this.parent.get)
+      } else {
+        None
+      }
+    }
+  }
+}
+
+class TypedAbstractSyntaxTreeWalker(opts: Options) extends TypedAbstractSyntaxTreeVisitor {
+  override def visitDocument(ctx: VisitorContext[Document]): Unit = {
+    visitVersion(ctx.createChildContext[Version](ctx.element.version))
+
+    ctx.element.elements.collect { case imp: ImportDoc => imp }.foreach { imp =>
+      visitImportDoc(ctx.createChildContext[ImportDoc](imp))
+    }
+
+    ctx.element.elements.collect { case struct: StructDefinition => struct }.foreach { imp =>
+      visitStruct(ctx.createChildContext[StructDefinition](imp))
+    }
+
+    if (ctx.element.workflow.isDefined) {
+      visitWorkflow(ctx.createChildContext[Workflow](ctx.element.workflow.get))
+    }
+
+    ctx.element.elements.collect { case task: Task => task }.foreach { task =>
+      visitTask(ctx.createChildContext[Task](task))
+    }
+  }
+
+  override def visitImportName(name: String, parent: VisitorContext[ImportDoc]): Unit = {
+    visitName[ImportDoc](name, parent)
+  }
+
+  override def visitImportAlias(ctx: VisitorContext[ImportAlias]): Unit = {
+    ctx.element.referee match {
+      case T_StructInvalid(reason, originalStructType) =>
+        visitInvalid(reason, Some(originalStructType), ctx)
+      case _ => visitName[ImportAlias](ctx.element.id2, ctx)
+    }
+  }
+
+  override def visitImportDoc(ctx: VisitorContext[ImportDoc]): Unit = {
+    ctx.element.wdlType match {
+      case T_DocumentInvalid(reason, originalDocumentType) =>
+        visitInvalid(reason, Some(originalDocumentType), ctx)
+      case doc: T_DocumentDef =>
+        visitImportName(doc.name, ctx)
+        ctx.element.aliases.foreach { alias =>
+          visitImportAlias(ctx.createChildContext[ImportAlias](alias))
+        }
+        if (opts.followImports) {
+          visitDocument(ctx.createChildContext[Document](ctx.element.doc))
+        }
+    }
+  }
+
+  override def visitStruct(ctx: VisitorContext[StructDefinition]): Unit = {
+    ctx.element.wdlType match {
+      case T_StructInvalid(reason, originalStructType) =>
+        visitInvalid(reason, Some(originalStructType), ctx)
+      case _ =>
+        visitName[StructDefinition](ctx.element.name, ctx)
+        ctx.element.members.foreach {
+          case (key, wdlType) => visitStructMember(key, wdlType, ctx)
+        }
+    }
+  }
+
+  override def visitExpression(ctx: VisitorContext[Expr]): Unit = {
+    ctx.element match {
+      case ExprInvalid(T_Invalid(reason, originalType), _, _) =>
+        visitInvalid(reason, originalType, ctx)
+      case e: Expr if e.wdlType.isInstanceOf[Invalid] =>
+        e.wdlType match {
+          case inv: Invalid => visitInvalid(inv.reason, inv.originalType, ctx)
+        }
+      case _ => ()
+    }
+  }
+
+  override def visitDeclaration(ctx: VisitorContext[Declaration]): Unit = {
+    ctx.element.wdlType match {
+      case inv: Invalid => visitInvalid(inv.reason, inv.originalType, ctx)
+      case _ =>
+        visitName[Declaration](ctx.element.name, ctx)
+        if (ctx.element.expr.isDefined) {
+          visitExpression(ctx.createChildContext[Expr](ctx.element.expr.get))
+        }
+    }
+  }
+
+  override def visitInputSection(ctx: VisitorContext[InputSection]): Unit = {
+    ctx.element.declarations.foreach { decl =>
+      visitDeclaration(ctx.createChildContext[Declaration](decl))
+    }
+  }
+
+  override def visitOutputSection(ctx: VisitorContext[OutputSection]): Unit = {
+    ctx.element.declarations.foreach { decl =>
+      visitDeclaration(ctx.createChildContext[Declaration](decl))
+    }
+  }
+
+  override def visitCallName(actualName: String,
+                             fullyQualifiedName: String,
+                             alias: Option[String],
+                             parent: VisitorContext[Call]): Unit = {
+    visitName[Call](alias.getOrElse(actualName), parent)
+  }
+
+  override def visitCall(ctx: VisitorContext[Call]): Unit = {
+    ctx.element.wdlType match {
+      case T_CallInvalid(_, reason, originalType, _) => visitInvalid(reason, originalType, ctx)
+      case _ =>
+        visitCallName(ctx.element.actualName,
+                      ctx.element.fullyQualifiedName,
+                      ctx.element.alias,
+                      ctx)
+        ctx.element.inputs.foreach { inp =>
+          visitExpression(ctx.createChildContext[Expr](inp._2))
+        }
+        ctx.element.afters.foreach {
+          case T_CallInvalid(_, reason, originalType, _) => visitInvalid(reason, originalType, ctx)
+        }
+    }
+  }
+
+  override def visitScatter(ctx: VisitorContext[Scatter]): Unit = {
+    ctx.element.wdlType match {
+      case inv: Invalid => visitInvalid(inv.reason, inv.originalType, ctx)
+      case _ =>
+        visitName[Scatter](ctx.element.identifier, ctx)
+        visitExpression(ctx.createChildContext[Expr](ctx.element.expr))
+        visitBody[Scatter](ctx.element.body, ctx)
+    }
+  }
+
+  override def visitConditional(ctx: VisitorContext[Conditional]): Unit = {
+    visitExpression(ctx.createChildContext[Expr](ctx.element.expr))
+    visitBody[Conditional](ctx.element.body, ctx)
+  }
+
+  override def visitBody[P <: Element](body: Vector[WorkflowElement],
+                                       parent: VisitorContext[P]): Unit = {
+    body.foreach {
+      case decl: Declaration => visitDeclaration(parent.createChildContext[Declaration](decl))
+      case call: Call        => visitCall(parent.createChildContext[Call](call))
+      case scatter: Scatter  => visitScatter(parent.createChildContext[Scatter](scatter))
+      case conditional: Conditional =>
+        visitConditional(parent.createChildContext[Conditional](conditional))
+      case other => throw new Exception(s"Unexpected workflow element ${other}")
+    }
+  }
+
+  override def visitMetaValue(ctx: VisitorContext[MetaValue]): Unit = {
+    ctx.element match {
+      case MetaInvalid(reason) => visitInvalid(reason, None, ctx)
+      case _                   => ()
+    }
+  }
+
+  override def visitMetaKV(key: String,
+                           value: MetaValue,
+                           parent: VisitorContext[MetaSection]): Unit = {
+    visitKey(key, parent)
+    visitMetaValue(parent.createChildContext[MetaValue](value))
+  }
+
+  override def visitMetaSection(ctx: VisitorContext[MetaSection]): Unit = {
+    ctx.element.kvs.foreach {
+      case (key, value) => visitMetaKV(key, value, ctx)
+    }
+  }
+
+  override def visitParameterMetaKV(key: String,
+                                    value: MetaValue,
+                                    parent: VisitorContext[ParameterMetaSection]): Unit = {
+    visitKey(key, parent)
+    visitMetaValue(parent.createChildContext[MetaValue](value))
+  }
+
+  override def visitParameterMetaSection(ctx: VisitorContext[ParameterMetaSection]): Unit = {
+    ctx.element.kvs.foreach {
+      case (key, value) => visitParameterMetaKV(key, value, ctx)
+    }
+  }
+
+  override def visitWorkflow(ctx: VisitorContext[Workflow]): Unit = {
+    ctx.element.wdlType match {
+      case T_WorkflowInvalid(reason, originalWorkflowType) =>
+        visitInvalid(reason, Some(originalWorkflowType), ctx)
+      case _ =>
+        visitName[Workflow](ctx.element.name, ctx)
+        if (ctx.element.input.isDefined) {
+          visitInputSection(ctx.createChildContext[InputSection](ctx.element.input.get))
+        }
+        visitBody[Workflow](ctx.element.body, ctx)
+        if (ctx.element.output.isDefined) {
+          visitOutputSection(ctx.createChildContext[OutputSection](ctx.element.output.get))
+        }
+        if (ctx.element.meta.isDefined) {
+          visitMetaSection(ctx.createChildContext[MetaSection](ctx.element.meta.get))
+        }
+        if (ctx.element.parameterMeta.isDefined) {
+          visitParameterMetaSection(
+              ctx.createChildContext[ParameterMetaSection](ctx.element.parameterMeta.get)
+          )
+        }
+    }
+  }
+
+  override def visitCommandSection(ctx: VisitorContext[CommandSection]): Unit = {
+    ctx.element.parts.foreach { expr =>
+      visitExpression(ctx.createChildContext[Expr](expr))
+    }
+  }
+
+  override def visitRuntimeKV(key: String,
+                              value: Expr,
+                              parent: VisitorContext[RuntimeSection]): Unit = {
+    visitName(key, parent)
+    visitExpression(parent.createChildContext[Expr](value))
+  }
+
+  override def visitRuntimeSection(ctx: VisitorContext[RuntimeSection]): Unit = {
+    ctx.element.kvs.foreach {
+      case (key, value) => visitRuntimeKV(key, value, ctx)
+    }
+  }
+
+  override def visitHintsKV(key: String,
+                            value: Expr,
+                            parent: VisitorContext[HintsSection]): Unit = {
+    visitName(key, parent)
+    visitExpression(parent.createChildContext[Expr](value))
+  }
+
+  override def visitHintsSection(ctx: VisitorContext[HintsSection]): Unit = {
+    ctx.element.kvs.foreach {
+      case (key, value) => visitHintsKV(key, value, ctx)
+    }
+  }
+
+  override def visitTask(ctx: VisitorContext[Task]): Unit = {
+    ctx.element.wdlType match {
+      case T_TaskInvalid(reason, originalTaskType) =>
+        visitInvalid(reason, Some(originalTaskType), ctx)
+      case _ =>
+        visitName[Task](ctx.element.name, ctx)
+        if (ctx.element.input.isDefined) {
+          visitInputSection(ctx.createChildContext[InputSection](ctx.element.input.get))
+        }
+        ctx.element.declarations.foreach { decl =>
+          visitDeclaration(ctx.createChildContext[Declaration](decl))
+        }
+        visitCommandSection(ctx.createChildContext[CommandSection](ctx.element.command))
+        if (ctx.element.output.isDefined) {
+          visitOutputSection(ctx.createChildContext[OutputSection](ctx.element.output.get))
+        }
+        if (ctx.element.runtime.isDefined) {
+          visitRuntimeSection(ctx.createChildContext[RuntimeSection](ctx.element.runtime.get))
+        }
+        if (ctx.element.hints.isDefined) {
+          visitHintsSection(ctx.createChildContext[HintsSection](ctx.element.hints.get))
+        }
+        if (ctx.element.meta.isDefined) {
+          visitMetaSection(ctx.createChildContext[MetaSection](ctx.element.meta.get))
+        }
+        if (ctx.element.parameterMeta.isDefined) {
+          visitParameterMetaSection(
+              ctx.createChildContext[ParameterMetaSection](ctx.element.parameterMeta.get)
+          )
+        }
+    }
+  }
+
+  def apply(doc: Document): Unit = {
+    visitDocument(VisitorContext[Document](doc))
+  }
+}

--- a/src/main/scala/wdlTools/types/Unification.scala
+++ b/src/main/scala/wdlTools/types/Unification.scala
@@ -5,10 +5,9 @@ import java.net.URL
 import wdlTools.syntax.TextSource
 import wdlTools.types.Util.{typeToString, isPrimitive}
 import wdlTools.types.WdlTypes._
-import wdlTools.util.Options
 import wdlTools.util.TypeCheckingRegime._
 
-case class Unification(conf: Options) {
+case class Unification(conf: TypeOptions) {
   // Type checking rules. Are we lenient or strict in checking coercions?
   private val regime = conf.typeChecking
 

--- a/src/main/scala/wdlTools/types/Unification.scala
+++ b/src/main/scala/wdlTools/types/Unification.scala
@@ -8,7 +8,7 @@ import wdlTools.types.WdlTypes._
 import wdlTools.util.Options
 import wdlTools.util.TypeCheckingRegime._
 
-case class Unification(conf: Options) {
+case class Unification(conf: Options, docSourceUrl: Option[URL]) {
   // Type checking rules. Are we lenient or strict in checking coercions?
   private val regime = conf.typeChecking
 
@@ -60,11 +60,12 @@ case class Unification(conf: Options) {
     }
   }
 
-  def isCoercibleTo(left: T, right: T): Boolean = {
+  @throws(classOf[TypeException])
+  def isCoercibleTo(left: T, right: T, textSource: TextSource): Boolean = {
     if (left.isInstanceOf[T_Identifier])
-      throw new Exception(s"${left} should not appear here")
+      throw new TypeException(s"${left} should not appear here", textSource, docSourceUrl)
     if (right.isInstanceOf[T_Identifier])
-      throw new Exception(s"${right} should not appear here")
+      throw new TypeException(s"${right} should not appear here", textSource, docSourceUrl)
 
     (left, right) match {
       // List of special cases goes here
@@ -97,77 +98,84 @@ case class Unification(conf: Options) {
   // we need to figure out that X is Int.
   //
   //
-  def unify(x: T, y: T, ctx: TypeUnificationContext): (T, TypeUnificationContext) = {
-    (x, y) match {
-      // base case, primitive types
-      case (_, _) if isPrimitive(x) && isPrimitive(y) && isCoercibleTo(x, y) =>
-        (x, ctx)
-      case (T_Any, T_Any) => (T_Any, ctx)
-      case (x, T_Any)     => (x, ctx)
-      case (T_Any, x)     => (x, ctx)
+  @throws(classOf[TypeUnificationException])
+  def unify(x: T,
+            y: T,
+            ctx: TypeUnificationContext,
+            textSource: TextSource): (T, TypeUnificationContext) = {
+    def unifyRecursive(x: T, y: T, ctx: TypeUnificationContext): (T, TypeUnificationContext) = {
+      (x, y) match {
+        // base case, primitive types
+        case (_, _) if isPrimitive(x) && isPrimitive(y) && isCoercibleTo(x, y, textSource) =>
+          (x, ctx)
+        case (T_Any, T_Any) => (T_Any, ctx)
+        case (x, T_Any)     => (x, ctx)
+        case (T_Any, x)     => (x, ctx)
 
-      case (T_Object, T_Object)    => (T_Object, ctx)
-      case (T_Object, _: T_Struct) => (T_Object, ctx)
+        case (T_Object, T_Object)    => (T_Object, ctx)
+        case (T_Object, _: T_Struct) => (T_Object, ctx)
 
-      case (T_Optional(l), T_Optional(r)) =>
-        val (t, ctx2) = unify(l, r, ctx)
-        (T_Optional(t), ctx2)
+        case (T_Optional(l), T_Optional(r)) =>
+          val (t, ctx2) = unifyRecursive(l, r, ctx)
+          (T_Optional(t), ctx2)
 
-      // These two cases are really questionable to me. We are allowing an X to
-      // become an X?
-      case (T_Optional(l), r) =>
-        val (t, ctx2) = unify(l, r, ctx)
-        (T_Optional(t), ctx2)
-      case (l, T_Optional(r)) =>
-        val (t, ctx2) = unify(l, r, ctx)
-        (T_Optional(t), ctx2)
+        // These two cases are really questionable to me. We are allowing an X to
+        // become an X?
+        case (T_Optional(l), r) =>
+          val (t, ctx2) = unifyRecursive(l, r, ctx)
+          (T_Optional(t), ctx2)
+        case (l, T_Optional(r)) =>
+          val (t, ctx2) = unifyRecursive(l, r, ctx)
+          (T_Optional(t), ctx2)
 
-      case (T_Array(l, _), T_Array(r, _)) =>
-        val (t, ctx2) = unify(l, r, ctx)
-        (T_Array(t), ctx2)
-      case (T_Map(k1, v1), T_Map(k2, v2)) =>
-        val (kt, ctx2) = unify(k1, k2, ctx)
-        val (vt, ctx3) = unify(v1, v2, ctx2)
-        (T_Map(kt, vt), ctx3)
-      case (T_Pair(l1, r1), T_Pair(l2, r2)) =>
-        val (lt, ctx2) = unify(l1, l2, ctx)
-        val (rt, ctx3) = unify(r1, r2, ctx2)
-        (T_Pair(lt, rt), ctx3)
-      case (T_Identifier(l), T_Identifier(r)) if l == r =>
-        // a user defined type
-        (T_Identifier(l), ctx)
-      case (T_Var(i), T_Var(j)) if i == j =>
-        (T_Var(i), ctx)
+        case (T_Array(l, _), T_Array(r, _)) =>
+          val (t, ctx2) = unifyRecursive(l, r, ctx)
+          (T_Array(t), ctx2)
+        case (T_Map(k1, v1), T_Map(k2, v2)) =>
+          val (kt, ctx2) = unifyRecursive(k1, k2, ctx)
+          val (vt, ctx3) = unifyRecursive(v1, v2, ctx2)
+          (T_Map(kt, vt), ctx3)
+        case (T_Pair(l1, r1), T_Pair(l2, r2)) =>
+          val (lt, ctx2) = unifyRecursive(l1, l2, ctx)
+          val (rt, ctx3) = unifyRecursive(r1, r2, ctx2)
+          (T_Pair(lt, rt), ctx3)
+        case (T_Identifier(l), T_Identifier(r)) if l == r =>
+          // a user defined type
+          (T_Identifier(l), ctx)
+        case (T_Var(i), T_Var(j)) if i == j =>
+          (T_Var(i), ctx)
 
-      case (a: T_Var, b: T_Var) =>
-        // found a type equality between two variables
-        val ctx3: TypeUnificationContext = (ctx.get(a), ctx.get(b)) match {
-          case (None, None) =>
-            ctx + (a -> b)
-          case (None, Some(z)) =>
-            ctx + (a -> z)
-          case (Some(z), None) =>
-            ctx + (b -> z)
-          case (Some(z), Some(w)) =>
-            val (_, ctx2) = unify(z, w, ctx)
-            ctx2
-        }
-        (ctx3(a), ctx3)
+        case (a: T_Var, b: T_Var) =>
+          // found a type equality between two variables
+          val ctx3: TypeUnificationContext = (ctx.get(a), ctx.get(b)) match {
+            case (None, None) =>
+              ctx + (a -> b)
+            case (None, Some(z)) =>
+              ctx + (a -> z)
+            case (Some(z), None) =>
+              ctx + (b -> z)
+            case (Some(z), Some(w)) =>
+              val (_, ctx2) = unifyRecursive(z, w, ctx)
+              ctx2
+          }
+          (ctx3(a), ctx3)
 
-      case (a: T_Var, z) =>
-        if (!(ctx contains a)) {
-          // found a binding for a type variable
-          (z, ctx + (a -> z))
-        } else {
-          // a binding already exists, choose the more general
-          // type
-          val w = ctx(a)
-          unify(w, z, ctx)
-        }
+        case (a: T_Var, z) =>
+          if (!(ctx contains a)) {
+            // found a binding for a type variable
+            (z, ctx + (a -> z))
+          } else {
+            // a binding already exists, choose the more general
+            // type
+            val w = ctx(a)
+            unifyRecursive(w, z, ctx)
+          }
 
-      case _ =>
-        throw new TypeUnificationException(s"Types $x and $y do not match")
+        case _ =>
+          throw new TypeUnificationException(s"Types $x and $y do not match")
+      }
     }
+    unifyRecursive(x, y, ctx)
   }
 
   // Unify a set of type pairs, and return a solution for the type
@@ -188,37 +196,39 @@ case class Unification(conf: Options) {
   //    T_Var(0) -> T_Int
   //    T_Var(1) -> T_String
   //
+  @throws(classOf[TypeUnificationException])
   def unifyFunctionArguments(x: Vector[T],
                              y: Vector[T],
-                             ctx: TypeUnificationContext): (Vector[T], TypeUnificationContext) = {
+                             ctx: TypeUnificationContext,
+                             textSource: TextSource): (Vector[T], TypeUnificationContext) = {
     (x zip y).foldLeft((Vector.empty[T], ctx)) {
       case ((tVec, ctx), (lt, rt)) =>
-        val (t, ctx2) = unify(lt, rt, ctx)
+        val (t, ctx2) = unify(lt, rt, ctx, textSource)
         (tVec :+ t, ctx2)
     }
   }
 
   // Unify elements in a collection. For example, a vector of values.
+  @throws(classOf[TypeUnificationException])
   def unifyCollection(tVec: Iterable[T],
-                      ctx: TypeUnificationContext): (T, TypeUnificationContext) = {
+                      ctx: TypeUnificationContext,
+                      textSource: TextSource): (T, TypeUnificationContext) = {
     assert(tVec.nonEmpty)
     tVec.tail.foldLeft((tVec.head, ctx)) {
       case ((t, ctx), t2) =>
-        unify(t, t2, ctx)
+        unify(t, t2, ctx, textSource)
     }
   }
 
   // substitute the type variables for the values in type 't'
-  def substitute(t: T,
-                 typeBindings: Map[T_Var, T],
-                 srcText: TextSource,
-                 docSourceUrl: Option[URL] = None): T = {
+  @throws(classOf[TypeException])
+  def substitute(t: T, typeBindings: Map[T_Var, T], textSource: TextSource): T = {
     def sub(t: T): T = {
       t match {
         case T_String | T_File | T_Boolean | T_Int | T_Float => t
         case a: T_Var if !(typeBindings contains a) =>
           throw new TypeException(s"type variable ${typeToString(a)} does not have a binding",
-                                  srcText,
+                                  textSource,
                                   docSourceUrl)
         case a: T_Var       => typeBindings(a)
         case x: T_Struct    => x
@@ -230,7 +240,7 @@ case class Unification(conf: Options) {
         case T_Any          => T_Any
         case other =>
           throw new TypeException(s"Type ${typeToString(other)} should not appear in this context",
-                                  srcText,
+                                  textSource,
                                   docSourceUrl)
       }
     }

--- a/src/main/scala/wdlTools/types/Util.scala
+++ b/src/main/scala/wdlTools/types/Util.scala
@@ -24,6 +24,8 @@ object Util {
 
   def typeToString(t: T): String = {
     t match {
+      case T_Error(textSource, reason) =>
+        s"Error at ${textSource}: ${reason.getOrElse("unknown error")}"
       case T_Boolean        => "Boolean"
       case T_Int            => "Int"
       case T_Float          => "Float"

--- a/src/main/scala/wdlTools/types/WdlTypes.scala
+++ b/src/main/scala/wdlTools/types/WdlTypes.scala
@@ -1,13 +1,11 @@
 package wdlTools.types
 
-import wdlTools.syntax.TextSource
-
 // This is the WDL typesystem
 object WdlTypes {
   sealed trait T
 
   // represents an error that occured during type inference
-  case class T_Error(textSource: TextSource, reason: Option[String]) extends T
+  case class T_Error(reason: String) extends T
 
   // primitive types
   case object T_Boolean extends T

--- a/src/main/scala/wdlTools/types/WdlTypes.scala
+++ b/src/main/scala/wdlTools/types/WdlTypes.scala
@@ -1,8 +1,13 @@
 package wdlTools.types
 
+import wdlTools.syntax.TextSource
+
 // This is the WDL typesystem
 object WdlTypes {
   sealed trait T
+
+  // represents an error that occured during type inference
+  case class T_Error(textSource: TextSource, reason: Option[String]) extends T
 
   // primitive types
   case object T_Boolean extends T

--- a/src/main/scala/wdlTools/types/WdlTypes.scala
+++ b/src/main/scala/wdlTools/types/WdlTypes.scala
@@ -5,7 +5,12 @@ object WdlTypes {
   sealed trait T
 
   // represents an error that occured during type inference
-  case class T_Error(reason: String) extends T
+  sealed trait Invalid extends T {
+    val reason: String
+    val originalType: Option[T]
+  }
+
+  case class T_Invalid(reason: String, originalType: Option[T] = None) extends Invalid
 
   // primitive types
   case object T_Boolean extends T
@@ -37,7 +42,20 @@ object WdlTypes {
   case class T_Optional(t: T) extends T
 
   // a user defined structure
-  case class T_Struct(name: String, members: Map[String, T]) extends T
+  sealed trait T_Struct extends T {
+    val name: String
+    val members: Map[String, T]
+  }
+
+  case class T_StructDef(name: String, members: Map[String, T]) extends T_Struct
+
+  case class T_StructInvalid(reason: String, originalStructType: T_Struct)
+      extends T_Struct
+      with Invalid {
+    override val name: String = originalStructType.name
+    override val members: Map[String, T] = originalStructType.members
+    override val originalType: Option[T] = Some(originalStructType)
+  }
 
   // Anything that can be called. Tasks and workflows implement this trait.
   // The inputs are decorated by whether they are optional.
@@ -47,20 +65,61 @@ object WdlTypes {
     val output: Map[String, T]
   }
 
+  // Represents a non-existant callable in a Call node
+  case class T_CallableInvalid(name: String,
+                               reason: String,
+                               originalType: Option[T],
+                               input: Map[String, (T, Boolean)] = Map.empty,
+                               output: Map[String, T] = Map.empty)
+      extends T_Callable
+      with Invalid
+
   // The type of a task.
   //
   // It takes typed-inputs and returns typed-outputs. The boolean flag denotes
   // if input is optional
-  case class T_Task(name: String, input: Map[String, (T, Boolean)], output: Map[String, T])
-      extends T_Callable
+  sealed trait T_Task extends T_Callable
+
+  case class T_TaskDef(name: String, input: Map[String, (T, Boolean)], output: Map[String, T])
+      extends T_Task
+
+  case class T_TaskInvalid(reason: String, originalTaskType: T_Task) extends T_Task with Invalid {
+    override val name: String = originalTaskType.name
+    override val originalType: Option[T] = Some(originalTaskType)
+    override val input: Map[String, (T, Boolean)] = originalTaskType.input
+    override val output: Map[String, T] = originalTaskType.output
+  }
 
   // The type of a workflow.
   // It takes typed-inputs and returns typed-outputs.
-  case class T_Workflow(name: String, input: Map[String, (T, Boolean)], output: Map[String, T])
-      extends T_Callable
+  sealed trait T_Workflow extends T_Callable
+
+  case class T_WorkflowDef(name: String, input: Map[String, (T, Boolean)], output: Map[String, T])
+      extends T_Workflow
+
+  case class T_WorkflowInvalid(reason: String, originalWorkflowType: T_Workflow)
+      extends T_Workflow
+      with Invalid {
+    override val name: String = originalWorkflowType.name
+    override val originalType: Option[T] = Some(originalWorkflowType)
+    override val input: Map[String, (T, Boolean)] = originalWorkflowType.input
+    override val output: Map[String, T] = originalWorkflowType.output
+  }
 
   // Result from calling a task or a workflow.
-  case class T_Call(name: String, output: Map[String, T]) extends T
+  sealed trait T_Call extends T {
+    val name: String
+    val output: Map[String, T]
+  }
+
+  case class T_CallDef(name: String, output: Map[String, T]) extends T_Call
+
+  case class T_CallInvalid(name: String,
+                           reason: String,
+                           originalType: Option[T],
+                           output: Map[String, T] = Map.empty)
+      extends T_Call
+      with Invalid
 
   // A standard library function implemented by the engine.
   sealed trait T_Function extends T {
@@ -86,4 +145,17 @@ object WdlTypes {
   // A function with three arguments. For example:
   // String sub(String, String, String)
   case class T_Function3(name: String, arg1: T, arg2: T, arg3: T, output: T) extends T_Function
+
+  sealed trait T_Document extends T {
+    val name: String
+  }
+
+  case class T_DocumentDef(name: String) extends T_Document
+
+  case class T_DocumentInvalid(reason: String, originalDocumentType: T_Document)
+      extends T_Document
+      with Invalid {
+    override val name: String = originalDocumentType.name
+    override val originalType: Option[T] = Some(originalDocumentType)
+  }
 }

--- a/src/main/scala/wdlTools/types/package.scala
+++ b/src/main/scala/wdlTools/types/package.scala
@@ -1,7 +1,20 @@
 package wdlTools.types
 
 import java.net.URL
+import java.nio.file.Path
+
 import wdlTools.syntax.TextSource
+import wdlTools.util.{Options, TypeCheckingRegime, Verbosity}
+
+/**
+  * @param typeChecking strictness of type-checking
+  */
+case class TypeOptions(override val localDirectories: Vector[Path] = Vector.empty,
+                       override val verbosity: Verbosity.Verbosity = Verbosity.Normal,
+                       override val antlr4Trace: Boolean = false,
+                       typeChecking: TypeCheckingRegime.Value = TypeCheckingRegime.Moderate,
+                       errorAsException: Boolean = false)
+    extends Options(localDirectories, followImports = true, verbosity, antlr4Trace)
 
 // Type error exception
 final class TypeException(message: String) extends Exception(message) {

--- a/src/main/scala/wdlTools/types/package.scala
+++ b/src/main/scala/wdlTools/types/package.scala
@@ -9,12 +9,13 @@ import wdlTools.util.{Options, TypeCheckingRegime, Verbosity}
 /**
   * @param typeChecking strictness of type-checking
   */
-case class TypeOptions(override val localDirectories: Vector[Path] = Vector.empty,
-                       override val verbosity: Verbosity.Verbosity = Verbosity.Normal,
-                       override val antlr4Trace: Boolean = false,
+case class TypeOptions(localDirectories: Vector[Path] = Vector.empty,
+                       followImports: Boolean = true,
+                       verbosity: Verbosity.Verbosity = Verbosity.Normal,
+                       antlr4Trace: Boolean = false,
                        typeChecking: TypeCheckingRegime.Value = TypeCheckingRegime.Moderate,
                        errorAsException: Boolean = false)
-    extends Options(localDirectories, followImports = true, verbosity, antlr4Trace)
+    extends Options
 
 // Type error exception
 final class TypeException(message: String) extends Exception(message) {

--- a/src/main/scala/wdlTools/util/JsonUtil.scala
+++ b/src/main/scala/wdlTools/util/JsonUtil.scala
@@ -1,0 +1,44 @@
+package wdlTools.util
+
+import spray.json._
+
+import scala.io.Source
+
+object JsonUtil {
+  def readJsonSource(src: Source, name: String): Map[String, JsValue] = {
+    try {
+      getFields(src.getLines.mkString(System.lineSeparator).parseJson)
+    } catch {
+      case _: NullPointerException =>
+        throw new Exception(s"Could not open resource ${name}")
+    }
+  }
+
+  def getFields(js: JsValue): Map[String, JsValue] = {
+    js match {
+      case JsObject(fields) => fields
+      case other            => throw new Exception(s"Expected JsObject, got ${other}")
+    }
+  }
+
+  def getValues(js: JsValue): Vector[JsValue] = {
+    js match {
+      case JsArray(values) => values
+      case other           => throw new Exception(s"Expected JsArray, got ${other}")
+    }
+  }
+
+  def getString(js: JsValue): String = {
+    js match {
+      case JsString(value) => value
+      case other           => throw new Exception(s"Expected JsString, got ${other}")
+    }
+  }
+
+  def getInt(js: JsValue): Int = {
+    js match {
+      case JsNumber(value) => value.toInt
+      case other           => throw new Exception(s"Expected JsNumber, got ${other}")
+    }
+  }
+}

--- a/src/main/scala/wdlTools/util/Util.scala
+++ b/src/main/scala/wdlTools/util/Util.scala
@@ -84,6 +84,10 @@ object Util {
     resolved
   }
 
+  def getUrlFileName(addr: String): String = {
+    Paths.get(new URL(addr).getPath).getFileName.toString
+  }
+
   /**
     * Reads the lines from a file and concatenates the lines using the system line separator.
     * @param path the path to the file

--- a/src/main/scala/wdlTools/util/Util.scala
+++ b/src/main/scala/wdlTools/util/Util.scala
@@ -188,11 +188,12 @@ object Util {
   def prettyFormat(a: Any,
                    indentSize: Int = 2,
                    maxElementWidth: Int = 30,
-                   depth: Int = 0): String = {
+                   depth: Int = 0,
+                   callback: Option[Product => Option[String]] = None): String = {
     val indent = " " * depth * indentSize
     val fieldIndent = indent + (" " * indentSize)
-    val thisDepth = prettyFormat(_: Any, indentSize, maxElementWidth, depth)
-    val nextDepth = prettyFormat(_: Any, indentSize, maxElementWidth, depth + 1)
+    val thisDepth = prettyFormat(_: Any, indentSize, maxElementWidth, depth, callback)
+    val nextDepth = prettyFormat(_: Any, indentSize, maxElementWidth, depth + 1, callback)
     a match {
       // Make Strings look similar to their literal form.
       case s: String =>
@@ -215,26 +216,30 @@ object Util {
         result.substring(0, result.length - 1) + "\n" + indent + ")"
       // Product should cover case classes.
       case p: Product =>
-        val prefix = p.productPrefix
-        // We'll use reflection to get the constructor arg names and values.
-        val cls = p.getClass
-        val fields = cls.getDeclaredFields.filterNot(_.isSynthetic).map(_.getName)
-        val values = p.productIterator.toSeq
-        // If we weren't able to match up fields/values, fall back to toString.
-        if (fields.length != values.length) return p.toString
-        fields.zip(values).toList match {
-          // If there are no fields, just use the normal String representation.
-          case Nil => p.toString
-          // If there is just one field, let's just print it as a wrapper.
-          case (_, value) :: Nil => s"$prefix(${thisDepth(value)})"
-          // If there is more than one field, build up the field names and values.
-          case kvps =>
-            val prettyFields = kvps.map { case (k, v) => s"$fieldIndent$k = ${nextDepth(v)}" }
-            // If the result is not too long, pretty print on one line.
-            val resultOneLine = s"$prefix(${prettyFields.mkString(", ")})"
-            if (resultOneLine.length <= maxElementWidth) return resultOneLine
-            // Otherwise, build it with newlines and proper field indents.
-            s"$prefix(\n${prettyFields.mkString(",\n")}\n$indent)"
+        callback.map(_(p)) match {
+          case Some(Some(s)) => s
+          case _ =>
+            val prefix = p.productPrefix
+            // We'll use reflection to get the constructor arg names and values.
+            val cls = p.getClass
+            val fields = cls.getDeclaredFields.filterNot(_.isSynthetic).map(_.getName)
+            val values = p.productIterator.toSeq
+            // If we weren't able to match up fields/values, fall back to toString.
+            if (fields.length != values.length) return p.toString
+            fields.zip(values).toList match {
+              // If there are no fields, just use the normal String representation.
+              case Nil => p.toString
+              // If there is just one field, let's just print it as a wrapper.
+              case (_, value) :: Nil => s"$prefix(${thisDepth(value)})"
+              // If there is more than one field, build up the field names and values.
+              case kvps =>
+                val prettyFields = kvps.map { case (k, v) => s"$fieldIndent$k = ${nextDepth(v)}" }
+                // If the result is not too long, pretty print on one line.
+                val resultOneLine = s"$prefix(${prettyFields.mkString(", ")})"
+                if (resultOneLine.length <= maxElementWidth) return resultOneLine
+                // Otherwise, build it with newlines and proper field indents.
+                s"$prefix(\n${prettyFields.mkString(",\n")}\n$indent)"
+            }
         }
       // If we haven't specialized this type, just use its toString.
       case _ => a.toString

--- a/src/main/scala/wdlTools/util/Util.scala
+++ b/src/main/scala/wdlTools/util/Util.scala
@@ -84,7 +84,7 @@ object Util {
     resolved
   }
 
-  def getUrlFileName(addr: String): String = {
+  def getFilename(addr: String): String = {
     Paths.get(new URL(addr).getPath).getFileName.toString
   }
 

--- a/src/main/scala/wdlTools/util/package.scala
+++ b/src/main/scala/wdlTools/util/package.scala
@@ -20,28 +20,24 @@ object TypeCheckingRegime extends Enumeration {
 
 /**
   * Common configuration options.
+  *
   * @param localDirectories local directories to search for imports.
   * @param followImports whether to follow imports when parsing.
   * @param verbosity verbosity level.
-  * @param antlr4Trace whether to turn on tracing in the ANTLR4 parser.
-  * @param typeChecking strictness of type-checking
+  * @param antlr4Trace  whether to turn on tracing in the ANTLR4 parser.
   */
-case class Options(localDirectories: Vector[Path] = Vector.empty,
-                   followImports: Boolean = false,
-                   verbosity: Verbosity.Verbosity = Verbosity.Normal,
-                   antlr4Trace: Boolean = false,
-                   typeChecking: TypeCheckingRegime.Value = TypeCheckingRegime.Moderate) {
+class Options(val localDirectories: Vector[Path] = Vector.empty,
+              val followImports: Boolean = false,
+              val verbosity: Verbosity.Verbosity = Verbosity.Normal,
+              val antlr4Trace: Boolean = false) {
 
   def getUrl(pathOrUrl: String, mustExist: Boolean = true): URL = {
     Util.getUrl(pathOrUrl, localDirectories, mustExist)
   }
 }
 
-/** Configuration for expression evaluation. Some operations perform file IO.
-  *
-  * @param homeDir  the root directory for relative paths, and the root directory for search (glob).
-  * @param tmpDir   directory for placing temporary files.
-  * @param stdout   the file that has a copy of standard output. This is used in the command section.
-  * @param stderr   as above for standard error.
-  */
-case class EvalConfig(homeDir: Path, tmpDir: Path, stdout: Path, stderr: Path)
+case class BasicOptions(override val localDirectories: Vector[Path] = Vector.empty,
+                        override val followImports: Boolean = false,
+                        override val verbosity: Verbosity.Verbosity = Verbosity.Normal,
+                        override val antlr4Trace: Boolean = false)
+    extends Options(localDirectories, followImports, verbosity, antlr4Trace)

--- a/src/main/scala/wdlTools/util/package.scala
+++ b/src/main/scala/wdlTools/util/package.scala
@@ -21,23 +21,24 @@ object TypeCheckingRegime extends Enumeration {
 /**
   * Common configuration options.
   *
-  * @param localDirectories local directories to search for imports.
-  * @param followImports whether to follow imports when parsing.
-  * @param verbosity verbosity level.
-  * @param antlr4Trace  whether to turn on tracing in the ANTLR4 parser.
+  * localDirectories local directories to search for imports.
+  * followImports whether to follow imports when parsing.
+  * verbosity verbosity level.
+  * antlr4Trace  whether to turn on tracing in the ANTLR4 parser.
   */
-class Options(val localDirectories: Vector[Path] = Vector.empty,
-              val followImports: Boolean = false,
-              val verbosity: Verbosity.Verbosity = Verbosity.Normal,
-              val antlr4Trace: Boolean = false) {
+trait Options {
+  val localDirectories: Vector[Path]
+  val followImports: Boolean
+  val verbosity: Verbosity.Verbosity
+  val antlr4Trace: Boolean
 
   def getUrl(pathOrUrl: String, mustExist: Boolean = true): URL = {
     Util.getUrl(pathOrUrl, localDirectories, mustExist)
   }
 }
 
-case class BasicOptions(override val localDirectories: Vector[Path] = Vector.empty,
-                        override val followImports: Boolean = false,
-                        override val verbosity: Verbosity.Verbosity = Verbosity.Normal,
-                        override val antlr4Trace: Boolean = false)
-    extends Options(localDirectories, followImports, verbosity, antlr4Trace)
+case class BasicOptions(localDirectories: Vector[Path] = Vector.empty,
+                        followImports: Boolean = false,
+                        verbosity: Verbosity.Verbosity = Verbosity.Normal,
+                        antlr4Trace: Boolean = false)
+    extends Options

--- a/src/test/scala/wdlTools/eval/EvalTest.scala
+++ b/src/test/scala/wdlTools/eval/EvalTest.scala
@@ -5,10 +5,10 @@ import java.nio.file.{Files, Path, Paths}
 import org.scalatest.Inside
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-
+import wdlTools.eval
 import wdlTools.eval.WdlValues._
 import wdlTools.syntax.v1.ParseAll
-import wdlTools.util.{EvalConfig, Options, Util => UUtil, TypeCheckingRegime, Verbosity}
+import wdlTools.util.{Options, TypeCheckingRegime, Verbosity, Util => UUtil}
 import wdlTools.types.{TypeInfer, TypedAbstractSyntax => TAT}
 
 class EvalTest extends AnyFlatSpec with Matchers with Inside {
@@ -39,7 +39,7 @@ class EvalTest extends AnyFlatSpec with Matchers with Inside {
       safeMkdir(d)
     val stdout = baseDir.resolve("stdout")
     val stderr = baseDir.resolve("stderr")
-    EvalConfig(homeDir, tmpDir, stdout, stderr)
+    eval.EvalConfig(homeDir, tmpDir, stdout, stderr)
   }
 
   def parseAndTypeCheck(file: Path): TAT.Document = {

--- a/src/test/scala/wdlTools/eval/EvalTest.scala
+++ b/src/test/scala/wdlTools/eval/EvalTest.scala
@@ -8,16 +8,17 @@ import org.scalatest.matchers.should.Matchers
 import wdlTools.eval
 import wdlTools.eval.WdlValues._
 import wdlTools.syntax.v1.ParseAll
-import wdlTools.util.{Options, TypeCheckingRegime, Verbosity, Util => UUtil}
-import wdlTools.types.{TypeInfer, TypedAbstractSyntax => TAT}
+import wdlTools.util.{TypeCheckingRegime, Verbosity, Util => UUtil}
+import wdlTools.types.{TypeInfer, TypeOptions, TypedAbstractSyntax => TAT}
 
 class EvalTest extends AnyFlatSpec with Matchers with Inside {
   private val srcDir = Paths.get(getClass.getResource("/wdlTools/eval/v1").getPath)
   private val opts =
-    Options(typeChecking = TypeCheckingRegime.Lenient,
-            antlr4Trace = false,
-            localDirectories = Vector(srcDir),
-            verbosity = Verbosity.Normal)
+    TypeOptions(typeChecking = TypeCheckingRegime.Lenient,
+                antlr4Trace = false,
+                localDirectories = Vector(srcDir),
+                verbosity = Verbosity.Normal,
+                errorAsException = true)
   private val parser = ParseAll(opts)
   private val typeInfer = TypeInfer(opts)
 

--- a/src/test/scala/wdlTools/format/BaseTest.scala
+++ b/src/test/scala/wdlTools/format/BaseTest.scala
@@ -5,13 +5,12 @@ import java.nio.file.{Path, Paths}
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-
 import wdlTools.formatter.WdlV1Formatter
 import wdlTools.syntax.{WdlVersion, v1}
-import wdlTools.util.{Options, Util}
+import wdlTools.util.{BasicOptions, Util}
 
 class BaseTest extends AnyFlatSpec with Matchers {
-  private lazy val opts = Options()
+  private lazy val opts = BasicOptions()
   private lazy val parser = v1.ParseAll(opts)
 
   def getWdlPath(fname: String, subdir: String): Path = {

--- a/src/test/scala/wdlTools/linter/v1/BaseTest.scala
+++ b/src/test/scala/wdlTools/linter/v1/BaseTest.scala
@@ -7,10 +7,10 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import wdlTools.linter.{LintEvent, Linter, Severity}
 import wdlTools.syntax.TextSource
-import wdlTools.util.{Options, Util}
+import wdlTools.util.{BasicOptions, Util}
 
 class BaseTest extends AnyFlatSpec with Matchers {
-  private val opts = Options()
+  private val opts = BasicOptions()
 
   def getWdlPath(fname: String, subdir: String): Path = {
     Paths.get(getClass.getResource(s"/lint/${subdir}/${fname}").getPath)

--- a/src/test/scala/wdlTools/syntax/AbstractSyntaxTest.scala
+++ b/src/test/scala/wdlTools/syntax/AbstractSyntaxTest.scala
@@ -5,18 +5,17 @@ import java.nio.file.Paths
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-
 import wdlTools.syntax.v1.ParseAll
-import wdlTools.util.{Options, SourceCode, Util, Verbosity}
+import wdlTools.util.{BasicOptions, SourceCode, Util, Verbosity}
 
 class AbstractSyntaxTest extends AnyFlatSpec with Matchers {
   private val tasksDir = Paths.get(getClass.getResource("/wdlTools/syntax/v1/tasks").getPath)
   private val workflowsDir =
     Paths.get(getClass.getResource("/wdlTools/syntax/v1/workflows").getPath)
   private val opts =
-    Options(antlr4Trace = false,
-            localDirectories = Vector(tasksDir, workflowsDir),
-            verbosity = Verbosity.Quiet)
+    BasicOptions(antlr4Trace = false,
+                 localDirectories = Vector(tasksDir, workflowsDir),
+                 verbosity = Verbosity.Quiet)
   private val parser = ParseAll(opts)
 
   private def getTaskSource(fname: String): SourceCode = {

--- a/src/test/scala/wdlTools/syntax/draft_2/ConcreteSyntaxDraft2Test.scala
+++ b/src/test/scala/wdlTools/syntax/draft_2/ConcreteSyntaxDraft2Test.scala
@@ -4,17 +4,16 @@ import java.nio.file.Paths
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-
 import wdlTools.syntax.{Comment, Edge, SyntaxException, TextSource}
 import wdlTools.syntax.draft_2.ConcreteSyntax._
 import wdlTools.util.Verbosity.Quiet
-import wdlTools.util.{Options, SourceCode, Util}
+import wdlTools.util.{BasicOptions, Options, SourceCode, Util}
 
 class ConcreteSyntaxDraft2Test extends AnyFlatSpec with Matchers {
   private val sourcePath = Paths.get(getClass.getResource("/wdlTools/syntax/draft_2").getPath)
   private val tasksDir = sourcePath.resolve("tasks")
   private val workflowsDir = sourcePath.resolve("workflows")
-  private val opts = Options(
+  private val opts = BasicOptions(
       antlr4Trace = false,
       verbosity = Quiet,
       localDirectories = Vector(tasksDir, workflowsDir)

--- a/src/test/scala/wdlTools/syntax/v1/ConcreteSyntaxV1Test.scala
+++ b/src/test/scala/wdlTools/syntax/v1/ConcreteSyntaxV1Test.scala
@@ -4,18 +4,17 @@ import java.nio.file.Paths
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-
 import wdlTools.syntax.{Comment, Edge, SyntaxException, TextSource, WdlVersion}
 import wdlTools.syntax.v1.ConcreteSyntax._
 import wdlTools.util.Verbosity._
-import wdlTools.util.{Options, SourceCode, Util}
+import wdlTools.util.{BasicOptions, Options, SourceCode, Util}
 
 class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
   private val sourcePath = Paths.get(getClass.getResource("/wdlTools/syntax/v1").getPath)
   private val tasksDir = sourcePath.resolve("tasks")
   private val workflowsDir = sourcePath.resolve("workflows")
   private val structsDir = sourcePath.resolve("structs")
-  private val opts = Options(
+  private val opts = BasicOptions(
       antlr4Trace = false,
       verbosity = Quiet,
       localDirectories = Vector(tasksDir, workflowsDir, structsDir)

--- a/src/test/scala/wdlTools/types/TypeInferTest.scala
+++ b/src/test/scala/wdlTools/types/TypeInferTest.scala
@@ -5,16 +5,17 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import scala.jdk.CollectionConverters._
 import wdlTools.syntax.Parsers
-import wdlTools.util.{Options, TypeCheckingRegime, Util => UUtil, Verbosity}
+import wdlTools.util.{TypeCheckingRegime, Util => UUtil, Verbosity}
 
 class TypeInferTest extends AnyFlatSpec with Matchers {
-  private val opts = Options(
+  private val opts = TypeOptions(
       antlr4Trace = false,
       localDirectories = Vector(
           Paths.get(getClass.getResource("/wdlTools/types/v1").getPath)
       ),
       verbosity = Verbosity.Quiet,
-      followImports = true
+      followImports = true,
+      errorAsException = true
   )
   private val parser = Parsers(opts)
 

--- a/src/test/scala/wdlTools/upgrade/BaseTest.scala
+++ b/src/test/scala/wdlTools/upgrade/BaseTest.scala
@@ -2,14 +2,15 @@ package wdlTools.upgrade
 
 import java.net.URL
 import java.nio.file.{Path, Paths}
+
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import wdlTools.formatter.Upgrader
 import wdlTools.syntax.WdlVersion
-import wdlTools.util.{Options, Util, Verbosity}
+import wdlTools.util.{BasicOptions, Util, Verbosity}
 
 class BaseTest extends AnyFlatSpec with Matchers {
-  private lazy val opts = Options(verbosity = Verbosity.Verbose)
+  private lazy val opts = BasicOptions(verbosity = Verbosity.Verbose)
 
   def getBeforePath(fname: String): Path = {
     Paths.get(getClass.getResource(s"/wdlTools/upgrade/before/${fname}").getPath)


### PR DESCRIPTION
* Introduce new `Invalid` WdlType that represents a type checking failure that is stored in the tree (rather than throwing a `TypeException`)
* Add `errorAsException` option to `TypeInfer` - when true, type errors are immediately thrown as `TypeException`; when false, type errors are stored in the tree as types that implement the Invalid trait
* switch to using `Either` return value in `Context` (rather than throw `TypeException`), which enables all the logic about whether to throw an exception or generate an `Invalid` type to be done in `TypeInfer`
* Add an optional `errorHandler` function parameter to `ParseAll` classes
* Improve the "check" command to collect all type-checking errors and pretty-print them to stdout or a file
* General clean-up of CLI, including switching from base classes to traits for handling common subcommand options
