### PR TITLE
Apps 492 indentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,28 +13,21 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Install & build
+      - name: Git Checkout
+        uses: actions/checkout@v2
+      - name: Install Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build
         run: |
           sudo apt-get update
-
-          # install java
-          sudo apt-get install wget make openjdk-8-jdk-headless
-
           # compile antlr4 sources
           cd ${GITHUB_WORKSPACE}
           make
-
-          # install sbt
-          echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
-          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
-          sudo apt-get install -y sbt
-
       - name: Unit Tests
         run: |
           sbt test
-
       - name: Scala formatting
         run: |
           sbt scalafmtCheckAll

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,12 +1,9 @@
 # Change log
 
-## 0.12.9
-
-* Fixed indentation issue in command block
-
 ## 0.12.8 (dev)
 
 * Adds support for Object -> Map coercion
+* Fixed indentation issue in command block
 * Bugfixes
 
 ## 0.12.7 (2021-03-17)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.12.9
+
+* Fixed indentation issue in command block
+
 ## 0.12.8 (dev)
 
 * Adds support for Object -> Map coercion

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 wdlTools {
-    version = "0.12.8"
+    version = "0.12.9"
 }
 
 #

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 wdlTools {
-    version = "0.12.9"
+    version = "0.12.8"
 }
 
 #

--- a/src/test/resources/eval/v1/empty_lines.wdl
+++ b/src/test/resources/eval/v1/empty_lines.wdl
@@ -1,0 +1,18 @@
+version 1.0
+
+task foo {
+    command <<<
+        cat <<-EOF > test.py
+a = 1
+
+
+
+if a == 0:
+
+    print("a = 0")
+else:
+    print("a = 1")
+EOF
+        python3 test.py
+    >>>
+}

--- a/src/test/resources/eval/v1/leading_spaces.wdl
+++ b/src/test/resources/eval/v1/leading_spaces.wdl
@@ -1,0 +1,14 @@
+version 1.0
+
+task foo {
+    command <<<
+        cat <<-EOF > test.py
+a = 1
+if a == 0:
+    print("a = 0")
+else:
+    print("a = 1")
+EOF
+        python3 test.py
+    >>>
+}

--- a/src/test/resources/eval/v1/leading_spaces2.wdl
+++ b/src/test/resources/eval/v1/leading_spaces2.wdl
@@ -1,0 +1,14 @@
+version 1.0
+
+task foo {
+    command <<<
+        cat <<-EOF > test.py
+    a = 1
+    if a == 0:
+        print("a = 0")
+    else:
+        print("a = 1")
+    EOF
+        python3 test.py
+    >>>
+}

--- a/src/test/scala/wdlTools/eval/EvalTest.scala
+++ b/src/test/scala/wdlTools/eval/EvalTest.scala
@@ -289,7 +289,7 @@ class EvalTest extends AnyFlatSpec with Matchers with Inside {
 
   it should "evaluate command with empty lines" in {
     val command = evalCommand("empty_lines.wdl")
-    command shouldBe "        cat <<-EOF > test.py\na = 1\nif a == 0:\n    print(\"a = 0\")\nelse:\n    print(\"a = 1\")\nEOF\n        python3 test.py"
+    command shouldBe "        cat <<-EOF > test.py\na = 1\n\n\n\nif a == 0:\n\n    print(\"a = 0\")\nelse:\n    print(\"a = 1\")\nEOF\n        python3 test.py"
   }
 
   it should "evaluate simple command section" in {

--- a/src/test/scala/wdlTools/eval/EvalTest.scala
+++ b/src/test/scala/wdlTools/eval/EvalTest.scala
@@ -277,6 +277,21 @@ class EvalTest extends AnyFlatSpec with Matchers with Inside {
     evaluator.applyCommand(task.command, ctx)
   }
 
+  it should "evaluate command with leading spaces" in {
+    val command = evalCommand("leading_spaces.wdl")
+    command shouldBe "        cat <<-EOF > test.py\na = 1\nif a == 0:\n    print(\"a = 0\")\nelse:\n    print(\"a = 1\")\nEOF\n        python3 test.py"
+  }
+
+  it should "evaluate command with leading spaces2" in {
+    val command = evalCommand("leading_spaces2.wdl")
+    command shouldBe "    cat <<-EOF > test.py\na = 1\nif a == 0:\n    print(\"a = 0\")\nelse:\n    print(\"a = 1\")\nEOF\n    python3 test.py"
+  }
+
+  it should "evaluate command with empty lines" in {
+    val command = evalCommand("empty_lines.wdl")
+    command shouldBe "        cat <<-EOF > test.py\na = 1\nif a == 0:\n    print(\"a = 0\")\nelse:\n    print(\"a = 1\")\nEOF\n        python3 test.py"
+  }
+
   it should "evaluate simple command section" in {
     val command = evalCommand("command_simple.wdl")
     command shouldBe "We just discovered a new flower with 100 basepairs. Is that possible?"


### PR DESCRIPTION
I merged the PR from @mhrvol fork into a new branch in the main repo.

@mhrvol: your change does fix the bug, but it also introduces a regression (unfortunately we did not have a test for it). The spec only states that common leading whitespace is removed, not blank lines (https://github.com/openwdl/wdl/blob/main/versions/1.1/SPEC.md#stripping-leading-whitespace). The reason is illustrated by the following example:

```
./my-command ~{arg1} \
    ~{arg2}
./another-command
```

If `arg2` is an optional input with a null value, and empty lines are removed, then the evaluated script ends up as:

```
./my-command ~{arg1} \
./another-command
```

which causes an error. If, however, the empty line is preserved, everything works fine because an empty line ends the command.

I updated the code to preserve empty lines, but to ignore empty lines for the purpose of determining common whitespace. For example, in the following script:

```
    foo

  bar
```

The least common whitespace is 2.