### PR TITLE
Consistent naming for meta values

### DIFF
--- a/src/main/scala/wdlTools/eval/Eval.scala
+++ b/src/main/scala/wdlTools/eval/Eval.scala
@@ -494,6 +494,23 @@ case class Eval(opts: Options,
     }
   }
 
+  // public entry points
+  //
+  def applyExpr(expr: TAT.Expr, ctx: Context): WdlValues.V = {
+    apply(expr, ctx)
+  }
+
+  // cast the result value to the correct type
+  // For example, an expression like:
+  //   Float x = "3.2"
+  // requires casting from string to float
+  def applyExprAndCoerce(expr: TAT.Expr,
+                        wdlType : WdlTypes.T,
+                         ctx: Context): WdlValues.V = {
+    val value = apply(expr, ctx)
+    coercion.coerceTo(wdlType, value, expr.text)
+  }
+
   // Evaluate all the declarations and return a context
   def applyDeclarations(decls: Vector[TAT.Declaration], ctx: Context): Context = {
     decls.foldLeft(ctx) {

--- a/src/main/scala/wdlTools/eval/Eval.scala
+++ b/src/main/scala/wdlTools/eval/Eval.scala
@@ -4,7 +4,7 @@ import java.net.URL
 
 import wdlTools.eval.WdlValues._
 import wdlTools.syntax.{TextSource, WdlVersion}
-import wdlTools.types.{TypedAbstractSyntax => TAT}
+import wdlTools.types.{TypedAbstractSyntax => TAT, WdlTypes}
 import wdlTools.util.{EvalConfig, Options}
 
 case class Eval(opts: Options,
@@ -504,9 +504,7 @@ case class Eval(opts: Options,
   // For example, an expression like:
   //   Float x = "3.2"
   // requires casting from string to float
-  def applyExprAndCoerce(expr: TAT.Expr,
-                        wdlType : WdlTypes.T,
-                         ctx: Context): WdlValues.V = {
+  def applyExprAndCoerce(expr: TAT.Expr, wdlType: WdlTypes.T, ctx: Context): WdlValues.V = {
     val value = apply(expr, ctx)
     coercion.coerceTo(wdlType, value, expr.text)
   }

--- a/src/main/scala/wdlTools/types/TypeInfer.scala
+++ b/src/main/scala/wdlTools/types/TypeInfer.scala
@@ -690,16 +690,16 @@ case class TypeInfer(conf: Options) {
   // language for meta values only.
   private def metaValueFromExpr(expr: AST.Expr, ctx: Context): TAT.MetaValue = {
     expr match {
-      case AST.ValueNull(_)                          => TAT.MetaNull
-      case AST.ValueBoolean(value, _)                => TAT.MetaBoolean(value)
-      case AST.ValueInt(value, _)                    => TAT.MetaInt(value)
-      case AST.ValueFloat(value, _)                  => TAT.MetaFloat(value)
-      case AST.ValueString(value, _)                 => TAT.MetaString(value)
-      case AST.ExprIdentifier(id, _) if id == "null" => TAT.MetaNull
-      case AST.ExprIdentifier(id, _)                 => TAT.MetaString(id)
-      case AST.ExprArray(vec, _)                     => TAT.MetaArray(vec.map(metaValueFromExpr(_, ctx)))
+      case AST.ValueNull(_)                          => TAT.MetaValueNull
+      case AST.ValueBoolean(value, _)                => TAT.MetaValueBoolean(value)
+      case AST.ValueInt(value, _)                    => TAT.MetaValueInt(value)
+      case AST.ValueFloat(value, _)                  => TAT.MetaValueFloat(value)
+      case AST.ValueString(value, _)                 => TAT.MetaValueString(value)
+      case AST.ExprIdentifier(id, _) if id == "null" => TAT.MetaValueNull
+      case AST.ExprIdentifier(id, _)                 => TAT.MetaValueString(id)
+      case AST.ExprArray(vec, _)                     => TAT.MetaValueArray(vec.map(metaValueFromExpr(_, ctx)))
       case AST.ExprMap(members, _) =>
-        TAT.MetaObject(members.map {
+        TAT.MetaValueObject(members.map {
           case AST.ExprMapItem(AST.ValueString(key, _), value, _) =>
             key -> metaValueFromExpr(value, ctx)
           case AST.ExprMapItem(AST.ExprIdentifier(key, _), value, _) =>
@@ -708,7 +708,7 @@ case class TypeInfer(conf: Options) {
             throw new RuntimeException(s"bad value ${SUtil.exprToString(other)}")
         }.toMap)
       case AST.ExprObject(members, _) =>
-        TAT.MetaObject(members.map {
+        TAT.MetaValueObject(members.map {
           case AST.ExprObjectMember(key, value, _) =>
             key -> metaValueFromExpr(value, ctx)
           case other =>

--- a/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
+++ b/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
@@ -169,13 +169,13 @@ object TypedAbstractSyntax {
 
   // A specialized JSON-like object language for meta values only.
   sealed trait MetaValue
-  case object MetaNull extends MetaValue
-  case class MetaBoolean(value: Boolean) extends MetaValue
-  case class MetaInt(value: Int) extends MetaValue
-  case class MetaFloat(value: Double) extends MetaValue
-  case class MetaString(value: String) extends MetaValue
-  case class MetaObject(value: Map[String, MetaValue]) extends MetaValue
-  case class MetaArray(value: Vector[MetaValue]) extends MetaValue
+  case object MetaValueNull extends MetaValue
+  case class MetaValueBoolean(value: Boolean) extends MetaValue
+  case class MetaValueInt(value: Int) extends MetaValue
+  case class MetaValueFloat(value: Double) extends MetaValue
+  case class MetaValueString(value: String) extends MetaValue
+  case class MetaValueObject(value: Map[String, MetaValue]) extends MetaValue
+  case class MetaValueArray(value: Vector[MetaValue]) extends MetaValue
 
   // the parameter sections have mappings from keys to json-like objects
   case class ParameterMetaSection(kvs: Map[String, MetaValue], text: TextSource) extends Element


### PR DESCRIPTION
Made meta value naming more consistent in the typed abstract syntax. 