### PR TITLE
Use restricted value types for meta values

### DIFF
--- a/src/main/antlr4/v1/WdlV1Lexer.g4
+++ b/src/main/antlr4/v1/WdlV1Lexer.g4
@@ -35,7 +35,7 @@ MAP: 'Map';
 PAIR: 'Pair';
 OBJECT: 'Object';
 OBJECT_LITERAL: 'object';
-
+NULL_LITERAL: 'null';
 SEP: 'sep';
 DEFAULT: 'default';
 

--- a/src/main/antlr4/v1/WdlV1Parser.g4
+++ b/src/main/antlr4/v1/WdlV1Parser.g4
@@ -3,283 +3,302 @@ parser grammar WdlV1Parser;
 options { tokenVocab=WdlV1Lexer; }
 
 map_type
-	: MAP LBRACK wdl_type COMMA wdl_type RBRACK
-	;
+  : MAP LBRACK wdl_type COMMA wdl_type RBRACK
+  ;
 
 array_type
-	: ARRAY LBRACK wdl_type RBRACK PLUS?
-	;
+  : ARRAY LBRACK wdl_type RBRACK PLUS?
+  ;
 
 pair_type
-	: PAIR LBRACK wdl_type COMMA wdl_type RBRACK
-	;
+  : PAIR LBRACK wdl_type COMMA wdl_type RBRACK
+  ;
 
 type_base
-	: array_type
-	| map_type
-	| pair_type
-	| (STRING | FILE | BOOLEAN | OBJECT | INT | FLOAT | Identifier)
-	;
+  : array_type
+  | map_type
+  | pair_type
+  | (STRING | FILE | BOOLEAN | OBJECT | INT | FLOAT | Identifier)
+  ;
 
 wdl_type
-	: (type_base OPTIONAL | type_base)
-	;
+  : (type_base OPTIONAL | type_base)
+  ;
 
 unbound_decls
-	: wdl_type Identifier
-	;
+  : wdl_type Identifier
+  ;
 
 bound_decls
-	: wdl_type Identifier EQUAL expr
-	;
+  : wdl_type Identifier EQUAL expr
+  ;
 
 any_decls
-	: unbound_decls
-	| bound_decls
-	;
+  : unbound_decls
+  | bound_decls
+  ;
 
 number
-	: IntLiteral
-	| FloatLiteral
-	;
+  : IntLiteral
+  | FloatLiteral
+  ;
 
 expression_placeholder_option
-	: BoolLiteral EQUAL (string | number)
-	| DEFAULT EQUAL (string | number)
-	| SEP EQUAL (string | number)
-	;
+  : BoolLiteral EQUAL (string | number)
+  | DEFAULT EQUAL (string | number)
+  | SEP EQUAL (string | number)
+  ;
 
 string_part
-	: StringPart*
-	;
+  : StringPart*
+  ;
 
 string_expr_part
-	: StringCommandStart (expression_placeholder_option)* expr RBRACE
-	;
+  : StringCommandStart (expression_placeholder_option)* expr RBRACE
+  ;
 
 string_expr_with_string_part
-	: string_expr_part string_part
-	;
+  : string_expr_part string_part
+  ;
 
 string
-	: DQUOTE string_part string_expr_with_string_part* DQUOTE
-	| SQUOTE string_part string_expr_with_string_part* SQUOTE
-	;
+  : DQUOTE string_part string_expr_with_string_part* DQUOTE
+  | SQUOTE string_part string_expr_with_string_part* SQUOTE
+  ;
 
 primitive_literal
-	: BoolLiteral
-	| number
-	| string
-	| Identifier
-	;
+  : BoolLiteral
+  | number
+  | string
+  | Identifier
+  ;
 
 expr
-	: expr_infix
-	;
+  : expr_infix
+  ;
 
 expr_infix
-	: expr_infix0 #infix0
-	;
+  : expr_infix0 #infix0
+  ;
 
 expr_infix0
-	: expr_infix0 OR expr_infix1 #lor
-	| expr_infix1 #infix1
-	;
+  : expr_infix0 OR expr_infix1 #lor
+  | expr_infix1 #infix1
+  ;
 
 expr_infix1
-	: expr_infix1 AND expr_infix2 #land
-	| expr_infix2 #infix2
-	;
+  : expr_infix1 AND expr_infix2 #land
+  | expr_infix2 #infix2
+  ;
 
 expr_infix2
-	: expr_infix2 EQUALITY expr_infix3 #eqeq
-	| expr_infix2 NOTEQUAL expr_infix3 #neq
-	| expr_infix2 LTE expr_infix3 #lte
-	| expr_infix2 GTE expr_infix3 #gte
-	| expr_infix2 LT expr_infix3 #lt
-	| expr_infix2 GT expr_infix3 #gt
-	| expr_infix3 #infix3
-	;
+  : expr_infix2 EQUALITY expr_infix3 #eqeq
+  | expr_infix2 NOTEQUAL expr_infix3 #neq
+  | expr_infix2 LTE expr_infix3 #lte
+  | expr_infix2 GTE expr_infix3 #gte
+  | expr_infix2 LT expr_infix3 #lt
+  | expr_infix2 GT expr_infix3 #gt
+  | expr_infix3 #infix3
+  ;
 
 expr_infix3
-	: expr_infix3 PLUS expr_infix4 #add
-	| expr_infix3 MINUS expr_infix4 #sub
-	| expr_infix4 #infix4
-	;
+  : expr_infix3 PLUS expr_infix4 #add
+  | expr_infix3 MINUS expr_infix4 #sub
+  | expr_infix4 #infix4
+  ;
 
 expr_infix4
-	: expr_infix4 STAR expr_infix5 #mul
-	| expr_infix4 DIVIDE expr_infix5 #divide
-	| expr_infix4 MOD expr_infix5 #mod
-	| expr_infix5 #infix5
-	;
+  : expr_infix4 STAR expr_infix5 #mul
+  | expr_infix4 DIVIDE expr_infix5 #divide
+  | expr_infix4 MOD expr_infix5 #mod
+  | expr_infix5 #infix5
+  ;
 
 expr_infix5
