### PR TITLE
APPS-573 escape strings when generating/formatting code unless they are in the command block

### DIFF
--- a/src/main/scala/wdlTools/generators/code/WdlFormatter.scala
+++ b/src/main/scala/wdlTools/generators/code/WdlFormatter.scala
@@ -891,7 +891,8 @@ case class WdlFormatter(targetVersion: Option[WdlVersion] = None,
   private def buildExpression(
       expr: Expr,
       placeholderOpen: String = Symbols.PlaceholderOpenDollar,
-      inStringOrCommand: Boolean = false,
+      inString: Boolean = false,
+      inCommand: Boolean = false,
       inPlaceholder: Boolean = false,
       inOperation: Boolean = false,
       parentOperation: Option[String] = None,
@@ -912,14 +913,15 @@ case class WdlFormatter(targetVersion: Option[WdlVersion] = None,
      */
     def nested(nestedExpression: Expr,
                placeholderOpen: String = placeholderOpen,
-               inString: Boolean = inStringOrCommand,
+               inString: Boolean = inString,
                inPlaceholder: Boolean = inPlaceholder,
                inOperation: Boolean = inOperation,
                parentOperation: Option[String] = None): Span = {
       buildExpression(
           nestedExpression,
           placeholderOpen = placeholderOpen,
-          inStringOrCommand = inString,
+          inString = inString,
+          inCommand = inCommand,
           inPlaceholder = inPlaceholder,
           inOperation = inOperation,
           parentOperation = parentOperation,
@@ -943,11 +945,16 @@ case class WdlFormatter(targetVersion: Option[WdlVersion] = None,
         } else {
           value
         }
-        Literal.fromStart(v, loc, quoting = inPlaceholder || !inStringOrCommand)
+        val escaped = if (!inCommand) {
+          Utils.escape(v)
+        } else {
+          v
+        }
+        Literal.fromStart(escaped, loc, quoting = inPlaceholder || !(inString || inCommand))
       case ValueBoolean(value, loc) => Literal.fromStart(value, loc)
       case ValueInt(value, loc)     => Literal.fromStart(value, loc)
       case ValueFloat(value, loc)   => Literal.fromStart(value, loc)
-      case ExprPair(left, right, loc) if !(inStringOrCommand || inPlaceholder) =>
+      case ExprPair(left, right, loc) if !(inString || inCommand || inPlaceholder) =>
         BoundedContainer(
             Vector(nested(left), nested(right)),
             Some(Literal.fromStart(Symbols.GroupOpen, loc),
@@ -1034,33 +1041,35 @@ case class WdlFormatter(targetVersion: Option[WdlVersion] = None,
                     default.map(e => option(Symbols.DefaultOption, e))
                 ).flatten
             ),
-            inString = inStringOrCommand,
+            inString = inString || inCommand,
             bounds = loc
         )
       case ExprCompoundString(value, loc) if !inPlaceholder =>
-        CompoundString(value.map(nested(_, inString = true)), quoting = !inStringOrCommand, loc)
+        CompoundString(value.map(nested(_, inString = true)),
+                       quoting = !(inString || inCommand),
+                       loc)
       // other expressions need to be wrapped in a placeholder if they
       // appear in a string or command block
       case other =>
         val span = other match {
           case ExprIdentifier(id, loc) => Literal.fromStart(id, loc)
           case ExprAt(array, index, loc) =>
-            val arraySpan = nested(array, inPlaceholder = inStringOrCommand)
+            val arraySpan = nested(array, inPlaceholder = inString || inCommand)
             val prefix = SpanSequence(
                 Vector(arraySpan, Literal.fromPrev(Symbols.IndexOpen, arraySpan))
             )
             val suffix = Literal.fromEnd(Symbols.IndexClose, loc)
             BoundedContainer(
-                Vector(nested(index, inPlaceholder = inStringOrCommand)),
+                Vector(nested(index, inPlaceholder = inString || inCommand)),
                 Some(prefix, suffix),
                 // TODO: shouldn't need a delimiter - index must be exactly length 1
                 Some(Symbols.ArrayDelimiter),
                 bounds = loc
             )
           case ExprIfThenElse(cond, tBranch, fBranch, loc) =>
-            val condSpan = nested(cond, inOperation = false, inPlaceholder = inStringOrCommand)
-            val tSpan = nested(tBranch, inOperation = false, inPlaceholder = inStringOrCommand)
-            val fSpan = nested(fBranch, inOperation = false, inPlaceholder = inStringOrCommand)
+            val condSpan = nested(cond, inOperation = false, inPlaceholder = inString || inCommand)
+            val tSpan = nested(tBranch, inOperation = false, inPlaceholder = inString || inCommand)
+            val fSpan = nested(fBranch, inOperation = false, inPlaceholder = inString || inCommand)
             BoundedContainer(
                 Vector(
                     Literal.fromStart(Symbols.If, loc),
@@ -1082,15 +1091,15 @@ case class WdlFormatter(targetVersion: Option[WdlVersion] = None,
             Operation(
                 symbol,
                 nested(lhs,
-                       inPlaceholder = inStringOrCommand,
+                       inPlaceholder = inString || inCommand,
                        inOperation = true,
                        parentOperation = Some(oper)),
                 nested(rhs,
-                       inPlaceholder = inStringOrCommand,
+                       inPlaceholder = inString || inCommand,
                        inOperation = true,
                        parentOperation = Some(oper)),
                 grouped = inOperation && !parentOperation.contains(oper),
-                inString = inStringOrCommand,
+                inString = inString || inCommand,
                 loc
             )
           case ExprApply(funcName, elements, loc) =>
@@ -1099,21 +1108,21 @@ case class WdlFormatter(targetVersion: Option[WdlVersion] = None,
             )
             val suffix = Literal.fromEnd(Symbols.FunctionCallClose, loc)
             BoundedContainer(
-                elements.map(nested(_, inPlaceholder = inStringOrCommand)),
+                elements.map(nested(_, inPlaceholder = inString || inCommand)),
                 Some(prefix, suffix),
                 Some(Symbols.ArrayDelimiter),
                 loc
             )
           case ExprGetName(e, id, loc) =>
-            val exprSpan = nested(e, inPlaceholder = inStringOrCommand)
+            val exprSpan = nested(e, inPlaceholder = inString || inCommand)
             val idLiteral = Literal.fromEnd(id, loc)
             SpanSequence(
                 Vector(exprSpan, Literal.between(Symbols.Access, exprSpan, idLiteral), idLiteral)
             )
           case other => throw new Exception(s"Unrecognized expression $other")
         }
-        if (inStringOrCommand && !inPlaceholder) {
-          Placeholder(span, placeholderOpen, inString = inStringOrCommand, bounds = other.loc)
+        if ((inString || inCommand) && !inPlaceholder) {
+          Placeholder(span, placeholderOpen, inString = inString || inCommand, bounds = other.loc)
         } else {
           span
         }
@@ -1788,7 +1797,7 @@ case class WdlFormatter(targetVersion: Option[WdlVersion] = None,
               buildExpression(
                   expr,
                   placeholderOpen = Symbols.PlaceholderOpenTilde,
-                  inStringOrCommand = true,
+                  inCommand = true,
                   stringModifier = replaceIndent
               )
           )

--- a/src/main/scala/wdlTools/generators/code/WdlGenerator.scala
+++ b/src/main/scala/wdlTools/generators/code/WdlGenerator.scala
@@ -519,7 +519,8 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
   private def buildExpression(
       expr: Expr,
       placeholderOpen: String = Symbols.PlaceholderOpenDollar,
-      inStringOrCommand: Boolean = false,
+      inString: Boolean = false,
+      inCommand: Boolean = false,
       inPlaceholder: Boolean = false,
       inOperation: Boolean = false,
       parentOperation: Option[String] = None,
@@ -540,14 +541,15 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
      */
     def nested(nestedExpression: Expr,
                placeholderOpen: String = placeholderOpen,
-               inString: Boolean = inStringOrCommand,
+               inString: Boolean = inString,
                inPlaceholder: Boolean = inPlaceholder,
                inOperation: Boolean = inOperation,
                parentOperation: Option[String] = None): Sized = {
       buildExpression(
           nestedExpression,
           placeholderOpen = placeholderOpen,
-          inStringOrCommand = inString,
+          inString = inString,
+          inCommand = inCommand,
           inPlaceholder = inPlaceholder,
           inOperation = inOperation,
           parentOperation = parentOperation,
@@ -561,7 +563,12 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
       } else {
         value
       }
-      Literal(v, quoting = inPlaceholder || !inStringOrCommand)
+      val escaped = if (!inCommand) {
+        Utils.escape(v)
+      } else {
+        v
+      }
+      Literal(escaped, quoting = inPlaceholder || !(inString || inCommand))
     }
 
     def option(name: String, value: Expr): Sized = {
@@ -580,7 +587,7 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
       case ValueBoolean(value, _, _)   => Literal(value)
       case ValueInt(value, _, _)       => Literal(value)
       case ValueFloat(value, _, _)     => Literal(value)
-      case ExprPair(left, right, _, _) if !(inStringOrCommand || inPlaceholder) =>
+      case ExprPair(left, right, _, _) if !(inString || inCommand || inPlaceholder) =>
         Container(
             Vector(nested(left), nested(right)),
             Some(Symbols.ArrayDelimiter),
@@ -638,7 +645,7 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
                     default.map(e => option(Symbols.DefaultOption, e))
                 ).flatten
             ),
-            inString = inStringOrCommand
+            inString = inString || inCommand
         )
       case ExprCompoundString(value, _, _) if !inPlaceholder =>
         // Often/always an ExprCompoundString contains one or more empty
@@ -648,27 +655,28 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
           case ValueString(s, _, _) => s.nonEmpty
           case _                    => true
         }
-        CompoundString(filteredExprs.map(nested(_, inString = true)), quoting = !inStringOrCommand)
+        CompoundString(filteredExprs.map(nested(_, inString = true)),
+                       quoting = !(inString || inCommand))
       // other expressions need to be wrapped in a placeholder if they
       // appear in a string or command block
       case other =>
         val sized = other match {
           case ExprIdentifier(id, _, _) => Literal(id)
           case ExprAt(array, index, _, _) =>
-            val arraySized = nested(array, inPlaceholder = inStringOrCommand)
+            val arraySized = nested(array, inPlaceholder = inString || inCommand)
             val prefix = Sequence(
                 Vector(arraySized, Literal(Symbols.IndexOpen))
             )
             val suffix = Literal(Symbols.IndexClose)
             Container(
-                Vector(nested(index, inPlaceholder = inStringOrCommand)),
+                Vector(nested(index, inPlaceholder = inString || inCommand)),
                 Some(Symbols.ArrayDelimiter),
                 Some(prefix, suffix)
             )
           case ExprIfThenElse(cond, tBranch, fBranch, _, _) =>
-            val condSized = nested(cond, inOperation = false, inPlaceholder = inStringOrCommand)
-            val tSized = nested(tBranch, inOperation = false, inPlaceholder = inStringOrCommand)
-            val fSized = nested(fBranch, inOperation = false, inPlaceholder = inStringOrCommand)
+            val condSized = nested(cond, inOperation = false, inPlaceholder = inString || inCommand)
+            val tSized = nested(tBranch, inOperation = false, inPlaceholder = inString || inCommand)
+            val fSized = nested(fBranch, inOperation = false, inPlaceholder = inString || inCommand)
             Container(
                 Vector(
                     Literal(Symbols.If),
@@ -684,14 +692,14 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
             val symbol = Operator.Vectorizable(oper).symbol
             val operands = args.map(
                 nested(_,
-                       inPlaceholder = inStringOrCommand,
+                       inPlaceholder = inString || inCommand,
                        inOperation = true,
                        parentOperation = Some(oper))
             )
             Operation(symbol,
                       operands,
                       grouped = inOperation && !parentOperation.contains(oper),
-                      inString = inStringOrCommand)
+                      inString = inString || inCommand)
           case ExprApply(oper, _, Vector(value), _, _) if Operator.All.contains(oper) =>
             val symbol = Operator.All(oper).symbol
             Sequence(Vector(Literal(symbol), nested(value, inOperation = true)))
@@ -701,16 +709,16 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
                 symbol,
                 Vector(
                     nested(lhs,
-                           inPlaceholder = inStringOrCommand,
+                           inPlaceholder = inString || inCommand,
                            inOperation = true,
                            parentOperation = Some(oper)),
                     nested(rhs,
-                           inPlaceholder = inStringOrCommand,
+                           inPlaceholder = inString || inCommand,
                            inOperation = true,
                            parentOperation = Some(oper))
                 ),
                 grouped = inOperation && !parentOperation.contains(oper),
-                inString = inStringOrCommand
+                inString = inString || inCommand
             )
           case ExprApply(funcName, _, elements, _, _) =>
             val prefix = Sequence(
@@ -718,20 +726,20 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
             )
             val suffix = Literal(Symbols.FunctionCallClose)
             Container(
-                elements.map(nested(_, inPlaceholder = inStringOrCommand)),
+                elements.map(nested(_, inPlaceholder = inString || inCommand)),
                 Some(Symbols.ArrayDelimiter),
                 Some(prefix, suffix)
             )
           case ExprGetName(e, id, _, _) =>
-            val exprSized = nested(e, inPlaceholder = inStringOrCommand)
+            val exprSized = nested(e, inPlaceholder = inString || inCommand)
             val idLiteral = Literal(id)
             Sequence(
                 Vector(exprSized, Literal(Symbols.Access), idLiteral)
             )
           case other => throw new Exception(s"Unrecognized expression $other")
         }
-        if (inStringOrCommand && !inPlaceholder) {
-          Placeholder(sized, placeholderOpen, inString = inStringOrCommand)
+        if ((inString || inCommand) && !inPlaceholder) {
+          Placeholder(sized, placeholderOpen, inString = inString || inCommand)
         } else {
           sized
         }
@@ -1191,7 +1199,7 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
               buildExpression(
                   expr,
                   placeholderOpen = Symbols.PlaceholderOpenTilde,
-                  inStringOrCommand = true,
+                  inCommand = true,
                   stringModifier = replaceIndent
               )
           )

--- a/src/main/scala/wdlTools/generators/code/package.scala
+++ b/src/main/scala/wdlTools/generators/code/package.scala
@@ -47,7 +47,7 @@ trait Sized {
 object Utils {
 
   /**
-    * Escapes a String according to the rules in the spec.
+    * Escapes special characters in a String.
     */
   def escape(raw: String): String = {
     val quoted = Literal(Constant(raw)).toString

--- a/src/main/scala/wdlTools/generators/code/package.scala
+++ b/src/main/scala/wdlTools/generators/code/package.scala
@@ -8,6 +8,7 @@
   */
 package wdlTools.generators.code
 
+import scala.reflect.runtime.universe._
 import wdlTools.syntax.BuiltinSymbols
 
 object Indenting extends Enumeration {
@@ -41,6 +42,17 @@ trait Sized {
     * The length of the element's first line, if it were formatted with line-wrapping.
     */
   def firstLineLength: Int = length
+}
+
+object Utils {
+
+  /**
+    * Escapes a String according to the rules in the spec.
+    */
+  def escape(raw: String): String = {
+    val quoted = Literal(Constant(raw)).toString
+    quoted.substring(1, quoted.length - 1)
+  }
 }
 
 /**

--- a/src/main/scala/wdlTools/syntax/v1/ParseTop.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ParseTop.scala
@@ -174,16 +174,16 @@ wdl_type
   }
 
   override def visitString_parts(ctx: WdlV1Parser.String_partsContext): Expr = {
-    ctx
-      .string_part()
-      .asScala
-      .map(visitString_part)
-      .filterNot(_.value.isEmpty)
-      .toVector match {
-      case Vector()  => ExprString("", getSourceLocation(grammar.docSource, ctx))
-      case Vector(e) => e
-      case parts     => ExprCompoundString(parts, getSourceLocation(grammar.docSource, ctx))
+    val parts = ctx.string_part().asScala.map(visitString_part).toVector
+    val (strings, locs) = parts.collect {
+      case ExprString(value, loc) if value.nonEmpty => (value, loc)
+    }.unzip
+    val loc = if (locs.nonEmpty) {
+      SourceLocation.merge(locs)
+    } else {
+      getSourceLocation(grammar.docSource, ctx)
     }
+    ExprString(strings.mkString(""), loc)
   }
 
   // These are parts of string interpolation expressions like:

--- a/src/main/scala/wdlTools/syntax/v2/ParseTop.scala
+++ b/src/main/scala/wdlTools/syntax/v2/ParseTop.scala
@@ -176,16 +176,16 @@ wdl_type
   }
 
   override def visitString_parts(ctx: WdlV2Parser.String_partsContext): Expr = {
-    ctx
-      .string_part()
-      .asScala
-      .map(visitString_part)
-      .filterNot(_.value.isEmpty)
-      .toVector match {
-      case Vector()  => ExprString("", getSourceLocation(grammar.docSource, ctx))
-      case Vector(e) => e
-      case parts     => ExprCompoundString(parts, getSourceLocation(grammar.docSource, ctx))
+    val parts = ctx.string_part().asScala.map(visitString_part).toVector
+    val (strings, locs) = parts.collect {
+      case ExprString(value, loc) if value.nonEmpty => (value, loc)
+    }.unzip
+    val loc = if (locs.nonEmpty) {
+      SourceLocation.merge(locs)
+    } else {
+      getSourceLocation(grammar.docSource, ctx)
     }
+    ExprString(strings.mkString(""), loc)
   }
 
   /* string_expr_with_string_part

--- a/src/test/resources/format/before/escape_sequences.wdl
+++ b/src/test/resources/format/before/escape_sequences.wdl
@@ -1,0 +1,13 @@
+version 1.0
+
+task string_tab {
+  Array[String] a = ["1\t1", "2\\t2", "3\\\t3", "4\\\\t4"]
+
+  command <<<
+    cat -vet ~{write_lines(a)}
+  >>>
+
+  output {
+    String out = read_string(stdout())
+  }
+}

--- a/src/test/scala/wdlTools/format/GeneratorTest.scala
+++ b/src/test/scala/wdlTools/format/GeneratorTest.scala
@@ -124,4 +124,8 @@ class GeneratorTest extends AnyFlatSpec with Matchers {
   it should "regenerate a WDL with only a placeholder in the command" in {
     generate("bug-382.wdl")
   }
+
+  it should "escape strings" in {
+    generate("escape_sequences.wdl", validateContentSelf = true)
+  }
 }

--- a/src/test/scala/wdlTools/syntax/v1/ConcreteSyntaxV1Test.scala
+++ b/src/test/scala/wdlTools/syntax/v1/ConcreteSyntaxV1Test.scala
@@ -732,19 +732,20 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
     }
   }
 
-  private def flattenCompoundString(expr: Expr): String = {
+  private def getString(expr: Expr): String = {
     expr match {
+      case ExprString(value, _) => value
       case ExprCompoundString(parts, _) =>
         parts
           .flatMap {
             case ExprString(s, _)        => Vector(s)
-            case cs: ExprCompoundString  => flattenCompoundString(cs)
+            case cs: ExprCompoundString  => getString(cs)
             case ExprIdentifier(name, _) => Vector(s"$${${name}}")
             case other =>
               throw new Exception(s"unexpected expression ${other}")
           }
           .mkString("")
-      case _ => throw new Exception(s"not a compound string: ${expr}")
+      case _ => throw new Exception(s"not a string or compound string: ${expr}")
     }
   }
 
@@ -763,7 +764,7 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
       case Some(
           ExprApply("select_first", Vector(ExprArrayLiteral(Vector(_, cs), _)), _)
           ) =>
-        flattenCompoundString(cs)
+        getString(cs)
       case _ =>
         throw new Exception(s"unexpected expression ${decl.expr}")
     }
@@ -785,7 +786,7 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
       case Some(
           ExprArrayLiteral(strings, _)
           ) =>
-        strings.map(flattenCompoundString)
+        strings.map(getString)
       case _ =>
         throw new Exception(s"unexpected expression ${decl.expr}")
     }


### PR DESCRIPTION
Strings with escapes are parsed into multiple tokens. For example `"foo\\tbar"` would be parsed to `Vector(ExprString("foo"), ExprString("\"), ExprString("tbar"))`. One of the changes in this PR is to merge adjacent `ExprString`s to make escaping easier. The other change is to call `escape` on strings in the code formatter and generator, as long as they are not in the command section.