### PR TITLE
Do not treat placeholder options as occurring 'inPlaceholder' when generating code

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## in develop
 
 * Escape strings when generating/formatting code (unless they are in the command block)
+* Fixes issues with using expressions in placeholder option values
 
 ## 0.12.9 (2021-04-19)
 

--- a/src/main/scala/wdlTools/generators/code/WdlFormatter.scala
+++ b/src/main/scala/wdlTools/generators/code/WdlFormatter.scala
@@ -930,7 +930,7 @@ case class WdlFormatter(targetVersion: Option[WdlVersion] = None,
     }
 
     def option(name: String, value: Expr): Span = {
-      val exprSpan = nested(value, inPlaceholder = true)
+      val exprSpan = nested(value)
       val eqLiteral = Literal.fromNext(Symbols.Assignment, exprSpan)
       val nameLiteral = Literal.fromNext(name, eqLiteral)
       SpanSequence(Vector(nameLiteral, eqLiteral, exprSpan))

--- a/src/main/scala/wdlTools/generators/code/WdlGenerator.scala
+++ b/src/main/scala/wdlTools/generators/code/WdlGenerator.scala
@@ -574,7 +574,7 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
     def option(name: String, value: Expr): Sized = {
       val nameLiteral = Literal(name)
       val eqLiteral = Literal(Symbols.Assignment)
-      val exprSized = nested(value, inPlaceholder = true)
+      val exprSized = nested(value)
       Sequence(Vector(nameLiteral, eqLiteral, exprSized))
     }
 

--- a/src/test/resources/syntax/v1_1/nested_expr.wdl
+++ b/src/test/resources/syntax/v1_1/nested_expr.wdl
@@ -1,0 +1,25 @@
+version 1.1
+
+task t1 {
+    input {
+        Boolean bool_flag = true
+        String if_true = "x"
+        String if_false = "y"
+    }
+
+    command <<<
+    echo ~{true="~{if_true}" false="~{if_false}" bool_flag}
+    >>>
+
+    output {
+        String out = read_lines(stdout())[0]
+    }
+}
+
+workflow w1 {
+    call t1
+
+    output {
+        String out = t1.out
+    }
+}

--- a/src/test/scala/wdlTools/syntax/v1_1/ConcreteSyntaxV1_1Test.scala
+++ b/src/test/scala/wdlTools/syntax/v1_1/ConcreteSyntaxV1_1Test.scala
@@ -23,4 +23,8 @@ class ConcreteSyntaxV1_1Test extends AnyFlatSpec with Matchers {
   it should "parse sep option and sep function" in {
     getDocument("sep.wdl")
   }
+
+  it should "parse nested expressions" in {
+    getDocument("nested_expr.wdl")
+  }
 }


### PR DESCRIPTION
Expressions in placeholders are handled a bit differently, but this should only apply to the expression itself, not any expressions used in placeholder options.