-	: expr_core
-	;
+  : expr_core
+  ;
 
 expr_core
-        : Identifier LPAREN (expr (COMMA expr)*)? RPAREN #apply
-        | LBRACK (expr (COMMA expr)*)* RBRACK #array_literal
-        | LPAREN expr COMMA expr RPAREN #pair_literal
-        | LBRACE (expr COLON expr (COMMA expr COLON expr)*)* RBRACE #map_literal
-        | OBJECT_LITERAL LBRACE (Identifier COLON expr (COMMA Identifier COLON expr)*)* RBRACE #object_literal
-        | IF expr THEN expr ELSE expr #ifthenelse
-        | LPAREN expr RPAREN #expression_group
-        | expr_core LBRACK expr RBRACK #at
-        | expr_core DOT Identifier #get_name
-        | NOT expr #negate
-        | (PLUS | MINUS) expr #unarysigned
-        | primitive_literal #primitives
-        | Identifier #left_name
-        ;
+  : Identifier LPAREN (expr (COMMA expr)*)? RPAREN #apply
+  | LBRACK (expr (COMMA expr)*)* RBRACK #array_literal
+  | LPAREN expr COMMA expr RPAREN #pair_literal
+  | LBRACE (expr COLON expr (COMMA expr COLON expr)*)* RBRACE #map_literal
+  | OBJECT_LITERAL LBRACE (Identifier COLON expr (COMMA Identifier COLON expr)*)* RBRACE #object_literal
+  | IF expr THEN expr ELSE expr #ifthenelse
+  | LPAREN expr RPAREN #expression_group
+  | expr_core LBRACK expr RBRACK #at
+  | expr_core DOT Identifier #get_name
+  | NOT expr #negate
+  | (PLUS | MINUS) expr #unarysigned
+  | primitive_literal #primitives
+  | Identifier #left_name
+  ;
 
 version
-	: VERSION ReleaseVersion
-	;
+  : VERSION ReleaseVersion
+  ;
 
 import_alias
-	: ALIAS Identifier AS Identifier
-	;
+  : ALIAS Identifier AS Identifier
+  ;
 
 import_as
-	: AS Identifier
-	;
+  : AS Identifier
+  ;
 
 import_doc
-	: IMPORT string import_as? (import_alias)*
-	;
+  : IMPORT string import_as? (import_alias)*
+  ;
+
 struct
-	: STRUCT Identifier LBRACE (unbound_decls)* RBRACE
-	;
+  : STRUCT Identifier LBRACE (unbound_decls)* RBRACE
+  ;
+
+meta_value
+  : BoolLiteral
+  | number
+  | meta_string
+  | meta_object
+  | meta_array
+  | NULL_LITERAL
+  ;
+
+meta_string
+  : DQUOTE string_part DQUOTE
+  | SQUOTE string_part SQUOTE
+  ;
+
+meta_array: LBRACK (meta_value (COMMA meta_value)*)* RBRACK;
+
+meta_object: LBRACE (meta_kv (COMMA meta_kv)*)* RBRACE;
 
 meta_kv
-	: Identifier COLON expr
-	;
+  : Identifier COLON meta_value
+  ;
 
 parameter_meta
-	: PARAMETERMETA LBRACE meta_kv* RBRACE
-	;
+  : PARAMETERMETA LBRACE meta_kv* RBRACE
+  ;
 
 meta
-	:	META LBRACE meta_kv* RBRACE
-	;
+  :	META LBRACE meta_kv* RBRACE
+  ;
 
 task_runtime_kv
-	: Identifier COLON expr
-	;
+  : Identifier COLON expr
+  ;
 
 task_runtime
-	: RUNTIME LBRACE (task_runtime_kv)* RBRACE
-	;
+  : RUNTIME LBRACE (task_runtime_kv)* RBRACE
+  ;
 
 task_input
-	: INPUT LBRACE (any_decls)* RBRACE
-	;
+  : INPUT LBRACE (any_decls)* RBRACE
+  ;
 
 task_output
-	: OUTPUT LBRACE (bound_decls)* RBRACE
-	;
+  : OUTPUT LBRACE (bound_decls)* RBRACE
+  ;
 
 task_command_string_part
-	: CommandStringPart*
-	;
+  : CommandStringPart*
+  ;
 
 task_command_expr_part
-	: StringCommandStart (expression_placeholder_option)* expr RBRACE
-	;
+  : StringCommandStart (expression_placeholder_option)* expr RBRACE
+  ;
 
 task_command_expr_with_string
-	: task_command_expr_part task_command_string_part
-	;
+  : task_command_expr_part task_command_string_part
+  ;
 
 task_command
-	: COMMAND BeginLBrace task_command_string_part task_command_expr_with_string* EndCommand
-	| COMMAND BeginHereDoc task_command_string_part task_command_expr_with_string* EndCommand
-	;
+  : COMMAND BeginLBrace task_command_string_part task_command_expr_with_string* EndCommand
+  | COMMAND BeginHereDoc task_command_string_part task_command_expr_with_string* EndCommand
+  ;
 
 task_element
-	: task_input
-	| task_output
-	| task_command
-	| task_runtime
-	| bound_decls
-	| parameter_meta
-	| meta
-	;
+  : task_input
+  | task_output
+  | task_command
+  | task_runtime
+  | bound_decls
+  | parameter_meta
+  | meta
+  ;
 
 task
-	: TASK Identifier LBRACE (task_element)+ RBRACE
-	;
+  : TASK Identifier LBRACE (task_element)+ RBRACE
+  ;
 
 inner_workflow_element
-	: bound_decls
-	| call
-	| scatter
-	| conditional
-	;
+  : bound_decls
+  | call
+  | scatter
+  | conditional
+  ;
 
 call_alias
-	: AS Identifier
-	;
+  : AS Identifier
+  ;
 
 call_input
-	: Identifier EQUAL expr
-	;
+  : Identifier EQUAL expr
+  ;
 
 call_inputs
