### PR TITLE
APPS-492:fixed indentation error

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.12.9
+
+* Fixed indentation issue in command block
+
 ## 0.12.8 (dev)
 
 * Adds support for Object -> Map coercion

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 wdlTools {
-    version = "0.12.8"
+    version = "0.12.9"
 }
 
 #

--- a/src/main/scala/wdlTools/eval/Eval.scala
+++ b/src/main/scala/wdlTools/eval/Eval.scala
@@ -548,7 +548,6 @@ case class Eval(paths: EvalPaths,
     val WsRegex = "^([ \t]*)(.*)$".r
 
     val content = lines.foldLeft(Vector.empty[(String, String)]) {
-      // case (content, wsRegex(txt))        => content :+ (txt, "")
       case (content, WsRegex(ws, txt)) if txt.length + ws.length > 0 => content :+ (ws, txt)
       case (content, WsRegex(_, _)) => content
     }

--- a/src/main/scala/wdlTools/eval/Eval.scala
+++ b/src/main/scala/wdlTools/eval/Eval.scala
@@ -545,25 +545,22 @@ case class Eval(paths: EvalPaths,
     // split string into lines and drop all leading and trailing empty lines
     val lines =
       s.split("\r\n?|\n").dropWhile(_.trim.isEmpty).reverse.dropWhile(_.trim.isEmpty).reverse
-    val wsRegex = "^([ \t]*)$".r
-    val nonWsRegex = "^([ \t]*)(.+)$".r
+    val WsRegex = "^([ \t]*)(.*)$".r
+
     val content = lines.foldLeft(Vector.empty[(String, String)]) {
-      case (content, wsRegex(txt))        => content :+ (txt, "")
-      case (content, nonWsRegex(ws, txt)) => content :+ (ws, txt)
+      // case (content, wsRegex(txt))        => content :+ (txt, "")
+      case (content, WsRegex(ws, txt)) if txt.length + ws.length > 0 => content :+ (ws, txt)
+      case (content, WsRegex(_, _)) => content
     }
     if (content.isEmpty) {
       ""
     } else {
       val (whitespace, strippedLines) = content.unzip
       val colOffset = whitespace.map(_.length).min
-      val strippedContent = if (colOffset == 0) {
-        strippedLines
-      } else {
-        // add back to each line any whitespace longer than colOffset
-        strippedLines.zip(whitespace).map {
-          case (line, ws) if ws.length > colOffset => ws.drop(colOffset) + line
-          case (line, _)                           => line
-        }
+      // add back to each line any whitespace longer than colOffset
+      val strippedContent = strippedLines.zip(whitespace).map {
+        case (line, ws) if ws.length > colOffset => ws.drop(colOffset) + line
+        case (line, _)                           => line
       }
       strippedContent.mkString(System.lineSeparator())
     }

--- a/src/test/resources/eval/v1/empty_lines.wdl
+++ b/src/test/resources/eval/v1/empty_lines.wdl
@@ -1,0 +1,18 @@
+version 1.0
+
+task foo {
+    command <<<
+        cat <<-EOF > test.py
+a = 1
+
+
+
+if a == 0:
+
+    print("a = 0")
+else:
+    print("a = 1")
+EOF
+        python3 test.py
+    >>>
+}

--- a/src/test/resources/eval/v1/leading_spaces.wdl
+++ b/src/test/resources/eval/v1/leading_spaces.wdl
@@ -1,0 +1,14 @@
+version 1.0
+
+task foo {
+    command <<<
+        cat <<-EOF > test.py
+a = 1
+if a == 0:
+    print("a = 0")
+else:
+    print("a = 1")
+EOF
+        python3 test.py
+    >>>
+}

--- a/src/test/resources/eval/v1/leading_spaces2.wdl
+++ b/src/test/resources/eval/v1/leading_spaces2.wdl
@@ -1,0 +1,14 @@
+version 1.0
+
+task foo {
+    command <<<
+        cat <<-EOF > test.py
+    a = 1
+    if a == 0:
+        print("a = 0")
+    else:
+        print("a = 1")
+    EOF
+        python3 test.py
+    >>>
+}

--- a/src/test/scala/wdlTools/eval/EvalTest.scala
+++ b/src/test/scala/wdlTools/eval/EvalTest.scala
@@ -277,6 +277,21 @@ class EvalTest extends AnyFlatSpec with Matchers with Inside {
     evaluator.applyCommand(task.command, ctx)
   }
 
+  it should "evaluate command with leading spaces" in {
+    val command = evalCommand("leading_spaces.wdl")
+    command shouldBe "        cat <<-EOF > test.py\na = 1\nif a == 0:\n    print(\"a = 0\")\nelse:\n    print(\"a = 1\")\nEOF\n        python3 test.py"
+  }
+
+  it should "evaluate command with leading spaces2" in {
+    val command = evalCommand("leading_spaces2.wdl")
+    command shouldBe "    cat <<-EOF > test.py\na = 1\nif a == 0:\n    print(\"a = 0\")\nelse:\n    print(\"a = 1\")\nEOF\n    python3 test.py"
+  }
+
+  it should "evaluate command with empty lines" in {
+    val command = evalCommand("empty_lines.wdl")
+    command shouldBe "        cat <<-EOF > test.py\na = 1\nif a == 0:\n    print(\"a = 0\")\nelse:\n    print(\"a = 1\")\nEOF\n        python3 test.py"
+  }
+
   it should "evaluate simple command section" in {
     val command = evalCommand("command_simple.wdl")
     command shouldBe "We just discovered a new flower with 100 basepairs. Is that possible?"


### PR DESCRIPTION
Fixed bug when dealing with indentation.
Previously:
```
code
    code
code
```
would turn into 
```
code
code
code
```

which would break some python code. Changed  so it reflects what was previously written in the function comments when dealing with whitespaces.

Note that empty line is going to be deleted only in case it does not contain any characters (including whitespace)