### PR TITLE
APPS-503 process escape sequences

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,27 +14,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
+      - name: Install Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
       - name: Install & build
         run: |
-          sudo apt-get update
-
-          # install java
-          sudo apt-get install wget make openjdk-8-jdk-headless
-
           # compile antlr4 sources
           cd ${GITHUB_WORKSPACE}
           make
-
-          # install sbt
-          echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
-          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
-          sudo apt-get install -y sbt
-
       - name: Unit Tests
         run: |
           sbt test
-
       - name: Scala formatting
         run: |
           sbt scalafmtCheckAll

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,44 +14,25 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
-
       - name: Install java
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-
       - name: Install & build
         run: |
-          sudo apt-get update
-
-          # install java
-          sudo apt-get install wget make openjdk-8-jdk-headless
-
           # compile antlr4 sources
           cd ${GITHUB_WORKSPACE}
           make
-
-          # install sbt
-          echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
-          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
-          sudo apt-get install -y sbt
-
-          # compile
-          sbt compile
-
       - name: Unit Tests
         run: |
           sbt test
-
       - name: Assembly
         run: |
           sbt assembly
           mv ./target/wdlTools.jar ./wdlTools-${{ github.event.inputs.release-version }}.jar
-
       - name: Scala formatting
         run: |
           sbt scalafmtCheckAll
-
       - name: Extract release notes and set version in application.conf files
         id: update-release
         run: |
@@ -65,7 +46,6 @@ jobs:
           RELEASE_NOTES_PATH="./release_notes_${{ github.event.inputs.release-version }}.md"
           sed -n '/## ${{ github.event.inputs.release-version }}/,/##/p' RELEASE_NOTES.md | sed '1d; $d' > $RELEASE_NOTES_PATH
           echo ::set-output name=release-notes-path::$(echo "${RELEASE_NOTES_PATH}")
-
       - name: Commit changes to application.conf files
         uses: EndBug/add-and-commit@v7
         with:
@@ -75,7 +55,6 @@ jobs:
           ]'
           push: false
           tag: ${{ github.event.inputs.release-version }}
-
       - name: Create release entry
         id: create-release
         uses: actions/create-release@v1
@@ -87,7 +66,6 @@ jobs:
           body_path: ${{ steps.update-release.outputs.release-notes-path }}
           draft: true
           prerelease: false
-
       - name: Upload assembly JAR
         id: upload-release-assembly
         uses: actions/upload-release-asset@v1
@@ -101,14 +79,12 @@ jobs:
           asset_path: ./wdlTools-${{ github.event.inputs.release-version }}.jar
           asset_name: wdlTools-${{ github.event.inputs.release-version }}.jar
           asset_content_type: application/jar
-
       - name: Push local release branch and tag to origin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git push origin HEAD:${{ github.ref }}
           git push origin HEAD:${{ github.event.inputs.release-version }}
-
       - name: Rollback release if unsuccessfull
         if: ${{ cancelled() || failure() }}
         uses: author/action-rollback@stable

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## 0.12.8 (dev)
 
 * Adds support for Object -> Map coercion
+* Fixes processing of escape sequences (including regular expressions used in second argument to `sub`)  
 * Bugfixes
 
 ## 0.12.7 (2021-03-17)

--- a/src/main/antlr4/draft_2/WdlDraft2Parser.g4
+++ b/src/main/antlr4/draft_2/WdlDraft2Parser.g4
@@ -50,7 +50,12 @@ expression_placeholder_option
 	;
 
 string_part
-	: StringPart*
+  : EscStringPart
+  | StringPart
+  ;
+
+string_parts
+	: string_part*
 	;
 
 string_expr_part
@@ -58,12 +63,12 @@ string_expr_part
 	;
 
 string_expr_with_string_part
-	: string_expr_part string_part
+	: string_expr_part string_parts
 	;
 
 string
-	: DQUOTE string_part string_expr_with_string_part* DQUOTE
-	| SQUOTE string_part string_expr_with_string_part* SQUOTE
+	: DQUOTE string_parts string_expr_with_string_part* DQUOTE
+	| SQUOTE string_parts string_expr_with_string_part* SQUOTE
 	;
 
 primitive_literal
@@ -174,21 +179,21 @@ task_output
 	: OUTPUT LBRACE (bound_decls)* RBRACE
 	;
 
-task_command_string_part
+task_command_string_parts
 	: CommandStringPart*
 	;
 
 task_command_expr_part
-	: StringCommandStart  (expression_placeholder_option)* expr RBRACE
+	: StringCommandStart (expression_placeholder_option)* expr RBRACE
 	;
 
 task_command_expr_with_string
-	: task_command_expr_part task_command_string_part
+	: task_command_expr_part task_command_string_parts
 	;
 
 task_command
-	: COMMAND BeginLBrace task_command_string_part task_command_expr_with_string* EndCommand
-	| COMMAND BeginHereDoc task_command_string_part task_command_expr_with_string* EndCommand
+	: COMMAND BeginLBrace task_command_string_parts task_command_expr_with_string* EndCommand
+	| COMMAND BeginHereDoc task_command_string_parts task_command_expr_with_string* EndCommand
 	;
 
 task_element

--- a/src/main/antlr4/v1/WdlV1Lexer.g4
+++ b/src/main/antlr4/v1/WdlV1Lexer.g4
@@ -90,23 +90,23 @@ Identifier: CompleteIdentifier;
 
 mode SquoteInterpolatedString;
 
-SQuoteEscapedChar: EscapeSequence -> type(StringPart);
+EscStringPart: EscapeSequence;
 SQuoteDollarString: '$'  -> type(StringPart);
 SQuoteTildeString: '~' -> type(StringPart);
 SQuoteCurlyString: '{' -> type(StringPart);
 SQuoteCommandStart: ('${' | '~{' ) -> pushMode(DEFAULT_MODE) , type(StringCommandStart);
 EndSquote: '\'' ->  popMode, type(SQUOTE);