-	: INPUT COLON (call_input (COMMA call_input)*) COMMA?
-	;
+  : INPUT COLON (call_input (COMMA call_input)*) COMMA?
+  ;
 
 call_body
-	: LBRACE call_inputs? RBRACE
-	;
+  : LBRACE call_inputs? RBRACE
+  ;
 
 call_name
-	: Identifier (DOT Identifier)*
-	;
+  : Identifier (DOT Identifier)*
+  ;
 
 call
-	: CALL call_name call_alias?	call_body?
-	;
+  : CALL call_name call_alias?	call_body?
+  ;
 
 scatter
-	: SCATTER LPAREN Identifier In expr RPAREN LBRACE inner_workflow_element* RBRACE
-	;
+  : SCATTER LPAREN Identifier In expr RPAREN LBRACE inner_workflow_element* RBRACE
+  ;
 
 conditional
-	: IF LPAREN expr RPAREN LBRACE inner_workflow_element* RBRACE
-	;
+  : IF LPAREN expr RPAREN LBRACE inner_workflow_element* RBRACE
+  ;
 
 workflow_input
-	: INPUT LBRACE (any_decls)* RBRACE
-	;
+  : INPUT LBRACE (any_decls)* RBRACE
+  ;
 
 workflow_output
-	: OUTPUT LBRACE (bound_decls)* RBRACE
-	;
+  : OUTPUT LBRACE (bound_decls)* RBRACE
+  ;
 
 workflow_element
-	: workflow_input #input
-	| workflow_output #output
-	| inner_workflow_element #inner_element
-	| parameter_meta #parameter_meta_element
-	| meta #meta_element
-	;
+  : workflow_input #input
+  | workflow_output #output
+  | inner_workflow_element #inner_element
+  | parameter_meta #parameter_meta_element
+  | meta #meta_element
+  ;
 
 workflow
-	: WORKFLOW Identifier LBRACE workflow_element* RBRACE
-	;
+  : WORKFLOW Identifier LBRACE workflow_element* RBRACE
+  ;
 
 document_element
-	: import_doc
-	| struct
-	| task
-	;
+  : import_doc
+  | struct
+  | task
+  ;
 
 document
-	: version document_element* (workflow document_element*)? EOF
-	;
+  : version document_element* (workflow document_element*)? EOF
+  ;
 
 type_document
   : wdl_type EOF

--- a/src/main/antlr4/v2/WdlV2Lexer.g4
+++ b/src/main/antlr4/v2/WdlV2Lexer.g4
@@ -43,6 +43,7 @@ MAP: 'Map';
 PAIR: 'Pair';
 AFTER: 'after';
 COMMAND: 'command'-> mode(Command);
+NULL_LITERAL: 'null';
 
 // Primitive Literals
 NONELITERAL: 'None';

--- a/src/main/antlr4/v2/WdlV2Parser.g4
+++ b/src/main/antlr4/v2/WdlV2Parser.g4
@@ -121,11 +121,11 @@ expr_core
   | LBRACE (expr COLON expr (COMMA expr COLON expr)*)* RBRACE #map_literal
   | Identifier LBRACE (Identifier COLON expr (COMMA Identifier COLON expr)*)* RBRACE #struct_literal
   | IF expr THEN expr ELSE expr #ifthenelse
-    | LPAREN expr RPAREN #expression_group
+  | LPAREN expr RPAREN #expression_group
   | expr_core LBRACK expr RBRACK #at
-    | expr_core DOT Identifier #get_name
-    | NOT expr #negate
-    | (PLUS | MINUS) expr #unarysigned
+  | expr_core DOT Identifier #get_name
+  | NOT expr #negate
+  | (PLUS | MINUS) expr #unarysigned
   | primitive_literal #primitives
   | Identifier #left_name
   ;
@@ -139,8 +139,8 @@ import_alias
   ;
 
 import_as
-    : AS Identifier
-    ;
+  : AS Identifier
+  ;
 
 import_doc
   : IMPORT string import_as? (import_alias)*
@@ -150,8 +150,26 @@ struct
   : STRUCT Identifier LBRACE (unbound_decls)* RBRACE
   ;
 
+meta_value
+  : BoolLiteral
+  | number
+  | meta_string
+  | meta_object
+  | meta_array
+  | NULL_LITERAL
+  ;
+
+meta_string
+  : DQUOTE string_part DQUOTE
+  | SQUOTE string_part SQUOTE
+  ;
+
+meta_array: LBRACK (meta_value (COMMA meta_value)*)* RBRACK;
+
+meta_object: LBRACE (meta_kv (COMMA meta_kv)*)* RBRACE;
+
 meta_kv
-  : Identifier COLON expr
+  : Identifier COLON meta_value
   ;
 
 parameter_meta
@@ -159,8 +177,8 @@ parameter_meta
   ;
 
 meta
-    :  META LBRACE meta_kv* RBRACE
-    ;
+  :  META LBRACE meta_kv* RBRACE
+  ;
 
 task_runtime_kv
   : RUNTIMECPU COLON expr
@@ -198,16 +216,16 @@ task_command
   ;
 
 task_command_string_part
-    : CommandStringPart*
-    ;
+  : CommandStringPart*
+  ;
 
 task_command_expr_part
-    : StringCommandStart expr RBRACE
-    ;
+  : StringCommandStart expr RBRACE
+  ;
 
 task_command_expr_with_string
-    : task_command_expr_part task_command_string_part
-    ;
+  : task_command_expr_part task_command_string_part
+  ;
 
 task_element
   : task_input
@@ -252,8 +270,8 @@ call_after
   ;
 
 call_name
-    : Identifier (DOT Identifier)*
-    ;
+  : Identifier (DOT Identifier)*
+  ;
 
 call
   : CALL call_name call_alias? (call_after)*  call_body?

