### PR TITLE
Using a protocol abstraction to access files

### DIFF
--- a/src/main/scala/wdlTools/eval/IoSupp.scala
+++ b/src/main/scala/wdlTools/eval/IoSupp.scala
@@ -1,102 +1,65 @@
 package wdlTools.eval
 
 import java.io.ByteArrayOutputStream
-import java.net.{HttpURLConnection, MalformedURLException, URL}
+import java.net.{HttpURLConnection, URL}
+import java.nio.charset.Charset
 import java.nio.file._
 
 import wdlTools.syntax.TextSource
-import wdlTools.util.{Options, Util, Verbosity}
+import wdlTools.util.{Options, Verbosity}
 
 import scala.jdk.CollectionConverters._
 import scala.util.Random
 
-case class IoSupp(opts: Options, evalCfg: EvalConfig, docSourceUrl: Option[URL]) {
-  val MiB = BigDecimal(1024 * 1024)
-  val MaxFileSizeMiB = BigDecimal(256)
+// Functions that (possibly) necessitate I/O operation (on local, network, or cloud filesystems)
+case class IoSupp(opts: Options,
+                  evalCfg: EvalConfig,
+                  docSourceUrl: Option[URL]) {
 
-  private def asPathOrUrl(pathOrUrl: String, text: TextSource): Either[Path, URL] = {
-    try {
+  // Figure out which protocol should be used
+  private def figureOutProtocol(pathOrUrl: String, text : TextSource) : FileAccessProtocol = {
+    val prefix : String =
       if (pathOrUrl.contains("://")) {
-        Right(new URL(pathOrUrl))
+        new URL(pathOrUrl).getProtocol
       } else {
-        Left(Paths.get(pathOrUrl))
+        "file"
       }
-    } catch {
-      case _: MalformedURLException =>
-        throw new EvalException(s"Invalid URL ${pathOrUrl}", text, docSourceUrl)
-      case _: InvalidPathException =>
-        throw new EvalException(s"Invalid path ${pathOrUrl}", text, docSourceUrl)
-      case t: Throwable =>
-        throw new EvalException(s"Invalid path or URL ${pathOrUrl}: ${t.getMessage}",
+    evalCfg.protocols.get(prefix) match {
+      case None =>
+        throw new EvalException(s"Protocol ${prefix} not supported",
                                 text,
                                 docSourceUrl)
+      case Some(proto) => proto
     }
   }
 
-  private def assertExists(p: Path): Unit = {
-    if (!Files.exists(p)) {
-      throw new FileSystemNotFoundException(s"File ${p} not found")
-    }
-  }
-
-  // Functions that (possibly) necessitate I/O operation (on local, network, or cloud filesystems)
-  private def readLocalFile(p: Path): String = {
-    assertExists(p)
-    new String(Files.readAllBytes(p), evalCfg.encoding)
-  }
-
-  private def readUrlContent(url: URL): String = {
-    val is = url.openStream()
-    val buffer: ByteArrayOutputStream = new ByteArrayOutputStream()
-
+  def size(pathOrUrl: String, text: TextSource) : Long = {
+    val proto = figureOutProtocol(pathOrUrl, text)
     try {
-      // read all the bytes from the URL
-      var nRead = 0
-      val data = new Array[Byte](16384)
-
-      while (nRead > 0) {
-        nRead = is.read(data, 0, data.length)
-        if (nRead > 0)
-          buffer.write(data, 0, nRead)
-      }
-
-      new String(buffer.toByteArray, evalCfg.encoding)
-    } finally {
-      is.close()
-      buffer.close()
+      proto.size(pathOrUrl)
+    } catch {
+      case e : Throwable =>
+        throw new EvalException(
+          s"error getting size of ${pathOrUrl}, msg=${e.getMessage}",
+          text,
+          docSourceUrl)
     }
   }
 
   // Read the contents of the file/URL and return a string
   def readFile(pathOrUrl: String, text: TextSource): String = {
-    // check that file isn't too big
-    val fileSizeMiB = BigDecimal(size(pathOrUrl, text)) / MiB
-    if (fileSizeMiB > MaxFileSizeMiB) {
-      throw new EvalException(
-          s"${pathOrUrl} size is ${fileSizeMiB} MiB; reading files larger than ${MaxFileSizeMiB} MiB is unsupported",
-          text,
-          docSourceUrl
-      )
-    }
+    val proto = figureOutProtocol(pathOrUrl, text)
     try {
-      asPathOrUrl(pathOrUrl, text) match {
-        case Left(path) => readLocalFile(path)
-        case Right(url) =>
-          url.getProtocol match {
-            case "http" | "https" => readUrlContent(new URL(pathOrUrl))
-            case "file"           => readLocalFile(Paths.get(pathOrUrl))
-            case _                => throw new EvalException(s"unknown protocol in URL ${url}", text, docSourceUrl)
-          }
-      }
+      proto.readFile(pathOrUrl)
     } catch {
-      case e: EvalException =>
-        Util.error(s"Error reading ${pathOrUrl}")
-        throw e
-      case t: Throwable =>
-        Util.error(s"Error reading ${pathOrUrl}")
-        throw new EvalException(s"Error reading ${pathOrUrl}: ${t.getMessage}", text, docSourceUrl)
+      case e : Throwable =>
+        throw new EvalException(
+          s"error read file ${pathOrUrl}, msg=${e.getMessage}",
+          text,
+          docSourceUrl)
     }
   }
+
 
   /**
     * Write "content" to the specified "path" location
@@ -143,44 +106,100 @@ case class IoSupp(opts: Options, evalCfg: EvalConfig, docSourceUrl: Option[URL])
     retval
   }
 
-  /**
-    * Return the size of the file located at "path"
-    */
-  def size(pathOrUrl: String, text: TextSource): Long = {
-    asPathOrUrl(pathOrUrl, text) match {
-      case Left(path) =>
-        try {
-          assertExists(path)
-          path.toFile.length()
-        } catch {
-          case t: Throwable =>
-            throw new EvalException(s"Error getting size of file ${pathOrUrl}: ${t.getMessage}",
-                                    text,
-                                    docSourceUrl)
-        }
-      case Right(url) =>
-        // A url
-        // https://stackoverflow.com/questions/12800588/how-to-calculate-a-file-size-from-url-in-java
-        var conn: HttpURLConnection = null
-        try {
-          conn = url.openConnection().asInstanceOf[HttpURLConnection]
-          conn.setRequestMethod("HEAD")
-          conn.getContentLengthLong
-        } catch {
-          case t: Throwable =>
-            throw new EvalException(s"Error getting size of URL ${url}: ${t.getMessage}",
-                                    text,
-                                    docSourceUrl)
-        } finally {
-          if (conn != null) {
-            conn.disconnect()
-          }
-        }
-    }
-  }
-
   def mkTempFile(): Path = {
     val rndName = Random.alphanumeric.take(8).mkString("")
     evalCfg.tmpDir.resolve(rndName)
+  }
+}
+
+object IoSupp {
+  val MiB = BigDecimal(1024 * 1024)
+  val MaxFileSizeMiB = BigDecimal(256)
+
+  case class LocalFiles(encoding: Charset) extends FileAccessProtocol {
+    val prefixes = Vector("", "file")
+
+    def size(path : String) : Long = {
+      val p = Paths.get(path)
+      if (!Files.exists(p)) {
+        throw new FileSystemNotFoundException(s"File ${p} not found")
+      }
+      try {
+        p.toFile.length()
+      } catch {
+        case t: Throwable =>
+          throw new Exception(s"Error getting size of file ${path}: ${t.getMessage}")
+      }
+    }
+
+    def readFile(path : String) : String = {
+      // check that file isn't too big
+      val fileSizeMiB = BigDecimal(size(path)) / MiB
+      if (fileSizeMiB > MaxFileSizeMiB) {
+        throw new Exception(
+          s"${path} size is ${fileSizeMiB} MiB; reading files larger than ${MaxFileSizeMiB} MiB is unsupported"
+        )
+      }
+      new String(Files.readAllBytes(Paths.get(path)), encoding)
+    }
+  }
+
+  case class HttpProtocol(encoding: Charset) extends FileAccessProtocol {
+    val prefixes = Vector("http", "https")
+
+    private def getUrl(rawUrl : String) : URL = {
+      if (!rawUrl.contains("://"))
+        throw new Exception(s"$rawUrl is not a URL")
+      new URL(rawUrl)
+    }
+
+    // A url
+    // https://stackoverflow.com/questions/12800588/how-to-calculate-a-file-size-from-url-in-java
+    //
+    def size(rawUrl : String) : Long = {
+      val url = getUrl(rawUrl)
+      var conn: HttpURLConnection = null
+      try {
+        conn = url.openConnection().asInstanceOf[HttpURLConnection]
+        conn.setRequestMethod("HEAD")
+        conn.getContentLengthLong
+      } catch {
+        case t: Throwable =>
+          throw new Exception(s"Error getting size of URL ${url}: ${t.getMessage}")
+      } finally {
+        if (conn != null) {
+          conn.disconnect()
+        }
+      }
+    }
+
+    def readFile(rawUrl: String): String = {
+      // check that file isn't too big
+      val fileSizeMiB = BigDecimal(size(rawUrl)) / MiB
+      if (fileSizeMiB > MaxFileSizeMiB)
+        throw new Exception(
+          s"${rawUrl} size is ${fileSizeMiB} MiB; reading files larger than ${MaxFileSizeMiB} MiB is unsupported")
+
+      val url = getUrl(rawUrl)
+      val is = url.openStream()
+      val buffer: ByteArrayOutputStream = new ByteArrayOutputStream()
+
+      try {
+        // read all the bytes from the URL
+        var nRead = 0
+        val data = new Array[Byte](16384)
+
+        while (nRead > 0) {
+          nRead = is.read(data, 0, data.length)
+          if (nRead > 0)
+            buffer.write(data, 0, nRead)
+        }
+
+        new String(buffer.toByteArray, encoding)
+      } finally {
+        is.close()
+        buffer.close()
+      }
+    }
   }
 }

--- a/src/main/scala/wdlTools/eval/package.scala
+++ b/src/main/scala/wdlTools/eval/package.scala
@@ -31,13 +31,13 @@ trait StandardLibraryImpl {
 //   For dnanexus        dx://
 //
 trait FileAccessProtocol {
-  val prefixes : Vector[String]
+  val prefixes: Vector[String]
 
   // Get the size of the file in bytes
-  def size(path : String) : Long
+  def size(path: String): Long
 
   // Read the entire file into a string
-  def readFile(path : String) : String
+  def readFile(path: String): String
 }
 
 /** Configuration for expression evaluation. Some operations perform file IO.
@@ -53,7 +53,7 @@ case class EvalConfig(homeDir: Path,
                       tmpDir: Path,
                       stdout: Path,
                       stderr: Path,
-                      protocols : Map[String, FileAccessProtocol],
+                      protocols: Map[String, FileAccessProtocol],
                       encoding: Charset)
 
 object EvalConfig {
@@ -62,25 +62,20 @@ object EvalConfig {
            tmpDir: Path,
            stdout: Path,
            stderr: Path,
-           userProtos : Vector[FileAccessProtocol] = Vector.empty,
+           userProtos: Vector[FileAccessProtocol] = Vector.empty,
            encoding: Charset = Codec.default.charSet) = {
-    val defaultProtos = Vector(IoSupp.LocalFiles(encoding),
-                               IoSupp.HttpProtocol(encoding))
+    val defaultProtos = Vector(IoSupp.LocalFiles(encoding), IoSupp.HttpProtocol(encoding))
     val allProtos = defaultProtos ++ userProtos
-    val dispatchTbl : Map[String, FileAccessProtocol] =
-      allProtos.map {
-        proto => proto.prefixes.map { prefix =>
-          (prefix, proto)
+    val dispatchTbl: Map[String, FileAccessProtocol] =
+      allProtos
+        .map { proto =>
+          proto.prefixes.map { prefix =>
+            (prefix, proto)
+          }
         }
-      }
         .flatten
         .toMap
-    new EvalConfig(homeDir,
-                   tmpDir,
-                   stdout,
-                   stderr,
-                   dispatchTbl,
-                   encoding)
+    new EvalConfig(homeDir, tmpDir, stdout, stderr, dispatchTbl, encoding)
   }
 }
 

--- a/src/main/scala/wdlTools/eval/package.scala
+++ b/src/main/scala/wdlTools/eval/package.scala
@@ -20,19 +20,68 @@ trait StandardLibraryImpl {
   def call(funcName: String, args: Vector[WdlValues.V], text: TextSource): WdlValues.V
 }
 
+// A protocol defined by the user. Intended for allowing access to
+// private/public clouds such as S3, Azure, or dnanexus. This has to be a web
+// protocol, meaning that the prefix has to include "://". Anything
+// else is considered a local file.
+//
+// PREFIX
+//   For S3 it is        s3://
+//   For dnanexus it is  dx://
+//
+trait FileAccessProtocol {
+  val prefixes : Vector[String]
+
+  // Get the size of the file in bytes
+  def size(path : String) : Long
+
+  // Read the entire file into a string
+  def readFile(path : String) : String
+}
+
 /** Configuration for expression evaluation. Some operations perform file IO.
   *
   * @param homeDir  the root directory for relative paths, and the root directory for search (glob).
   * @param tmpDir   directory for placing temporary files.
   * @param stdout   the file that has a copy of standard output. This is used in the command section.
   * @param stderr   as above for standard error.
+  * @param protocols  protocols for accessing files. By default local-file and http protocols are provided.
   * @param encoding the encoding to use when reading files.
   */
 case class EvalConfig(homeDir: Path,
                       tmpDir: Path,
                       stdout: Path,
                       stderr: Path,
-                      encoding: Charset = Codec.default.charSet)
+                      protocols : Map[String, FileAccessProtocol],
+                      encoding: Charset)
+
+object EvalConfig {
+  // Add the default protocols (file and web) into the configuration.
+  def make(homeDir: Path,
+           tmpDir: Path,
+           stdout: Path,
+           stderr: Path,
+           userProtos : Vector[FileAccessProtocol] = Vector.empty,
+           encoding: Charset = Codec.default.charSet) = {
+    val defaultProtos = Vector(IoSupp.LocalFiles(encoding),
+                               IoSupp.HttpProtocol(encoding))
+    val allProtos = defaultProtos ++ userProtos
+    val dispatchTbl : Map[String, FileAccessProtocol] =
+      allProtos.map {
+        proto => proto.prefixes.map { prefix =>
+          (prefix, proto)
+        }
+      }
+        .flatten
+        .toMap
+    new EvalConfig(homeDir,
+                   tmpDir,
+                   stdout,
+                   stderr,
+                   dispatchTbl,
+                   encoding)
+  }
+}
 
 // A runtime error
 final class EvalException(message: String) extends Exception(message) {

--- a/src/main/scala/wdlTools/eval/package.scala
+++ b/src/main/scala/wdlTools/eval/package.scala
@@ -26,8 +26,9 @@ trait StandardLibraryImpl {
 // else is considered a local file.
 //
 // PREFIX
-//   For S3 it is        s3://
-//   For dnanexus it is  dx://
+//   For S3              s3://
+//   For google cloud    gs://
+//   For dnanexus        dx://
 //
 trait FileAccessProtocol {
   val prefixes : Vector[String]
@@ -56,7 +57,7 @@ case class EvalConfig(homeDir: Path,
                       encoding: Charset)
 
 object EvalConfig {
-  // Add the default protocols (file and web) into the configuration.
+  // Always add the default protocols (file and web) into the configuration.
   def make(homeDir: Path,
            tmpDir: Path,
            stdout: Path,

--- a/src/test/scala/wdlTools/eval/EvalTest.scala
+++ b/src/test/scala/wdlTools/eval/EvalTest.scala
@@ -40,7 +40,7 @@ class EvalTest extends AnyFlatSpec with Matchers with Inside {
       safeMkdir(d)
     val stdout = baseDir.resolve("stdout")
     val stderr = baseDir.resolve("stderr")
-    eval.EvalConfig(homeDir, tmpDir, stdout, stderr)
+    eval.EvalConfig.make(homeDir, tmpDir, stdout, stderr)
   }
 
   def parseAndTypeCheck(file: Path): TAT.Document = {

--- a/src/test/scala/wdlTools/syntax/v1/ConcreteSyntaxV1Test.scala
+++ b/src/test/scala/wdlTools/syntax/v1/ConcreteSyntaxV1Test.scala
@@ -15,7 +15,7 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
   private val workflowsDir = sourcePath.resolve("workflows")
   private val structsDir = sourcePath.resolve("structs")
   private val opts = BasicOptions(
-      antlr4Trace = true,
+      antlr4Trace = false,
       verbosity = Quiet,
       localDirectories = Vector(tasksDir, workflowsDir, structsDir)
   )


### PR DESCRIPTION
Use an abstraction to support multiple file access protocols. By default web and local files are supported. For dnanexus, dxWDL adds an implementation for URLs that are prefixed by "dx://". Te mechanism is extensible to, say, S3, Azure, or google cloud URLs.