-StringPart: ~[$~{\r\n']+;
+StringPart: ~[$~{\r\n'\\]+;
 
 mode DquoteInterpolatedString;
 
-DQuoteEscapedChar: EscapeSequence -> type(StringPart);
+DQuoteEscapedChar: EscapeSequence -> type(EscStringPart);
 DQuoteTildeString: '~' -> type(StringPart);
 DQuoteDollarString: '$' -> type(StringPart);
 DQUoteCurlString: '{' -> type(StringPart);
 DQuoteCommandStart: ('${' | '~{' ) -> pushMode(DEFAULT_MODE), type(StringCommandStart);
 EndDQuote: '"' ->  popMode, type(DQUOTE);
-DQuoteStringPart: ~[$~{\r\n"]+ -> type(StringPart);
+DQuoteStringPart: ~[$~{\r\n"\\]+ -> type(StringPart);
 
 mode Command;
 
@@ -116,24 +116,24 @@ BeginLBrace: '{' -> mode(CurlyCommand);
 
 mode HereDocCommand;
 
-HereDocEscapedChar: EscapeSequence -> type(CommandStringPart);
+HereDocEscapedChar: EscapeSequence -> type(CommandEscStringPart);
 HereDocTildeString: '~' -> type(CommandStringPart);
 HereDocCurlyString: '{' -> type(CommandStringPart);
 HereDocCurlyStringCommand: '~{' -> pushMode(DEFAULT_MODE), type(StringCommandStart);
 HereDocEscapedEnd: '\\>>>' -> type(CommandStringPart);
 EndHereDocCommand: '>>>' -> mode(DEFAULT_MODE), type(EndCommand);
 HereDocEscape: ( '>' | '>>' | '>>>>' '>'*) -> type(CommandStringPart);
-HereDocStringPart: ~[~{>]+ -> type(CommandStringPart);
+HereDocStringPart: ~[~{>\\]+ -> type(CommandStringPart);
 
 mode CurlyCommand;
 
-CommandEscapedChar: EscapeSequence -> type(CommandStringPart);
+CommandEscStringPart: EscapeSequence;
 CommandTildeString: '~'  -> type(CommandStringPart);
 CommandDollarString: '$' -> type(CommandStringPart);
 CommandCurlyString: '{' -> type(CommandStringPart);
 StringCommandStart:  ('${' | '~{' ) -> pushMode(DEFAULT_MODE);
 EndCommand: '}' -> mode(DEFAULT_MODE);
-CommandStringPart: ~[$~{}]+;
+CommandStringPart: ~[$~{}\\]+;
 
 mode Version;
 
@@ -170,15 +170,15 @@ MetaValueWhitespace: [ \t\r\n]+ -> channel(HIDDEN);
 
 mode MetaSquoteString;
 
-MetaSquoteEscapedChar: EscapeSequence -> type(MetaStringPart);
+MetaEscStringPart: EscapeSequence;
 MetaEndSquote: '\'' ->  popMode, type(MetaSquote), popMode;
-MetaStringPart: ~[\r\n']+;
+MetaStringPart: ~[\r\n'\\]+;
 
 mode MetaDquoteString;
 
-MetaDquoteEscapedChar: EscapeSequence -> type(MetaStringPart);
+MetaDquoteEscapedChar: EscapeSequence -> type(MetaEscStringPart);
 MetaEndDquote: '"' ->  popMode, type(MetaDquote), popMode;
-MetaDquoteStringPart: ~[\r\n"]+ -> type(MetaStringPart);
+MetaDquoteStringPart: ~[\r\n"\\]+ -> type(MetaStringPart);
 
 mode MetaArray;
 

--- a/src/main/antlr4/v1/WdlV1Lexer.g4
+++ b/src/main/antlr4/v1/WdlV1Lexer.g4
@@ -116,24 +116,22 @@ BeginLBrace: '{' -> mode(CurlyCommand);
 
 mode HereDocCommand;
 
-HereDocEscapedChar: EscapeSequence -> type(CommandEscStringPart);
 HereDocTildeString: '~' -> type(CommandStringPart);
 HereDocCurlyString: '{' -> type(CommandStringPart);
 HereDocCurlyStringCommand: '~{' -> pushMode(DEFAULT_MODE), type(StringCommandStart);
 HereDocEscapedEnd: '\\>>>' -> type(CommandStringPart);
 EndHereDocCommand: '>>>' -> mode(DEFAULT_MODE), type(EndCommand);
 HereDocEscape: ( '>' | '>>' | '>>>>' '>'*) -> type(CommandStringPart);
-HereDocStringPart: ~[~{>\\]+ -> type(CommandStringPart);
+HereDocStringPart: ~[~{>]+ -> type(CommandStringPart);
 
 mode CurlyCommand;
 
-CommandEscStringPart: EscapeSequence;
 CommandTildeString: '~'  -> type(CommandStringPart);
 CommandDollarString: '$' -> type(CommandStringPart);
 CommandCurlyString: '{' -> type(CommandStringPart);
 StringCommandStart:  ('${' | '~{' ) -> pushMode(DEFAULT_MODE);
 EndCommand: '}' -> mode(DEFAULT_MODE);
-CommandStringPart: ~[$~{}\\]+;
+CommandStringPart: ~[$~{}]+;
 
 mode Version;
 

--- a/src/main/antlr4/v1/WdlV1Parser.g4
+++ b/src/main/antlr4/v1/WdlV1Parser.g4
@@ -229,13 +229,8 @@ task_output
   : OUTPUT LBRACE (bound_decls)* RBRACE
   ;
 
-task_command_string_part
-  : CommandStringPart
-  | CommandEscStringPart
-  ;
-
 task_command_string_parts
-  : task_command_string_part*
+  : CommandStringPart*
   ;
 
 task_command_expr_part

--- a/src/main/antlr4/v1/WdlV1Parser.g4
+++ b/src/main/antlr4/v1/WdlV1Parser.g4
@@ -50,7 +50,12 @@ expression_placeholder_option
   ;
 
 string_part
-  : StringPart*
+  : EscStringPart
+  | StringPart
+  ;
+
+string_parts
+  : string_part*
   ;
 
 string_expr_part
@@ -58,12 +63,12 @@ string_expr_part
   ;
 
 string_expr_with_string_part
-  : string_expr_part string_part
+  : string_expr_part string_parts
   ;
 
 string
-  : DQUOTE string_part string_expr_with_string_part* DQUOTE
-  | SQUOTE string_part string_expr_with_string_part* SQUOTE
+  : DQUOTE string_parts string_expr_with_string_part* DQUOTE
+  | SQUOTE string_parts string_expr_with_string_part* SQUOTE
   ;
 
 primitive_literal
@@ -169,12 +174,17 @@ meta_value
   ;
 
 meta_string_part
-  : MetaStringPart*
+  : MetaEscStringPart
+  | MetaStringPart
+  ;
+
+meta_string_parts
+  : meta_string_part*
   ;
 
 meta_string
-  : MetaDquote meta_string_part MetaDquote
-  | MetaSquote meta_string_part MetaSquote
+  : MetaDquote meta_string_parts MetaDquote
+  | MetaSquote meta_string_parts MetaSquote
   ;
 
 meta_array
@@ -220,7 +230,12 @@ task_output
   ;
 
 task_command_string_part
-  : CommandStringPart*
+  : CommandStringPart
+  | CommandEscStringPart
+  ;
+
+task_command_string_parts
+  : task_command_string_part*
   ;
 
 task_command_expr_part
@@ -228,12 +243,12 @@ task_command_expr_part
   ;
 
 task_command_expr_with_string
-  : task_command_expr_part task_command_string_part
+  : task_command_expr_part task_command_string_parts
   ;
 
 task_command
-  : COMMAND BeginLBrace task_command_string_part task_command_expr_with_string* EndCommand
-  | COMMAND BeginHereDoc task_command_string_part task_command_expr_with_string* EndCommand
+  : COMMAND BeginLBrace task_command_string_parts task_command_expr_with_string* EndCommand
+  | COMMAND BeginHereDoc task_command_string_parts task_command_expr_with_string* EndCommand
   ;
 
 task_element

--- a/src/main/antlr4/v1_1/WdlV1_1Lexer.g4
+++ b/src/main/antlr4/v1_1/WdlV1_1Lexer.g4
@@ -93,25 +93,23 @@ Identifier: CompleteIdentifier;
 
 mode SquoteInterpolatedString;
 
-SQuoteEscapedChar: '\\' . -> type(StringPart);
+EscStringPart: EscapeSequence;
 SQuoteDollarString: '$'  -> type(StringPart);
 SQuoteTildeString: '~' -> type(StringPart);
 SQuoteCurlyString: '{' -> type(StringPart);
 SQuoteCommandStart: ('${' | '~{' ) -> pushMode(DEFAULT_MODE) , type(StringCommandStart);
-SQuoteUnicodeEscape: '\\u' (HexDigit (HexDigit (HexDigit HexDigit?)?)?)? -> type(StringPart);
 EndSquote: '\'' ->  popMode, type(SQUOTE);
-StringPart: ~[$~{\r\n']+;
+StringPart: ~[$~{\r\n'\\]+;
 
 mode DquoteInterpolatedString;
 
-DQuoteEscapedChar: '\\' . -> type(StringPart);
+DQuoteEscapedChar: EscapeSequence -> type(EscStringPart);
 DQuoteTildeString: '~' -> type(StringPart);
 DQuoteDollarString: '$' -> type(StringPart);
 DQUoteCurlString: '{' -> type(StringPart);
 DQuoteCommandStart: ('${' | '~{' ) -> pushMode(DEFAULT_MODE), type(StringCommandStart);
-DQuoteUnicodeEscape: '\\u' (HexDigit (HexDigit (HexDigit HexDigit?)?)?) -> type(StringPart);
 EndDQuote: '"' ->  popMode, type(DQUOTE);
-DQuoteStringPart: ~[$~{\r\n"]+ -> type(StringPart);
+DQuoteStringPart: ~[$~{\r\n"\\]+ -> type(StringPart);
 
 mode Command;
 
@@ -121,8 +119,6 @@ BeginLBrace: '{' -> mode(CurlyCommand);
 
 mode HereDocCommand;
 
-HereDocUnicodeEscape: '\\u' (HexDigit (HexDigit (HexDigit HexDigit?)?)?)?;
-HereDocEscapedChar: '\\' . -> type(CommandStringPart);
 HereDocTildeString: '~' -> type(CommandStringPart);
 HereDocCurlyString: '{' -> type(CommandStringPart);
 HereDocCurlyStringCommand: '~{' -> pushMode(DEFAULT_MODE), type(StringCommandStart);
@@ -133,8 +129,6 @@ HereDocStringPart: ~[~{>]+ -> type(CommandStringPart);
 
 mode CurlyCommand;
 
-CommandEscapedChar: '\\' . -> type(CommandStringPart);
-CommandUnicodeEscape: '\\u' (HexDigit (HexDigit (HexDigit HexDigit?)?)?)?;
 CommandTildeString: '~'  -> type(CommandStringPart);
 CommandDollarString: '$' -> type(CommandStringPart);
 CommandCurlyString: '{' -> type(CommandStringPart);
@@ -177,15 +171,14 @@ MetaValueWhitespace: [ \t\r\n]+ -> channel(HIDDEN);
 
 mode MetaSquoteString;
 
-MetaSquoteEscapedChar: '\\' . -> type(MetaStringPart);
+MetaEscStringPart: EscapeSequence;
 MetaSquoteUnicodeEscape: '\\u' (HexDigit (HexDigit (HexDigit HexDigit?)?)?)? -> type(MetaStringPart);
 MetaEndSquote: '\'' ->  popMode, type(MetaSquote), popMode;
-MetaStringPart: ~[\r\n']+;
+MetaStringPart: ~[\r\n'\\]+;
 
 mode MetaDquoteString;
 
-MetaDquoteEscapedChar: '\\' . -> type(MetaStringPart);
-MetaDquoteUnicodeEscape: '\\u' (HexDigit (HexDigit (HexDigit HexDigit?)?)?) -> type(MetaStringPart);
+MetaDquoteEscapedChar: EscapeSequence -> type(MetaEscStringPart);
 MetaEndDquote: '"' ->  popMode, type(MetaDquote), popMode;
 MetaDquoteStringPart: ~[\r\n"]+ -> type(MetaStringPart);
 
@@ -220,19 +213,37 @@ fragment IdentifierFollow
 	: [a-zA-Z0-9_]+
 	;
 
-fragment EscapeSequence
-    : '\\' [btnfr"'\\]
-    | '\\' ([0-3]? [0-7])? [0-7]
-    | '\\' UnicodeEsc
-    ;
-
-fragment UnicodeEsc
-   : 'u' (HexDigit (HexDigit (HexDigit HexDigit?)?)?)?
-   ;
+fragment OctDigit
+  : [0-7]
+  ;
 
 fragment HexDigit
-   : [0-9a-fA-F]
-   ;
+	: [0-9a-fA-F]
+	;
+
+fragment OctEsc
+  : OctDigit OctDigit OctDigit
+  ;
+
+fragment HexEsc
+  : 'x' HexDigit HexDigit
+  ;
+
+fragment UnicodeEsc
+	: 'u' HexDigit HexDigit HexDigit HexDigit
+	;
+
+fragment UnicodeEsc2
+	: 'U' HexDigit HexDigit HexDigit HexDigit HexDigit HexDigit HexDigit HexDigit
+	;
+
+fragment EscapeSequence
+	: ESC [tn"'\\]
+	| ESC OctEsc
+	| ESC HexEsc
+	| ESC UnicodeEsc
+	| ESC UnicodeEsc2
+	;
 
 fragment Digit
 	: [0-9]

--- a/src/main/antlr4/v1_1/WdlV1_1Parser.g4
+++ b/src/main/antlr4/v1_1/WdlV1_1Parser.g4
@@ -52,7 +52,12 @@ expression_placeholder_option
   ;
 
 string_part
-  : StringPart*
+  : EscStringPart
+  | StringPart
+  ;
+
+string_parts
+  : string_part*
   ;
 
 string_expr_part
@@ -60,12 +65,12 @@ string_expr_part
   ;
 
 string_expr_with_string_part
-  : string_expr_part string_part
+  : string_expr_part string_parts
   ;
 
 string
-  : DQUOTE string_part string_expr_with_string_part* DQUOTE
-  | SQUOTE string_part string_expr_with_string_part* SQUOTE
+  : DQUOTE string_parts string_expr_with_string_part* DQUOTE
+  | SQUOTE string_parts string_expr_with_string_part* SQUOTE
   ;
 
 primitive_literal
@@ -173,12 +178,17 @@ meta_value
   ;
 
 meta_string_part
-  : MetaStringPart*
+  : MetaEscStringPart
+  | MetaStringPart
+  ;
+
+meta_string_parts
+  : meta_string_part*
   ;
 
 meta_string
-  : MetaDquote meta_string_part MetaDquote
-  | MetaSquote meta_string_part MetaSquote
+  : MetaDquote meta_string_parts MetaDquote
+  | MetaSquote meta_string_parts MetaSquote
   ;
 
 meta_array
@@ -227,7 +237,7 @@ task_output
   : OUTPUT LBRACE (bound_decls)* RBRACE
   ;
 
-task_command_string_part
+task_command_string_parts
   : CommandStringPart*
   ;
 
@@ -236,12 +246,12 @@ task_command_expr_part
   ;
 
 task_command_expr_with_string
-  : task_command_expr_part task_command_string_part
+  : task_command_expr_part task_command_string_parts
   ;
 
 task_command
-  : COMMAND BeginLBrace task_command_string_part task_command_expr_with_string* EndCommand
-  | COMMAND BeginHereDoc task_command_string_part task_command_expr_with_string* EndCommand
+  : COMMAND BeginLBrace task_command_string_parts task_command_expr_with_string* EndCommand
+  | COMMAND BeginHereDoc task_command_string_parts task_command_expr_with_string* EndCommand
   ;
 
 task_element

--- a/src/main/antlr4/v2/WdlV2Lexer.g4
+++ b/src/main/antlr4/v2/WdlV2Lexer.g4
@@ -86,25 +86,23 @@ Identifier: CompleteIdentifier;
 
 mode SquoteInterpolatedString;
 
-SQuoteEscapedChar: '\\' . -> type(StringPart);
+EscStringPart: EscapeSequence;
 SQuoteDollarString: '$'  -> type(StringPart);
 SQuoteTildeString: '~' -> type(StringPart);
 SQuoteCurlyString: '{' -> type(StringPart);
 SQuoteCommandStart: ('${' | '~{' ) -> pushMode(DEFAULT_MODE) , type(StringCommandStart);
-SQuoteUnicodeEscape: '\\u' (HexDigit (HexDigit (HexDigit HexDigit?)?)?)? -> type(StringPart);
 EndSquote: '\'' ->  popMode, type(SQUOTE);
-StringPart: ~[$~{\r\n']+;
+StringPart: ~[$~{\r\n'\\]+;
 
 mode DquoteInterpolatedString;
 
-DQuoteEscapedChar: '\\' . -> type(StringPart);
+DQuoteEscapedChar: EscapeSequence -> type(EscStringPart);
 DQuoteTildeString: '~' -> type(StringPart);
 DQuoteDollarString: '$' -> type(StringPart);
 DQUoteCurlString: '{' -> type(StringPart);
 DQuoteCommandStart: ('${' | '~{' ) -> pushMode(DEFAULT_MODE), type(StringCommandStart);
-DQuoteUnicodeEscape: '\\u' (HexDigit (HexDigit (HexDigit HexDigit?)?)?) -> type(StringPart);
 EndDQuote: '"' ->  popMode, type(DQUOTE);
-DQuoteStringPart: ~[$~{\r\n"]+ -> type(StringPart);
+DQuoteStringPart: ~[$~{\r\n"\\]+ -> type(StringPart);
 
 mode Command;
 
@@ -114,8 +112,6 @@ BeginLBrace: '{' -> mode(CurlyCommand);
 
 mode HereDocCommand;
 
-HereDocUnicodeEscape: '\\u' (HexDigit (HexDigit (HexDigit HexDigit?)?)?)?;
-HereDocEscapedChar: '\\' . -> type(CommandStringPart);
 HereDocTildeString: '~' -> type(CommandStringPart);
 HereDocCurlyString: '{' -> type(CommandStringPart);
 HereDocCurlyStringCommand: '~{' -> pushMode(DEFAULT_MODE), type(StringCommandStart);
@@ -126,8 +122,6 @@ HereDocStringPart: ~[~{>]+ -> type(CommandStringPart);
 
 mode CurlyCommand;
 
-CommandEscapedChar: '\\' . -> type(CommandStringPart);
-CommandUnicodeEscape: '\\u' (HexDigit (HexDigit (HexDigit HexDigit?)?)?)?;
 CommandTildeString: '~'  -> type(CommandStringPart);
 CommandDollarString: '$' -> type(CommandStringPart);
 CommandCurlyString: '{' -> type(CommandStringPart);
@@ -170,17 +164,15 @@ MetaValueWhitespace: [ \t\r\n]+ -> channel(HIDDEN);
 
 mode MetaSquoteString;
 
-MetaSquoteEscapedChar: '\\' . -> type(MetaStringPart);
-MetaSquoteUnicodeEscape: '\\u' (HexDigit (HexDigit (HexDigit HexDigit?)?)?)? -> type(MetaStringPart);
+MetaEscStringPart: EscapeSequence;
 MetaEndSquote: '\'' ->  popMode, type(MetaSquote), popMode;
-MetaStringPart: ~[\r\n']+;
+MetaStringPart: ~[\r\n'\\]+;
 
 mode MetaDquoteString;
 
-MetaDquoteEscapedChar: '\\' . -> type(MetaStringPart);
-MetaDquoteUnicodeEscape: '\\u' (HexDigit (HexDigit (HexDigit HexDigit?)?)?) -> type(MetaStringPart);
+MetaDquoteEscapedChar: EscapeSequence -> type(MetaEscStringPart);
 MetaEndDquote: '"' ->  popMode, type(MetaDquote), popMode;
-MetaDquoteStringPart: ~[\r\n"]+ -> type(MetaStringPart);
+MetaDquoteStringPart: ~[\r\n"\\]+ -> type(MetaStringPart);
 
 mode MetaArray;
 
@@ -214,19 +206,37 @@ fragment IdentifierFollow
 	: [a-zA-Z0-9_]+
 	;
 
-fragment EscapeSequence
-    : '\\' [btnfr"'\\]
-    | '\\' ([0-3]? [0-7])? [0-7]
-    | '\\' UnicodeEsc
-    ;
-
-fragment UnicodeEsc
-   : 'u' (HexDigit (HexDigit (HexDigit HexDigit?)?)?)?
-   ;
+fragment OctDigit
+  : [0-7]
+  ;
 
 fragment HexDigit
-   : [0-9a-fA-F]
-   ;
+	: [0-9a-fA-F]
+	;
+
+fragment OctEsc
+  : OctDigit OctDigit OctDigit
+  ;
+
+fragment HexEsc
+  : 'x' HexDigit HexDigit
+  ;
+
+fragment UnicodeEsc
+	: 'u' HexDigit HexDigit HexDigit HexDigit
+	;
+
+fragment UnicodeEsc2
+	: 'U' HexDigit HexDigit HexDigit HexDigit HexDigit HexDigit HexDigit HexDigit
+	;
+
+fragment EscapeSequence
+	: ESC [tn"'\\]
+	| ESC OctEsc
+	| ESC HexEsc
+	| ESC UnicodeEsc
+	| ESC UnicodeEsc2
+	;
 
 fragment Digit
 	: [0-9]

--- a/src/main/antlr4/v2/WdlV2Parser.g4
+++ b/src/main/antlr4/v2/WdlV2Parser.g4
@@ -46,7 +46,12 @@ number
 // Literals
 
 string_part
-  : StringPart*
+  : EscStringPart
+  | StringPart
+  ;
+
+string_parts
+  : string_part*
   ;
 
 string_expr_part
@@ -54,12 +59,12 @@ string_expr_part
   ;
 
 string_expr_with_string_part
-  : string_expr_part string_part
+  : string_expr_part string_parts
   ;
 
 string
-  : DQUOTE string_part string_expr_with_string_part* DQUOTE
-  | SQUOTE string_part string_expr_with_string_part* SQUOTE
+  : DQUOTE string_parts string_expr_with_string_part* DQUOTE
+  | SQUOTE string_parts string_expr_with_string_part* SQUOTE
   ;
 
 primitive_literal
@@ -167,12 +172,17 @@ meta_value
   ;
 
 meta_string_part
-  : MetaStringPart*
+  : MetaEscStringPart
+  | MetaStringPart
+  ;
+
+meta_string_parts
+  : meta_string_part*
   ;
 
 meta_string
-  : MetaDquote meta_string_part MetaDquote
-  | MetaSquote meta_string_part MetaSquote
+  : MetaDquote meta_string_parts MetaDquote
+  | MetaSquote meta_string_parts MetaSquote
   ;
 
 meta_array
@@ -225,12 +235,7 @@ task_output
   : OUTPUT LBRACE (bound_decls)* RBRACE
   ;
 
-task_command
-  : COMMAND BeginLBrace task_command_string_part task_command_expr_with_string* EndCommand
-  | COMMAND BeginHereDoc task_command_string_part task_command_expr_with_string* EndCommand
-  ;
-
-task_command_string_part
+task_command_string_parts
   : CommandStringPart*
   ;
 
@@ -239,7 +244,12 @@ task_command_expr_part
   ;
 
 task_command_expr_with_string
-  : task_command_expr_part task_command_string_part
+  : task_command_expr_part task_command_string_parts
+  ;
+
+task_command
+  : COMMAND BeginLBrace task_command_string_parts task_command_expr_with_string* EndCommand
+  | COMMAND BeginHereDoc task_command_string_parts task_command_expr_with_string* EndCommand
   ;
 
 task_element

--- a/src/main/scala/wdlTools/syntax/AllParseTreeListener.scala
+++ b/src/main/scala/wdlTools/syntax/AllParseTreeListener.scala
@@ -48,6 +48,8 @@ class AllParseTreeListener
   def exitExpression_placeholder_option(ctx: ParserRuleContext): Unit = {}
   def enterString_part(ctx: ParserRuleContext): Unit = {}
   def exitString_part(ctx: ParserRuleContext): Unit = {}
+  def enterString_parts(ctx: ParserRuleContext): Unit = {}
+  def exitString_parts(ctx: ParserRuleContext): Unit = {}
   def enterString_expr_part(ctx: ParserRuleContext): Unit = {}
   def exitString_expr_part(ctx: ParserRuleContext): Unit = {}
   def enterString_expr_with_string_part(ctx: ParserRuleContext): Unit = {}
@@ -138,6 +140,8 @@ class AllParseTreeListener
   def exitMeta_value(ctx: ParserRuleContext): Unit = {}
   def enterMeta_string_part(ctx: ParserRuleContext): Unit = {}
   def exitMeta_string_part(ctx: ParserRuleContext): Unit = {}
+  def enterMeta_string_parts(ctx: ParserRuleContext): Unit = {}
+  def exitMeta_string_parts(ctx: ParserRuleContext): Unit = {}
   def enterMeta_string(ctx: ParserRuleContext): Unit = {}
   def exitMeta_string(ctx: ParserRuleContext): Unit = {}
   def enterMeta_array(ctx: ParserRuleContext): Unit = {}
@@ -166,6 +170,8 @@ class AllParseTreeListener
   def exitTask_output(ctx: ParserRuleContext): Unit = {}
   def enterTask_command_string_part(ctx: ParserRuleContext): Unit = {}
   def exitTask_command_string_part(ctx: ParserRuleContext): Unit = {}
+  def enterTask_command_string_parts(ctx: ParserRuleContext): Unit = {}
+  def exitTask_command_string_parts(ctx: ParserRuleContext): Unit = {}
   def enterTask_command_expr_part(ctx: ParserRuleContext): Unit = {}
   def exitTask_command_expr_part(ctx: ParserRuleContext): Unit = {}
   def enterTask_command_expr_with_string(ctx: ParserRuleContext): Unit = {}
@@ -884,6 +890,12 @@ class AllParseTreeListener
   override def exitString_part(ctx: WdlV1Parser.String_partContext): Unit = {
     exitString_part(ctx.asInstanceOf[ParserRuleContext])
   }
+  override def enterString_parts(ctx: WdlV1Parser.String_partsContext): Unit = {
+    enterString_parts(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def exitString_parts(ctx: WdlV1Parser.String_partsContext): Unit = {
+    exitString_parts(ctx.asInstanceOf[ParserRuleContext])
+  }
   override def enterString_expr_part(ctx: WdlV1Parser.String_expr_partContext): Unit = {
     enterString_expr_part(ctx.asInstanceOf[ParserRuleContext])
   }
@@ -1164,6 +1176,12 @@ class AllParseTreeListener
   override def exitMeta_string_part(ctx: WdlV1Parser.Meta_string_partContext): Unit = {
     exitMeta_string_part(ctx.asInstanceOf[ParserRuleContext])
   }
+  override def enterMeta_string_parts(ctx: WdlV1Parser.Meta_string_partsContext): Unit = {
+    enterMeta_string_parts(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def exitMeta_string_parts(ctx: WdlV1Parser.Meta_string_partsContext): Unit = {
+    exitMeta_string_parts(ctx.asInstanceOf[ParserRuleContext])
+  }
   override def enterMeta_string(ctx: WdlV1Parser.Meta_stringContext): Unit = {
     enterMeta_string(ctx.asInstanceOf[ParserRuleContext])
   }
@@ -1239,6 +1257,16 @@ class AllParseTreeListener
       ctx: WdlV1Parser.Task_command_string_partContext
   ): Unit = {
     exitTask_command_string_part(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def enterTask_command_string_parts(
+      ctx: WdlV1Parser.Task_command_string_partsContext
+  ): Unit = {
+    enterTask_command_string_parts(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def exitTask_command_string_parts(
+      ctx: WdlV1Parser.Task_command_string_partsContext
+  ): Unit = {
+    exitTask_command_string_parts(ctx.asInstanceOf[ParserRuleContext])
   }
   override def enterTask_command_expr_part(ctx: WdlV1Parser.Task_command_expr_partContext): Unit = {
     enterTask_command_expr_part(ctx.asInstanceOf[ParserRuleContext])

--- a/src/main/scala/wdlTools/syntax/AllParseTreeListener.scala
+++ b/src/main/scala/wdlTools/syntax/AllParseTreeListener.scala
@@ -316,6 +316,12 @@ class AllParseTreeListener
   override def exitString_part(ctx: WdlDraft2Parser.String_partContext): Unit = {
     exitString_part(ctx.asInstanceOf[ParserRuleContext])
   }
+  override def enterString_parts(ctx: WdlDraft2Parser.String_partsContext): Unit = {
+    enterString_part(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def exitString_parts(ctx: WdlDraft2Parser.String_partsContext): Unit = {
+    exitString_part(ctx.asInstanceOf[ParserRuleContext])
+  }
   override def enterString_expr_part(ctx: WdlDraft2Parser.String_expr_partContext): Unit = {
     enterString_expr_part(ctx.asInstanceOf[ParserRuleContext])
   }
@@ -614,15 +620,15 @@ class AllParseTreeListener
   override def exitTask_output(ctx: WdlDraft2Parser.Task_outputContext): Unit = {
     exitTask_output(ctx.asInstanceOf[ParserRuleContext])
   }
-  override def enterTask_command_string_part(
-      ctx: WdlDraft2Parser.Task_command_string_partContext
+  override def enterTask_command_string_parts(
+      ctx: WdlDraft2Parser.Task_command_string_partsContext
   ): Unit = {
-    enterTask_command_string_part(ctx.asInstanceOf[ParserRuleContext])
+    enterTask_command_string_parts(ctx.asInstanceOf[ParserRuleContext])
   }
-  override def exitTask_command_string_part(
-      ctx: WdlDraft2Parser.Task_command_string_partContext
+  override def exitTask_command_string_parts(
+      ctx: WdlDraft2Parser.Task_command_string_partsContext
   ): Unit = {
-    exitTask_command_string_part(ctx.asInstanceOf[ParserRuleContext])
+    exitTask_command_string_parts(ctx.asInstanceOf[ParserRuleContext])
   }
   override def enterTask_command_expr_part(
       ctx: WdlDraft2Parser.Task_command_expr_partContext
@@ -1247,16 +1253,6 @@ class AllParseTreeListener
   }
   override def exitTask_output(ctx: WdlV1Parser.Task_outputContext): Unit = {
     exitTask_output(ctx.asInstanceOf[ParserRuleContext])
-  }
-  override def enterTask_command_string_part(
-      ctx: WdlV1Parser.Task_command_string_partContext
-  ): Unit = {
-    enterTask_command_string_part(ctx.asInstanceOf[ParserRuleContext])
-  }
-  override def exitTask_command_string_part(
-      ctx: WdlV1Parser.Task_command_string_partContext
-  ): Unit = {
-    exitTask_command_string_part(ctx.asInstanceOf[ParserRuleContext])
   }
   override def enterTask_command_string_parts(
       ctx: WdlV1Parser.Task_command_string_partsContext

--- a/src/main/scala/wdlTools/syntax/AllParseTreeListener.scala
+++ b/src/main/scala/wdlTools/syntax/AllParseTreeListener.scala
@@ -168,8 +168,6 @@ class AllParseTreeListener
   def exitTask_input(ctx: ParserRuleContext): Unit = {}
   def enterTask_output(ctx: ParserRuleContext): Unit = {}
   def exitTask_output(ctx: ParserRuleContext): Unit = {}
-  def enterTask_command_string_part(ctx: ParserRuleContext): Unit = {}
-  def exitTask_command_string_part(ctx: ParserRuleContext): Unit = {}
   def enterTask_command_string_parts(ctx: ParserRuleContext): Unit = {}
   def exitTask_command_string_parts(ctx: ParserRuleContext): Unit = {}
   def enterTask_command_expr_part(ctx: ParserRuleContext): Unit = {}
@@ -542,12 +540,6 @@ class AllParseTreeListener
   override def exitGet_name(ctx: WdlDraft2Parser.Get_nameContext): Unit = {
     exitGet_name(ctx.asInstanceOf[ParserRuleContext])
   }
-
-  /**
-    * Enter a parse tree produced by {@link WdlDraft2Parser#   member}.
-    *
-    * @param ctx the parse tree
-    */
   override def enterMember(ctx: WdlDraft2Parser.MemberContext): Unit = {
     enterMember(ctx.asInstanceOf[ParserRuleContext])
   }
@@ -1497,6 +1489,12 @@ class AllParseTreeListener
   override def exitString_part(ctx: WdlV1_1Parser.String_partContext): Unit = {
     exitString_part(ctx.asInstanceOf[ParserRuleContext])
   }
+  override def enterString_parts(ctx: WdlV1_1Parser.String_partsContext): Unit = {
+    enterString_parts(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def exitString_parts(ctx: WdlV1_1Parser.String_partsContext): Unit = {
+    exitString_parts(ctx.asInstanceOf[ParserRuleContext])
+  }
   override def enterString_expr_part(ctx: WdlV1_1Parser.String_expr_partContext): Unit = {
     enterString_expr_part(ctx.asInstanceOf[ParserRuleContext])
   }
@@ -1783,6 +1781,12 @@ class AllParseTreeListener
   override def exitMeta_string_part(ctx: WdlV1_1Parser.Meta_string_partContext): Unit = {
     exitMeta_string_part(ctx.asInstanceOf[ParserRuleContext])
   }
+  override def enterMeta_string_parts(ctx: WdlV1_1Parser.Meta_string_partsContext): Unit = {
+    enterMeta_string_parts(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def exitMeta_string_parts(ctx: WdlV1_1Parser.Meta_string_partsContext): Unit = {
+    exitMeta_string_parts(ctx.asInstanceOf[ParserRuleContext])
+  }
   override def enterMeta_string(ctx: WdlV1_1Parser.Meta_stringContext): Unit = {
     enterMeta_string(ctx.asInstanceOf[ParserRuleContext])
   }
@@ -1855,15 +1859,15 @@ class AllParseTreeListener
   override def exitTask_command(ctx: WdlV1_1Parser.Task_commandContext): Unit = {
     exitTask_command(ctx.asInstanceOf[ParserRuleContext])
   }
-  override def enterTask_command_string_part(
-      ctx: WdlV1_1Parser.Task_command_string_partContext
+  override def enterTask_command_string_parts(
+      ctx: WdlV1_1Parser.Task_command_string_partsContext
   ): Unit = {
-    enterTask_command_string_part(ctx.asInstanceOf[ParserRuleContext])
+    enterTask_command_string_parts(ctx.asInstanceOf[ParserRuleContext])
   }
-  override def exitTask_command_string_part(
-      ctx: WdlV1_1Parser.Task_command_string_partContext
+  override def exitTask_command_string_parts(
+      ctx: WdlV1_1Parser.Task_command_string_partsContext
   ): Unit = {
-    exitTask_command_string_part(ctx.asInstanceOf[ParserRuleContext])
+    exitTask_command_string_parts(ctx.asInstanceOf[ParserRuleContext])
   }
   override def enterTask_command_expr_part(
       ctx: WdlV1_1Parser.Task_command_expr_partContext
@@ -2092,6 +2096,12 @@ class AllParseTreeListener
   }
   override def exitNumber(ctx: WdlV2Parser.NumberContext): Unit = {
     exitNumber(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def enterString_parts(ctx: WdlV2Parser.String_partsContext): Unit = {
+    enterString_parts(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def exitString_parts(ctx: WdlV2Parser.String_partsContext): Unit = {
+    exitString_parts(ctx.asInstanceOf[ParserRuleContext])
   }
   override def enterString_part(ctx: WdlV2Parser.String_partContext): Unit = {
     enterString_part(ctx.asInstanceOf[ParserRuleContext])
@@ -2385,6 +2395,12 @@ class AllParseTreeListener
   override def exitMeta_string_part(ctx: WdlV2Parser.Meta_string_partContext): Unit = {
     exitMeta_string_part(ctx.asInstanceOf[ParserRuleContext])
   }
+  override def enterMeta_string_parts(ctx: WdlV2Parser.Meta_string_partsContext): Unit = {
+    enterMeta_string_parts(ctx.asInstanceOf[ParserRuleContext])
+  }
+  override def exitMeta_string_parts(ctx: WdlV2Parser.Meta_string_partsContext): Unit = {
+    exitMeta_string_parts(ctx.asInstanceOf[ParserRuleContext])
+  }
   override def enterMeta_string(ctx: WdlV2Parser.Meta_stringContext): Unit = {
     enterMeta_string(ctx.asInstanceOf[ParserRuleContext])
   }
@@ -2463,15 +2479,15 @@ class AllParseTreeListener
   override def exitTask_command(ctx: WdlV2Parser.Task_commandContext): Unit = {
     exitTask_command(ctx.asInstanceOf[ParserRuleContext])
   }
-  override def enterTask_command_string_part(
-      ctx: WdlV2Parser.Task_command_string_partContext
+  override def enterTask_command_string_parts(
+      ctx: WdlV2Parser.Task_command_string_partsContext
   ): Unit = {
-    enterTask_command_string_part(ctx.asInstanceOf[ParserRuleContext])
+    enterTask_command_string_parts(ctx.asInstanceOf[ParserRuleContext])
   }
-  override def exitTask_command_string_part(
-      ctx: WdlV2Parser.Task_command_string_partContext
+  override def exitTask_command_string_parts(
+      ctx: WdlV2Parser.Task_command_string_partsContext
   ): Unit = {
-    exitTask_command_string_part(ctx.asInstanceOf[ParserRuleContext])
+    exitTask_command_string_parts(ctx.asInstanceOf[ParserRuleContext])
   }
   override def enterTask_command_expr_part(ctx: WdlV2Parser.Task_command_expr_partContext): Unit = {
     enterTask_command_expr_part(ctx.asInstanceOf[ParserRuleContext])

--- a/src/main/scala/wdlTools/syntax/v1/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ParseAll.scala
@@ -381,7 +381,6 @@ case class ParseAll(followImports: Boolean = false,
         visitor.parseDocument
       } catch {
         case ex: Throwable =>
-          ex.printStackTrace()
           throw new SyntaxException(s"error parsing document ${fileSource.toString}", ex)
       }
     val errorListener = grammar.errListener

--- a/src/main/scala/wdlTools/syntax/v1/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ParseAll.scala
@@ -381,6 +381,7 @@ case class ParseAll(followImports: Boolean = false,
         visitor.parseDocument
       } catch {
         case ex: Throwable =>
+          ex.printStackTrace()
           throw new SyntaxException(s"error parsing document ${fileSource.toString}", ex)
       }
     val errorListener = grammar.errListener

--- a/src/main/scala/wdlTools/syntax/v1/ParseTop.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ParseTop.scala
@@ -931,28 +931,13 @@ task_input
     OutputSection(decls, getSourceLocation(grammar.docSource, ctx))
   }
 
-  override def visitTask_command_string_part(
-      ctx: WdlV1Parser.Task_command_string_partContext
-  ): ExprString = {
-    val text = if (ctx.CommandStringPart() != null) {
-      ctx.CommandStringPart().getText
-    } else if (ctx.CommandEscStringPart() != null) {
-      visitEscapse_sequence(ctx.CommandEscStringPart())
-    } else {
-      throw new SyntaxException(s"invalid task_command_string_part ${ctx}",
-                                getSourceLocation(grammar.docSource, ctx))
-    }
-    ExprString(text, getSourceLocation(grammar.docSource, ctx))
-  }
-
   override def visitTask_command_string_parts(
       ctx: WdlV1Parser.Task_command_string_partsContext
   ): ExprString = {
     val text = ctx
-      .task_command_string_part()
+      .CommandStringPart()
       .asScala
-      .map(visitTask_command_string_part)
-      .map(_.value)
+      .map(_.getText)
       .mkString("")
     ExprString(text, getSourceLocation(grammar.docSource, ctx))
   }

--- a/src/main/scala/wdlTools/syntax/v1/ParseTop.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ParseTop.scala
@@ -161,9 +161,6 @@ wdl_type
     }
   }
 
-  /* string_part
-  : StringPart*
-  ; */
   override def visitString_part(ctx: WdlV1Parser.String_partContext): ExprString = {
     if (ctx.StringPart() != null) {
       ExprString(ctx.StringPart().getText, getSourceLocation(grammar.docSource, ctx))

--- a/src/main/scala/wdlTools/syntax/v1/ParseTop.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ParseTop.scala
@@ -140,43 +140,47 @@ wdl_type
                               getSourceLocation(grammar.docSource, ctx))
   }
 
-  // a string_part may be an escape sequence, in which case we need
-  // to replace it with its unescaped value
-  private def visitString_part_text(text: String, ctx: ParserRuleContext): String = {
-    if (text.startsWith("\\")) {
-      text.drop(1) match {
-        case "t"                                         => "\t"
-        case "n"                                         => "\n"
-        case "\\"                                        => "\\"
-        case "'"                                         => "'"
-        case "\""                                        => "\""
-        case s if s.startsWith("u") || s.startsWith("U") =>
-          // convert unicode escape to unicode character
-          new String(Character.toChars(Integer.parseInt(s.drop(1), 16)))
-        case s if s.startsWith("x") =>
-          // convert escaped hex value to integer
-          Integer.parseInt(s.drop(1), 16).toString
-        case s if s.length == 3 =>
-          Integer.parseInt(s, 8).toString
-        case _ =>
-          throw new SyntaxException(s"invalid escape sequence: ${text}",
-                                    getSourceLocation(grammar.docSource, ctx))
-      }
-    } else {
-      text
+  private def visitEscapse_sequence(terminalNode: TerminalNode): String = {
+    terminalNode.getText.drop(1) match {
+      case "t"                                         => "\t"
+      case "n"                                         => "\n"
+      case "\\"                                        => "\\"
+      case "'"                                         => "'"
+      case "\""                                        => "\""
+      case s if s.startsWith("u") || s.startsWith("U") =>
+        // convert unicode escape to unicode character
+        new String(Character.toChars(Integer.parseInt(s.drop(1), 16)))
+      case s if s.startsWith("x") =>
+        // convert escaped hex value to integer
+        Integer.parseInt(s.drop(1), 16).toString
+      case s if s.length == 3 =>
+        Integer.parseInt(s, 8).toString
+      case _ =>
+        throw new SyntaxException(s"invalid escape sequence: ${terminalNode}",
+                                  getSourceLocation(grammar.docSource, terminalNode))
     }
   }
 
   /* string_part
   : StringPart*
   ; */
-  override def visitString_part(ctx: WdlV1Parser.String_partContext): Expr = {
+  override def visitString_part(ctx: WdlV1Parser.String_partContext): ExprString = {
+    if (ctx.StringPart() != null) {
+      ExprString(ctx.StringPart().getText, getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.EscStringPart() != null) {
+      ExprString(visitEscapse_sequence(ctx.EscStringPart()),
+                 getSourceLocation(grammar.docSource, ctx))
+    } else {
+      throw new SyntaxException(s"invalid string_part ${ctx}",
+                                getSourceLocation(grammar.docSource, ctx))
+    }
+  }
+
+  override def visitString_parts(ctx: WdlV1Parser.String_partsContext): Expr = {
     ctx
-      .StringPart()
+      .string_part()
       .asScala
-      .map(x =>
-        ExprString(visitString_part_text(x.getText, ctx), getSourceLocation(grammar.docSource, x))
-      )
+      .map(visitString_part)
       .filterNot(_.value.isEmpty)
       .toVector match {
       case Vector()  => ExprString("", getSourceLocation(grammar.docSource, ctx))
@@ -292,7 +296,7 @@ wdl_type
       ctx: WdlV1Parser.String_expr_with_string_partContext
   ): Expr = {
     val exprPart = visitString_expr_part(ctx.string_expr_part())
-    val stringPart = visitString_part(ctx.string_part())
+    val stringPart = visitString_parts(ctx.string_parts())
     val loc = getSourceLocation(grammar.docSource, ctx)
     (exprPart, stringPart) match {
       case (e, ExprString(s, _)) if s.isEmpty => ExprCompoundString(Vector(e), loc)
@@ -307,8 +311,7 @@ string
   ;
    */
   override def visitString(ctx: WdlV1Parser.StringContext): Expr = {
-    val stringPart =
-      ExprString(ctx.string_part().getText, getSourceLocation(grammar.docSource, ctx.string_part()))
+    val stringPart = visitString_parts(ctx.string_parts())
     val exprPart: Vector[Expr] = ctx
       .string_expr_with_string_part()
       .asScala
@@ -780,21 +783,38 @@ any_decls
                               getSourceLocation(grammar.docSource, ctx))
   }
 
-  /* meta_string
-    : DQUOTE string_part DQUOTE
-    | SQUOTE string_part SQUOTE
-    ; */
-  override def visitMeta_string(ctx: WdlV1Parser.Meta_stringContext): MetaValueString = {
+  override def visitMeta_string_part(ctx: WdlV1Parser.Meta_string_partContext): MetaValueString = {
+    val text = if (ctx.MetaStringPart() != null) {
+      ctx.MetaStringPart().getText
+    } else if (ctx.MetaEscStringPart() != null) {
+      visitEscapse_sequence(ctx.MetaEscStringPart())
+    } else {
+      throw new SyntaxException(s"invalid meta_string_part ${ctx}",
+                                getSourceLocation(grammar.docSource, ctx))
+    }
+    MetaValueString(text, getSourceLocation(grammar.docSource, ctx))
+  }
+
+  override def visitMeta_string_parts(
+      ctx: WdlV1Parser.Meta_string_partsContext
+  ): MetaValueString = {
     MetaValueString(
         ctx
           .meta_string_part()
-          .MetaStringPart()
           .asScala
-          .toVector
-          .map(x => visitString_part_text(x.getText, ctx))
+          .map(visitMeta_string_part)
+          .map(_.value)
           .mkString,
         getSourceLocation(grammar.docSource, ctx)
     )
+  }
+
+  /* meta_string
+      : DQUOTE string_part DQUOTE
+      | SQUOTE string_part SQUOTE
+      ; */
+  override def visitMeta_string(ctx: WdlV1Parser.Meta_stringContext): MetaValueString = {
+    visitMeta_string_parts(ctx.meta_string_parts())
   }
 
   /* meta_array: LBRACK (meta_value (COMMA meta_value)*)* RBRACK;
@@ -911,16 +931,28 @@ task_input
     OutputSection(decls, getSourceLocation(grammar.docSource, ctx))
   }
 
-  /* task_command_string_part
-    : CommandStringPart*
-    ; */
   override def visitTask_command_string_part(
       ctx: WdlV1Parser.Task_command_string_partContext
   ): ExprString = {
-    val text: String = ctx
-      .CommandStringPart()
+    val text = if (ctx.CommandStringPart() != null) {
+      ctx.CommandStringPart().getText
+    } else if (ctx.CommandEscStringPart() != null) {
+      visitEscapse_sequence(ctx.CommandEscStringPart())
+    } else {
+      throw new SyntaxException(s"invalid task_command_string_part ${ctx}",
+                                getSourceLocation(grammar.docSource, ctx))
+    }
+    ExprString(text, getSourceLocation(grammar.docSource, ctx))
+  }
+
+  override def visitTask_command_string_parts(
+      ctx: WdlV1Parser.Task_command_string_partsContext
+  ): ExprString = {
+    val text = ctx
+      .task_command_string_part()
       .asScala
-      .map(x => visitString_part_text(x.getText, ctx))
+      .map(visitTask_command_string_part)
+      .map(_.value)
       .mkString("")
     ExprString(text, getSourceLocation(grammar.docSource, ctx))
   }
@@ -947,8 +979,8 @@ task_input
       ctx: WdlV1Parser.Task_command_expr_with_stringContext
   ): Expr = {
     val exprPart: Expr = visitTask_command_expr_part(ctx.task_command_expr_part())
-    val stringPart: Expr = visitTask_command_string_part(
-        ctx.task_command_string_part()
+    val stringPart: Expr = visitTask_command_string_parts(
+        ctx.task_command_string_parts()
     )
     (exprPart, stringPart) match {
       case (e, ExprString(s, _)) if s.isEmpty => e
@@ -963,7 +995,7 @@ task_input
   | HEREDOC_COMMAND task_command_string_part task_command_expr_with_string* EndCommand
   ; */
   override def visitTask_command(ctx: WdlV1Parser.Task_commandContext): CommandSection = {
-    val start: Expr = visitTask_command_string_part(ctx.task_command_string_part())
+    val start: Expr = visitTask_command_string_parts(ctx.task_command_string_parts())
     val parts: Vector[Expr] = ctx
       .task_command_expr_with_string()
       .asScala

--- a/src/main/scala/wdlTools/syntax/v1_1/ParseTop.scala
+++ b/src/main/scala/wdlTools/syntax/v1_1/ParseTop.scala
@@ -142,14 +142,44 @@ wdl_type
                               getSourceLocation(grammar.docSource, ctx))
   }
 
-  /* string_part
-  : StringPart*
-  ; */
-  override def visitString_part(ctx: WdlV1_1Parser.String_partContext): Expr = {
+  private def visitEscapse_sequence(terminalNode: TerminalNode): String = {
+    terminalNode.getText.drop(1) match {
+      case "t"                                         => "\t"
+      case "n"                                         => "\n"
+      case "\\"                                        => "\\"
+      case "'"                                         => "'"
+      case "\""                                        => "\""
+      case s if s.startsWith("u") || s.startsWith("U") =>
+        // convert unicode escape to unicode character
+        new String(Character.toChars(Integer.parseInt(s.drop(1), 16)))
+      case s if s.startsWith("x") =>
+        // convert escaped hex value to integer
+        Integer.parseInt(s.drop(1), 16).toString
+      case s if s.length == 3 =>
+        Integer.parseInt(s, 8).toString
+      case _ =>
+        throw new SyntaxException(s"invalid escape sequence: ${terminalNode}",
+                                  getSourceLocation(grammar.docSource, terminalNode))
+    }
+  }
+
+  override def visitString_part(ctx: WdlV1_1Parser.String_partContext): ExprString = {
+    if (ctx.StringPart() != null) {
+      ExprString(ctx.StringPart().getText, getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.EscStringPart() != null) {
+      ExprString(visitEscapse_sequence(ctx.EscStringPart()),
+                 getSourceLocation(grammar.docSource, ctx))
+    } else {
+      throw new SyntaxException(s"invalid string_part ${ctx}",
+                                getSourceLocation(grammar.docSource, ctx))
+    }
+  }
+
+  override def visitString_parts(ctx: WdlV1_1Parser.String_partsContext): Expr = {
     ctx
-      .StringPart()
+      .string_part()
       .asScala
-      .map(x => ExprString(x.getText, getSourceLocation(grammar.docSource, x)))
+      .map(visitString_part)
       .filterNot(_.value.isEmpty)
       .toVector match {
       case Vector()  => ExprString("", getSourceLocation(grammar.docSource, ctx))
@@ -266,7 +296,7 @@ wdl_type
       ctx: WdlV1_1Parser.String_expr_with_string_partContext
   ): Expr = {
     val exprPart = visitString_expr_part(ctx.string_expr_part())
-    val stringPart = visitString_part(ctx.string_part())
+    val stringPart = visitString_parts(ctx.string_parts())
     val loc = getSourceLocation(grammar.docSource, ctx)
     (exprPart, stringPart) match {
       case (e, ExprString(s, _)) if s.isEmpty => ExprCompoundString(Vector(e), loc)
@@ -281,8 +311,7 @@ string
   ;
    */
   override def visitString(ctx: WdlV1_1Parser.StringContext): Expr = {
-    val stringPart =
-      ExprString(ctx.string_part().getText, getSourceLocation(grammar.docSource, ctx.string_part()))
+    val stringPart = visitString_parts(ctx.string_parts())
     val exprPart: Vector[Expr] = ctx
       .string_expr_with_string_part()
       .asScala
@@ -764,15 +793,40 @@ any_decls
                               getSourceLocation(grammar.docSource, ctx))
   }
 
-  /* meta_string
-    : DQUOTE string_part DQUOTE
-    | SQUOTE string_part SQUOTE
-    ; */
-  override def visitMeta_string(ctx: WdlV1_1Parser.Meta_stringContext): MetaValueString = {
+  override def visitMeta_string_part(
+      ctx: WdlV1_1Parser.Meta_string_partContext
+  ): MetaValueString = {
+    val text = if (ctx.MetaStringPart() != null) {
+      ctx.MetaStringPart().getText
+    } else if (ctx.MetaEscStringPart() != null) {
+      visitEscapse_sequence(ctx.MetaEscStringPart())
+    } else {
+      throw new SyntaxException(s"invalid meta_string_part ${ctx}",
+                                getSourceLocation(grammar.docSource, ctx))
+    }
+    MetaValueString(text, getSourceLocation(grammar.docSource, ctx))
+  }
+
+  override def visitMeta_string_parts(
+      ctx: WdlV1_1Parser.Meta_string_partsContext
+  ): MetaValueString = {
     MetaValueString(
-        ctx.meta_string_part().MetaStringPart().asScala.toVector.map(x => x.getText).mkString,
+        ctx
+          .meta_string_part()
+          .asScala
+          .map(visitMeta_string_part)
+          .map(_.value)
+          .mkString,
         getSourceLocation(grammar.docSource, ctx)
     )
+  }
+
+  /* meta_string
+      : DQUOTE string_part DQUOTE
+      | SQUOTE string_part SQUOTE
+      ; */
+  override def visitMeta_string(ctx: WdlV1_1Parser.Meta_stringContext): MetaValueString = {
+    visitMeta_string_parts(ctx.meta_string_parts())
   }
 
   /* meta_array: LBRACK (meta_value (COMMA meta_value)*)* RBRACK;
@@ -888,8 +942,8 @@ task_input
   /* task_command_string_part
     : CommandStringPart*
     ; */
-  override def visitTask_command_string_part(
-      ctx: WdlV1_1Parser.Task_command_string_partContext
+  override def visitTask_command_string_parts(
+      ctx: WdlV1_1Parser.Task_command_string_partsContext
   ): ExprString = {
     val text: String = ctx
       .CommandStringPart()
@@ -921,8 +975,8 @@ task_input
       ctx: WdlV1_1Parser.Task_command_expr_with_stringContext
   ): Expr = {
     val exprPart: Expr = visitTask_command_expr_part(ctx.task_command_expr_part())
-    val stringPart: Expr = visitTask_command_string_part(
-        ctx.task_command_string_part()
+    val stringPart: Expr = visitTask_command_string_parts(
+        ctx.task_command_string_parts()
     )
     (exprPart, stringPart) match {
       case (e, ExprString(s, _)) if s.isEmpty => e
@@ -937,7 +991,7 @@ task_input
   | HEREDOC_COMMAND task_command_string_part task_command_expr_with_string* EndCommand
   ; */
   override def visitTask_command(ctx: WdlV1_1Parser.Task_commandContext): CommandSection = {
-    val start: Expr = visitTask_command_string_part(ctx.task_command_string_part())
+    val start: Expr = visitTask_command_string_parts(ctx.task_command_string_parts())
     val parts: Vector[Expr] = ctx
       .task_command_expr_with_string()
       .asScala

--- a/src/test/resources/eval/v1/simple_expr.wdl
+++ b/src/test/resources/eval/v1/simple_expr.wdl
@@ -42,6 +42,13 @@ workflow foo {
 
   String l1 = if (false) then "a" else "b"
 
+  # escape sequences
+  String esc = "hello\n\t\"x\\o\""
+  String esc_unicode = "\u274C"
+  String esc_unicode2 = "\U0001F32D"
+  String esc_hex = "\xCC"
+  String esc_oct = "\027"
+
   # access pairs
   Pair[String, Boolean] p = ("hello", true)
   String l = p.left

--- a/src/test/resources/eval/v1/stdlib.wdl
+++ b/src/test/resources/eval/v1/stdlib.wdl
@@ -37,6 +37,8 @@ workflow foo {
   String sentence1 = sub(sentence, "He", "She")
   String sentence2 = sub(sentence, "A[ab]", "Berlin")
   String sentence3 = sub(sentence, "[a-z]*", "")
+  String fname = "file.bai"
+  String fname1 = sub(fname, "\\.bai$", ".bam.bai")
 
   # range
   Array[Int] ar3 = range(3)

--- a/src/test/scala/wdlTools/eval/EvalTest.scala
+++ b/src/test/scala/wdlTools/eval/EvalTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import wdlTools.Edge
 import wdlTools.eval.WdlValues._
-import wdlTools.syntax.{Parsers, SourceLocation, WdlVersion}
+import wdlTools.syntax.{Antlr4Util, Parsers, SourceLocation, WdlVersion}
 import wdlTools.types.{TypeCheckingRegime, TypeInfer, TypedAbstractSyntax => TAT}
 import wdlTools.types.WdlTypes._
 
@@ -100,6 +100,7 @@ class EvalTest extends AnyFlatSpec with Matchers with Inside {
   }
 
   it should "call stdlib" in {
+    Antlr4Util.setParserTrace(true)
     val file = v1Dir.resolve("stdlib.wdl")
     val (evaluator, decls) = parseAndTypeCheckAndGetDeclarations(file)
     val ctx = WdlValueBindings(Map("empty_string" -> V_Null))
@@ -133,6 +134,7 @@ class EvalTest extends AnyFlatSpec with Matchers with Inside {
         "He visited three places on his trip: Berlin, Berlin, C, D, and E"
     )
     bindings("sentence3") shouldBe V_String("H      : A, A, C, D,  E")
+    bindings("fname1") shouldBe V_String("file.bam.bai")
 
     // transpose
     bindings("ar3") shouldBe V_Array(V_Int(0), V_Int(1), V_Int(2))

--- a/src/test/scala/wdlTools/eval/EvalTest.scala
+++ b/src/test/scala/wdlTools/eval/EvalTest.scala
@@ -87,6 +87,13 @@ class EvalTest extends AnyFlatSpec with Matchers with Inside {
     bindings("l0") shouldBe V_String("a")
     bindings("l1") shouldBe V_String("b")
 
+    // escape sequences
+    bindings("esc") shouldBe V_String("hello\n\t\"x\\o\"")
+    bindings("esc_unicode") shouldBe V_String("\u274C")
+    bindings("esc_unicode2") shouldBe V_String("🌭")
+    bindings("esc_hex") shouldBe V_String("204")
+    bindings("esc_oct") shouldBe V_String("23")
+
     // pairs
     bindings("l") shouldBe V_String("hello")
     bindings("r") shouldBe V_Boolean(true)

--- a/src/test/scala/wdlTools/eval/EvalTest.scala
+++ b/src/test/scala/wdlTools/eval/EvalTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import wdlTools.Edge
 import wdlTools.eval.WdlValues._
-import wdlTools.syntax.{Antlr4Util, Parsers, SourceLocation, WdlVersion}
+import wdlTools.syntax.{Parsers, SourceLocation, WdlVersion}
 import wdlTools.types.{TypeCheckingRegime, TypeInfer, TypedAbstractSyntax => TAT}
 import wdlTools.types.WdlTypes._
 
@@ -100,7 +100,6 @@ class EvalTest extends AnyFlatSpec with Matchers with Inside {
   }
 
   it should "call stdlib" in {
-    Antlr4Util.setParserTrace(true)
     val file = v1Dir.resolve("stdlib.wdl")
     val (evaluator, decls) = parseAndTypeCheckAndGetDeclarations(file)
     val ctx = WdlValueBindings(Map("empty_string" -> V_Null))


### PR DESCRIPTION
There were two issues:
* The grammar for string literals did not exactly match the spec with regards to escape sequences
* wdlTools was not translating escape sequence tokens into their literal values

This PR fixes both issues.