--- a/src/main/resources/templates/documentation/document.ssp
+++ b/src/main/resources/templates/documentation/document.ssp
@@ -24,10 +24,15 @@ def typeToString(wdlType: Type): String = {
 def formatMetaValue(metaValue: ValueDocumentation, indent: String = ""): String = {
   metaValue match {
     case SimpleValueDocumentation(value, comment) =>
+      val s: String = value match {
+        case e: Expr => exprToString(e)
+        case v: MetaValue => metaValueToString(v)
+        case other => other.toString
+      }
       if (comment.isDefined) {
-        s"${exprToString(value)} (${comment.get})"
+        s"${s} (${comment.get})"
       } else {
-        exprToString(value)
+        s
       }
       case ListValueDocumentation(value, comment) => s"${value.map(x => formatMetaValue(x, indent + "    ")).mkString(", ")}"
       case MapValueDocumentation(value, comment) =>

--- a/src/main/scala/wdlTools/formatter/package.scala
+++ b/src/main/scala/wdlTools/formatter/package.scala
@@ -109,6 +109,7 @@ object Symbols {
   val Version: String = "version"
   val Workflow: String = "workflow"
   val Null: String = "null"
+  val None: String = "None"
 
   // data types
   val ArrayType: String = "Array"

--- a/src/main/scala/wdlTools/linter/LinterASTWalker.scala
+++ b/src/main/scala/wdlTools/linter/LinterASTWalker.scala
@@ -55,6 +55,12 @@ case class LinterASTWalker(opts: Options, visitors: Vector[ASTVisitor]) extends 
     super.visitStructMember(ctx)
   }
 
+  override def visitMetaValue(ctx: Context[MetaValue]): Unit = {
+    visitEveryRule(ctx.asInstanceOf[Context[Element]])
+    visitors.foreach(_.visitMetaValue(ctx))
+    super.visitMetaValue(ctx)
+  }
+
   override def visitExpression(ctx: Context[Expr]): Unit = {
     visitEveryRule(ctx.asInstanceOf[Context[Element]])
     visitors.foreach(_.visitExpression(ctx))

--- a/src/main/scala/wdlTools/syntax/ASTWalker.scala
+++ b/src/main/scala/wdlTools/syntax/ASTWalker.scala
@@ -26,6 +26,8 @@ class ASTVisitor {
 
   def visitStructMember(ctx: Context[StructMember]): Unit = {}
 
+  def visitMetaValue(ctx: Context[MetaValue]): Unit = {}
+
   def visitExpression(ctx: Context[Expr]): Unit = {}
 
   def visitDeclaration(ctx: Context[Declaration]): Unit = {}
@@ -222,7 +224,7 @@ class ASTWalker(opts: Options) extends ASTVisitor {
 
   override def visitMetaKV(ctx: Context[MetaKV]): Unit = {
     visitIdentifier[MetaKV](ctx.element.id, ctx)
-    visitExpression(createContext[Expr, MetaKV](ctx.element.expr, ctx))
+    visitMetaValue(createContext[MetaValue, MetaKV](ctx.element.value, ctx))
   }
 
   override def visitMetaSection(ctx: Context[MetaSection]): Unit = {

--- a/src/main/scala/wdlTools/syntax/AbstractSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/AbstractSyntax.scala
@@ -34,7 +34,6 @@ object AbstractSyntax {
 
   // values
   sealed trait Value extends Expr
-  case class ValueNull(text: TextSource) extends Value
   case class ValueNone(text: TextSource) extends Value
   case class ValueString(value: String, text: TextSource) extends Value
   case class ValueBoolean(value: Boolean, text: TextSource) extends Value
@@ -130,8 +129,17 @@ object AbstractSyntax {
   case class HintsKV(id: String, expr: Expr, text: TextSource) extends Element
   case class HintsSection(kvs: Vector[HintsKV], text: TextSource) extends Element
 
+  // A specialized JSON-like object language for meta values only.
+  sealed trait MetaValue extends Element
+  case class MetaValueNull(text: TextSource) extends MetaValue
+  case class MetaValueBoolean(value: Boolean, text: TextSource) extends MetaValue
+  case class MetaValueInt(value: Int, text: TextSource) extends MetaValue
+  case class MetaValueFloat(value: Double, text: TextSource) extends MetaValue
+  case class MetaValueString(value: String, text: TextSource) extends MetaValue
+  case class MetaValueObject(value: Vector[MetaKV], text: TextSource) extends MetaValue
+  case class MetaValueArray(value: Vector[MetaValue], text: TextSource) extends MetaValue
   // meta section
-  case class MetaKV(id: String, expr: Expr, text: TextSource) extends Element
+  case class MetaKV(id: String, value: MetaValue, text: TextSource) extends Element
   case class ParameterMetaSection(kvs: Vector[MetaKV], text: TextSource) extends Element
   case class MetaSection(kvs: Vector[MetaKV], text: TextSource) extends Element
 

--- a/src/main/scala/wdlTools/syntax/AllParseTreeListener.scala
+++ b/src/main/scala/wdlTools/syntax/AllParseTreeListener.scala
@@ -131,6 +131,14 @@ class AllParseTreeListener
   def exitImport_as(ctx: ParserRuleContext): Unit = {}
   def enterImport_doc(ctx: ParserRuleContext): Unit = {}
   def exitImport_doc(ctx: ParserRuleContext): Unit = {}
+  def enterMeta_value(ctx: ParserRuleContext): Unit = {}
+  def exitMeta_value(ctx: ParserRuleContext): Unit = {}
+  def enterMeta_string(ctx: ParserRuleContext): Unit = {}
+  def exitMeta_string(ctx: ParserRuleContext): Unit = {}
+  def enterMeta_array(ctx: ParserRuleContext): Unit = {}
+  def exitMeta_array(ctx: ParserRuleContext): Unit = {}
+  def enterMeta_object(ctx: ParserRuleContext): Unit = {}
+  def exitMeta_object(ctx: ParserRuleContext): Unit = {}
   def enterMeta_kv(ctx: ParserRuleContext): Unit = {}
   def exitMeta_kv(ctx: ParserRuleContext): Unit = {}
   def enterParameter_meta(ctx: ParserRuleContext): Unit = {}
@@ -735,7 +743,6 @@ class AllParseTreeListener
   override def exitTask_runtime_element(ctx: WdlDraft2Parser.Task_runtime_elementContext): Unit = {
     exitTask_runtime_element(ctx.asInstanceOf[ParserRuleContext])
   }
-
   override def enterTask_parameter_meta_element(
       ctx: WdlDraft2Parser.Task_parameter_meta_elementContext
   ): Unit = {
@@ -1119,6 +1126,30 @@ class AllParseTreeListener
   }
   override def exitStruct(ctx: WdlV1Parser.StructContext): Unit = {
     exitStruct(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def enterMeta_value(ctx: WdlV1Parser.Meta_valueContext): Unit = {
+    enterMeta_value(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def exitMeta_value(ctx: WdlV1Parser.Meta_valueContext): Unit = {
+    exitMeta_value(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def enterMeta_string(ctx: WdlV1Parser.Meta_stringContext): Unit = {
+    enterMeta_string(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def exitMeta_string(ctx: WdlV1Parser.Meta_stringContext): Unit = {
+    exitMeta_string(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def enterMeta_array(ctx: WdlV1Parser.Meta_arrayContext): Unit = {
+    enterMeta_array(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def exitMeta_array(ctx: WdlV1Parser.Meta_arrayContext): Unit = {
+    exitMeta_array(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def enterMeta_object(ctx: WdlV1Parser.Meta_objectContext): Unit = {
+    enterMeta_object(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def exitMeta_object(ctx: WdlV1Parser.Meta_objectContext): Unit = {
+    exitMeta_object(ctx.asInstanceOf[ParserRuleContext])
   }
   override def enterMeta_kv(ctx: WdlV1Parser.Meta_kvContext): Unit = {
     enterMeta_kv(ctx.asInstanceOf[ParserRuleContext])
@@ -1655,6 +1686,30 @@ class AllParseTreeListener
   }
   override def exitStruct(ctx: WdlV2Parser.StructContext): Unit = {
     exitStruct(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def enterMeta_value(ctx: WdlV2Parser.Meta_valueContext): Unit = {
+    enterMeta_value(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def exitMeta_value(ctx: WdlV2Parser.Meta_valueContext): Unit = {
+    exitMeta_value(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def enterMeta_string(ctx: WdlV2Parser.Meta_stringContext): Unit = {
+    enterMeta_string(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def exitMeta_string(ctx: WdlV2Parser.Meta_stringContext): Unit = {
+    exitMeta_string(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def enterMeta_array(ctx: WdlV2Parser.Meta_arrayContext): Unit = {
+    enterMeta_array(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def exitMeta_array(ctx: WdlV2Parser.Meta_arrayContext): Unit = {
+    exitMeta_array(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def enterMeta_object(ctx: WdlV2Parser.Meta_objectContext): Unit = {
+    enterMeta_object(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def exitMeta_object(ctx: WdlV2Parser.Meta_objectContext): Unit = {
+    exitMeta_object(ctx.asInstanceOf[ParserRuleContext])
   }
   override def enterMeta_kv(ctx: WdlV2Parser.Meta_kvContext): Unit = {
     enterMeta_kv(ctx.asInstanceOf[ParserRuleContext])

--- a/src/main/scala/wdlTools/syntax/Util.scala
+++ b/src/main/scala/wdlTools/syntax/Util.scala
@@ -21,7 +21,6 @@ object Util {
     }
 
     expr match {
-      case ValueNull(_)                    => "null"
       case ValueNone(_)                    => "None"
       case ValueString(value, _)           => value
       case ValueBoolean(value: Boolean, _) => value.toString
@@ -114,6 +113,30 @@ object Util {
 
       case ExprGetName(e: Expr, id: String, _) =>
         s"${exprToString(e, callback)}.${id}"
+    }
+  }
+
+  def metaValueToString(value: MetaValue,
+                        callback: Option[MetaValue => Option[String]] = None): String = {
+    if (callback.isDefined) {
+      val s = callback.get(value)
+      if (s.isDefined) {
+        return s.get
+      }
+    }
+    value match {
+      case MetaValueNull(_)                    => "null"
+      case MetaValueString(value, _)           => value
+      case MetaValueBoolean(value: Boolean, _) => value.toString
+      case MetaValueInt(value, _)              => value.toString
+      case MetaValueFloat(value, _)            => value.toString
+      case MetaValueArray(value, _) =>
+        "[" + value.map(x => metaValueToString(x, callback)).mkString(", ") + "]"
+      case MetaValueObject(value, _) =>
+        val m = value
+          .map(x => s"${x.id} : ${metaValueToString(x.value, callback)}")
+          .mkString(", ")
+        s"{$m}"
     }
   }
 }

--- a/src/main/scala/wdlTools/syntax/draft_2/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/draft_2/ParseAll.scala
@@ -133,7 +133,7 @@ case class ParseAll(opts: Options,
     }
 
     def translateMetaKV(kv: CST.MetaKV): AST.MetaKV = {
-      AST.MetaKV(kv.id, AST.ValueString(kv.value, kv.text), kv.text)
+      AST.MetaKV(kv.id, AST.MetaValueString(kv.value, kv.text), kv.text)
     }
 
     def translateInputSection(

--- a/src/main/scala/wdlTools/syntax/v1/ConcreteSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ConcreteSyntax.scala
@@ -33,7 +33,6 @@ object ConcreteSyntax {
 
   // expressions
   sealed trait Expr extends Element
-  case class ExprNull(text: TextSource) extends Expr
   case class ExprString(value: String, text: TextSource) extends Expr
   case class ExprBoolean(value: Boolean, text: TextSource) extends Expr
   case class ExprInt(value: Int, text: TextSource) extends Expr
@@ -122,8 +121,17 @@ object ConcreteSyntax {
   case class RuntimeKV(id: String, expr: Expr, text: TextSource) extends Element
   case class RuntimeSection(kvs: Vector[RuntimeKV], text: TextSource) extends Element
 
+  // A specialized JSON-like object language for meta values only.
+  sealed trait MetaValue extends Element
+  case class MetaValueNull(text: TextSource) extends MetaValue
+  case class MetaValueBoolean(value: Boolean, text: TextSource) extends MetaValue
+  case class MetaValueInt(value: Int, text: TextSource) extends MetaValue
+  case class MetaValueFloat(value: Double, text: TextSource) extends MetaValue
+  case class MetaValueString(value: String, text: TextSource) extends MetaValue
+  case class MetaValueObject(value: Vector[MetaKV], text: TextSource) extends MetaValue
+  case class MetaValueArray(value: Vector[MetaValue], text: TextSource) extends MetaValue
   // meta section
-  case class MetaKV(id: String, expr: Expr, text: TextSource) extends Element
+  case class MetaKV(id: String, value: MetaValue, text: TextSource) extends Element
   case class ParameterMetaSection(kvs: Vector[MetaKV], text: TextSource) extends Element
   case class MetaSection(kvs: Vector[MetaKV], text: TextSource) extends Element
 

--- a/src/main/scala/wdlTools/syntax/v2/ConcreteSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/v2/ConcreteSyntax.scala
@@ -33,7 +33,6 @@ object ConcreteSyntax {
 
   // expressions
   sealed trait Expr extends Element
-  case class ExprNull(text: TextSource) extends Expr
   case class ExprNone(text: TextSource) extends Expr
   case class ExprString(value: String, text: TextSource) extends Expr
   case class ExprBoolean(value: Boolean, text: TextSource) extends Expr
@@ -46,7 +45,6 @@ object ConcreteSyntax {
   case class ExprCompoundString(value: Vector[Expr], text: TextSource) extends Expr
   case class ExprMapItem(key: Expr, value: Expr, text: TextSource) extends Expr
   case class ExprMapLiteral(value: Vector[ExprMapItem], text: TextSource) extends Expr
-  case class ExprObjectMember(key: String, value: Expr, text: TextSource) extends Expr
   case class ExprArrayLiteral(value: Vector[Expr], text: TextSource) extends Expr
 
   case class ExprIdentifier(id: String, text: TextSource) extends Expr
@@ -98,8 +96,17 @@ object ConcreteSyntax {
   case class RuntimeKV(id: String, expr: Expr, text: TextSource) extends Element
   case class RuntimeSection(kvs: Vector[RuntimeKV], text: TextSource) extends Element
 
+  // A specialized JSON-like object language for meta values only.
+  sealed trait MetaValue extends Element
+  case class MetaValueNull(text: TextSource) extends MetaValue
+  case class MetaValueBoolean(value: Boolean, text: TextSource) extends MetaValue
+  case class MetaValueInt(value: Int, text: TextSource) extends MetaValue
+  case class MetaValueFloat(value: Double, text: TextSource) extends MetaValue
+  case class MetaValueString(value: String, text: TextSource) extends MetaValue
+  case class MetaValueObject(value: Vector[MetaKV], text: TextSource) extends MetaValue
+  case class MetaValueArray(value: Vector[MetaValue], text: TextSource) extends MetaValue
   // meta section
-  case class MetaKV(id: String, expr: Expr, text: TextSource) extends Element
+  case class MetaKV(id: String, value: MetaValue, text: TextSource) extends Element
   case class ParameterMetaSection(kvs: Vector[MetaKV], text: TextSource) extends Element
   case class MetaSection(kvs: Vector[MetaKV], text: TextSource) extends Element
 

--- a/src/main/scala/wdlTools/syntax/v2/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/v2/ParseAll.scala
@@ -121,46 +121,28 @@ case class ParseAll(opts: Options,
     // $meta_object = '{}' | '{' $parameter_meta_kv (, $parameter_meta_kv)* '}'
     // $meta_array = '[]' |  '[' $meta_value (, $meta_value)* ']'
     //
-    private def translateMetaValue(value: CST.Expr): AST.Expr = {
+    private def translateMetaValue(value: CST.MetaValue): AST.MetaValue = {
       value match {
         // values
-        case CST.ExprString(value, srcText)  => AST.ValueString(value, srcText)
-        case CST.ExprBoolean(value, srcText) => AST.ValueBoolean(value, srcText)
-        case CST.ExprInt(value, srcText)     => AST.ValueInt(value, srcText)
-        case CST.ExprFloat(value, srcText)   => AST.ValueFloat(value, srcText)
-
-        // special handling for null. It appears as an identifier here, even though
-        // it has not been defined, and it is no identifier.
-        case CST.ExprIdentifier(id, srcText) if id == "null" =>
-          AST.ExprIdentifier(id, srcText)
-        case CST.ExprIdentifier(id, srcText) =>
-          throw new SyntaxException(s"cannot access identifier (${id}) in a meta section",
-                                    srcText,
-                                    docSourceUrl)
-
-        // compound values
-        case CST.ExprPair(l, r, srcText) =>
-          AST.ExprPair(translateMetaValue(l), translateMetaValue(r), srcText)
-        case CST.ExprArrayLiteral(vec, srcText) =>
-          AST.ExprArray(vec.map(translateMetaValue), srcText)
-        case CST.ExprMapLiteral(m, srcText) =>
-          AST.ExprMap(
-              m.map {
-                case CST.ExprMapItem(CST.ExprIdentifier(k, text2), value, text) =>
-                  AST.ExprMapItem(AST.ExprIdentifier(k, text2), translateMetaValue(value), text)
-                case _ =>
-                  throw new SyntaxException(s"Illegal meta field value", srcText, docSourceUrl)
-              },
-              srcText
-          )
-
+        case CST.MetaValueString(value, srcText)  => AST.MetaValueString(value, srcText)
+        case CST.MetaValueBoolean(value, srcText) => AST.MetaValueBoolean(value, srcText)
+        case CST.MetaValueInt(value, srcText)     => AST.MetaValueInt(value, srcText)
+        case CST.MetaValueFloat(value, srcText)   => AST.MetaValueFloat(value, srcText)
+        case CST.MetaValueNull(srcText)           => AST.MetaValueNull(srcText)
+        case CST.MetaValueArray(vec, srcText) =>
+          AST.MetaValueArray(vec.map(translateMetaValue), srcText)
+        case CST.MetaValueObject(m, srcText) =>
+          AST.MetaValueObject(m.map {
+            case CST.MetaKV(fieldName: String, v, text) =>
+              AST.MetaKV(fieldName, translateMetaValue(v), text)
+          }, srcText)
         case other =>
           throw new SyntaxException("illegal expression in meta section", other.text, docSourceUrl)
       }
     }
 
     def translateMetaKV(kv: CST.MetaKV): AST.MetaKV = {
-      AST.MetaKV(kv.id, translateMetaValue(kv.expr), kv.text)
+      AST.MetaKV(kv.id, translateMetaValue(kv.value), kv.text)
     }
 
     def translateInputSection(

--- a/src/main/scala/wdlTools/syntax/v2/ParseTop.scala
+++ b/src/main/scala/wdlTools/syntax/v2/ParseTop.scala
@@ -580,12 +580,81 @@ any_decls
     throw new SyntaxException("bad declaration format", getTextSource(ctx), grammar.docSourceUrl)
   }
 
+  /* meta_value
+    : BoolLiteral
+    | number
+    | string
+    | meta_object
+    | meta_array
+    | NULL_LITERAL
+    ; */
+  override def visitMeta_value(ctx: WdlV2Parser.Meta_valueContext): MetaValue = {
+    if (ctx.NULL_LITERAL() != null) {
+      return MetaValueNull(getTextSource(ctx))
+    }
+    if (ctx.BoolLiteral() != null) {
+      val value = ctx.getText.toLowerCase() == "true"
+      return MetaValueBoolean(value, getTextSource(ctx))
+    }
+    if (ctx.number() != null) {
+      visitNumber(ctx.number()) match {
+        case ExprInt(value, text)   => MetaValueInt(value, text)
+        case ExprFloat(value, text) => MetaValueFloat(value, text)
+        case other                  => throw new RuntimeException(s"Invalid number expression ${other}")
+      }
+    }
+    if (ctx.meta_string() != null) {
+      return visitMeta_string(ctx.meta_string())
+    }
+    if (ctx.meta_array() != null) {
+      return visitMeta_array(ctx.meta_array())
+    }
+    if (ctx.meta_object() != null) {
+      return visitMeta_object(ctx.meta_object())
+    }
+    throw new SyntaxException("Not one of four supported variants of meta_value",
+                              getTextSource(ctx),
+                              grammar.docSourceUrl)
+  }
+
+  /* meta_string
+    : DQUOTE string_part DQUOTE
+    | SQUOTE string_part SQUOTE
+    ; */
+  override def visitMeta_string(ctx: WdlV2Parser.Meta_stringContext): MetaValueString = {
+    val parts: Vector[String] = ctx
+      .string_part()
+      .StringPart()
+      .asScala
+      .map(x => x.getText)
+      .toVector
+    MetaValueString(parts.mkString, getTextSource(ctx))
+  }
+
+  /* meta_array: LBRACK (meta_value (COMMA meta_value)*)* RBRACK;
+   */
+  override def visitMeta_array(ctx: WdlV2Parser.Meta_arrayContext): MetaValueArray = {
+    val items = ctx.meta_value().asScala.toVector.map(visitMeta_value)
+    MetaValueArray(items, getTextSource(ctx))
+  }
+
+  /* meta_object: LBRACE (meta_kv (COMMA meta_kv)*)* RBRACE;
+   */
+  override def visitMeta_object(ctx: WdlV2Parser.Meta_objectContext): MetaValueObject = {
+    val members = ctx
+      .meta_kv()
+      .asScala
+      .toVector
+      .map(visitMeta_kv)
+    MetaValueObject(members, getTextSource(ctx))
+  }
+
   /* meta_kv
-   : Identifier COLON expr
-   ; */
+     : Identifier COLON expr
+     ; */
   override def visitMeta_kv(ctx: WdlV2Parser.Meta_kvContext): MetaKV = {
     val id = getIdentifierText(ctx.Identifier(), ctx)
-    val expr = visitExpr(ctx.expr())
+    val expr = visitMeta_value(ctx.meta_value())
     MetaKV(id, expr, getTextSource(ctx))
   }
 

--- a/src/main/scala/wdlTools/types/TypeInfer.scala
+++ b/src/main/scala/wdlTools/types/TypeInfer.scala
@@ -229,8 +229,8 @@ case class TypeInfer(conf: TypeOptions, errorHandler: Option[Vector[TypeError] =
   //
   private def applyExpr(expr: AST.Expr, bindings: Bindings, ctx: Context): TAT.Expr = {
     expr match {
-      // null can be any type optional
-      case AST.ValueNull(text)           => TAT.ValueNull(T_Optional(T_Any), text)
+      // None can be any type optional
+      case AST.ValueNone(text)           => TAT.ValueNone(T_Optional(T_Any), text)
       case AST.ValueBoolean(value, text) => TAT.ValueBoolean(value, T_Boolean, text)
       case AST.ValueInt(value, text)     => TAT.ValueInt(value, T_Int, text)
       case AST.ValueFloat(value, text)   => TAT.ValueFloat(value, T_Float, text)
@@ -705,40 +705,25 @@ case class TypeInfer(conf: TypeOptions, errorHandler: Option[Vector[TypeError] =
 
   // convert the generic expression syntax into a specialized JSON object
   // language for meta values only.
-  private def metaValueFromExpr(expr: AST.Expr, ctx: Context): TAT.MetaValue = {
+  private def applyMetaValue(expr: AST.MetaValue, ctx: Context): TAT.MetaValue = {
     expr match {
-      case AST.ValueNull(text)                          => TAT.MetaValueNull(text)
-      case AST.ValueBoolean(value, text)                => TAT.MetaValueBoolean(value, text)
-      case AST.ValueInt(value, text)                    => TAT.MetaValueInt(value, text)
-      case AST.ValueFloat(value, text)                  => TAT.MetaValueFloat(value, text)
-      case AST.ValueString(value, text)                 => TAT.MetaValueString(value, text)
-      case AST.ExprIdentifier(id, text) if id == "null" => TAT.MetaValueNull(text)
-      case AST.ExprIdentifier(id, text)                 => TAT.MetaValueString(id, text)
-      case AST.ExprArray(vec, text)                     => TAT.MetaValueArray(vec.map(metaValueFromExpr(_, ctx)), text)
-      case AST.ExprMap(members, text) =>
+      case AST.MetaValueNull(text)           => TAT.MetaValueNull(text)
+      case AST.MetaValueBoolean(value, text) => TAT.MetaValueBoolean(value, text)
+      case AST.MetaValueInt(value, text)     => TAT.MetaValueInt(value, text)
+      case AST.MetaValueFloat(value, text)   => TAT.MetaValueFloat(value, text)
+      case AST.MetaValueString(value, text)  => TAT.MetaValueString(value, text)
+      case AST.MetaValueArray(vec, text) =>
+        TAT.MetaValueArray(vec.map(applyMetaValue(_, ctx)), text)
+      case AST.MetaValueObject(members, text) =>
         TAT.MetaValueObject(
             members.map {
-              case AST.ExprMapItem(AST.ValueString(key, _), value, _) =>
-                key -> metaValueFromExpr(value, ctx)
-              case AST.ExprMapItem(AST.ExprIdentifier(key, _), value, _) =>
-                key -> metaValueFromExpr(value, ctx)
-              case other =>
-                throw new RuntimeException(s"bad value ${SUtil.exprToString(other)}")
-            }.toMap,
-            text
-        )
-      case AST.ExprObject(members, text) =>
-        TAT.MetaValueObject(
-            members.map {
-              case AST.ExprObjectMember(key, value, _) =>
-                key -> metaValueFromExpr(value, ctx)
-              case other =>
-                throw new RuntimeException(s"bad value ${SUtil.exprToString(other)}")
+              case AST.MetaKV(key, value, _) =>
+                key -> applyMetaValue(value, ctx)
             }.toMap,
             text
         )
       case other =>
-        handleError(s"${SUtil.exprToString(other)} is an invalid meta value", expr.text, ctx)
+        handleError(s"${SUtil.metaValueToString(other)} is an invalid meta value", expr.text, ctx)
         TAT.MetaValueNull(other.text)
     }
   }
@@ -746,7 +731,7 @@ case class TypeInfer(conf: TypeOptions, errorHandler: Option[Vector[TypeError] =
   private def applyMeta(metaSection: AST.MetaSection, ctx: Context): TAT.MetaSection = {
     TAT.MetaSection(metaSection.kvs.map {
       case AST.MetaKV(k, v, _) =>
-        k -> metaValueFromExpr(v, ctx)
+        k -> applyMetaValue(v, ctx)
     }.toMap, metaSection.text)
   }
 
@@ -755,14 +740,14 @@ case class TypeInfer(conf: TypeOptions, errorHandler: Option[Vector[TypeError] =
     TAT.ParameterMetaSection(
         paramMetaSection.kvs.map { kv: AST.MetaKV =>
           val metaValue = if (ctx.inputs.contains(kv.id) || ctx.outputs.contains(kv.id)) {
-            metaValueFromExpr(kv.expr, ctx)
+            applyMetaValue(kv.value, ctx)
           } else {
             handleError(
                 s"parameter_meta key ${kv.id} does not refer to an input or output declaration",
                 kv.text,
                 ctx
             )
-            TAT.MetaValueNull(kv.expr.text)
+            TAT.MetaValueNull(kv.value.text)
           }
           kv.id -> metaValue
         }.toMap,
@@ -1050,7 +1035,7 @@ case class TypeInfer(conf: TypeOptions, errorHandler: Option[Vector[TypeError] =
     // add a binding for the iteration variable
     //
     // The iterator identifier is not exported outside the scatter
-    val (ctxInner, wdlType) =
+    val (ctxInner, _) =
       try {
         (ctxOuter.bindVar(scatter.identifier, elementType), elementType)
       } catch {

--- a/src/test/scala/wdlTools/syntax/AbstractSyntaxTest.scala
+++ b/src/test/scala/wdlTools/syntax/AbstractSyntaxTest.scala
@@ -72,7 +72,7 @@ class AbstractSyntaxTest extends AnyFlatSpec with Matchers {
     task.parameterMeta.get.kvs.size shouldBe 1
     val mpkv = task.parameterMeta.get.kvs.head
     mpkv should matchPattern {
-      case MetaKV("i", ExprIdentifier("null", _), _) =>
+      case MetaKV("i", MetaValueNull(_), _) =>
     }
   }
 

--- a/src/test/scala/wdlTools/syntax/v1/ConcreteSyntaxV1Test.scala
+++ b/src/test/scala/wdlTools/syntax/v1/ConcreteSyntaxV1Test.scala
@@ -324,14 +324,14 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
     task.meta.get.kvs.size shouldBe 1
     val mkv = task.meta.get.kvs.head
     mkv should matchPattern {
-      case MetaKV("author", ExprString("Robin Hood", _), _) =>
+      case MetaKV("author", MetaValueString("Robin Hood", _), _) =>
     }
 
     task.parameterMeta.get shouldBe a[ParameterMetaSection]
     task.parameterMeta.get.kvs.size shouldBe 1
     val mpkv = task.parameterMeta.get.kvs.head
     mpkv should matchPattern {
-      case MetaKV("inp_file", ExprString("just because", _), _) =>
+      case MetaKV("inp_file", MetaValueString("just because", _), _) =>
     }
 
     task.declarations(0) should matchPattern {
@@ -450,7 +450,7 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
 
     wf.meta.get shouldBe a[MetaSection]
     wf.meta.get.kvs should matchPattern {
-      case Vector(MetaKV("author", ExprString("Robert Heinlein", _), _)) =>
+      case Vector(MetaKV("author", MetaValueString("Robert Heinlein", _), _)) =>
     }
   }
 


### PR DESCRIPTION
This PR implements separate handling of meta values from the grammar all the way through to AST. It also adds a 'null' keyword that is only recognized for meta values, so it is no longer necessary to handle null as a special-case identifier.