### PR TITLE
wdlType field in Scatter

### DIFF
--- a/src/main/scala/wdlTools/types/TypeInfer.scala
+++ b/src/main/scala/wdlTools/types/TypeInfer.scala
@@ -1071,7 +1071,7 @@ case class TypeInfer(conf: TypeOptions,
           varName -> T_Array(typ)
       }
 
-    val tScatter = TAT.Scatter(scatter.identifier, wdlType, eCollection, tElements, scatter.text)
+    val tScatter = TAT.Scatter(scatter.identifier, eCollection, tElements, scatter.text)
     (tScatter, bindingsWithArray)
   }
 

--- a/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
+++ b/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
@@ -238,7 +238,6 @@ object TypedAbstractSyntax {
       extends WorkflowElement
 
   case class Scatter(identifier: String,
-                     wdlType: WdlTypes.T,
                      expr: Expr,
                      body: Vector[WorkflowElement],
                      text: TextSource)


### PR DESCRIPTION
Do we really need the `wdlType` field in Scatter? 

There is a lot of code now in dxWDL that relies on the Typed Abstract Syntax structures, so, I would rather not modify it if this isn't necessary. Also, the utility of this field is unclear to me.  