### PR TITLE
fix quoting of placeholder options

### DIFF
--- a/src/main/scala/wdlTools/generators/code/WdlFormatter.scala
+++ b/src/main/scala/wdlTools/generators/code/WdlFormatter.scala
@@ -954,14 +954,6 @@ case class WdlFormatter(targetVersion: Option[WdlVersion] = None,
       case ValueBoolean(value, loc) => Literal.fromStart(value, loc)
       case ValueInt(value, loc)     => Literal.fromStart(value, loc)
       case ValueFloat(value, loc)   => Literal.fromStart(value, loc)
-      case ExprPair(left, right, loc) if !(inString || inCommand || inPlaceholder) =>
-        BoundedContainer(
-            Vector(nested(left), nested(right)),
-            Some(Literal.fromStart(Symbols.GroupOpen, loc),
-                 Literal.fromEnd(Symbols.GroupClose, loc)),
-            Some(Symbols.ArrayDelimiter),
-            loc
-        )
       case ExprArray(value, loc) =>
         BoundedContainer(
             value.map(nested(_)),
@@ -970,6 +962,14 @@ case class WdlFormatter(targetVersion: Option[WdlVersion] = None,
             Some(Symbols.ArrayDelimiter),
             loc,
             wrapping = Wrapping.AllOrNone
+        )
+      case ExprPair(left, right, loc) =>
+        BoundedContainer(
+            Vector(nested(left), nested(right)),
+            Some(Literal.fromStart(Symbols.GroupOpen, loc),
+                 Literal.fromEnd(Symbols.GroupClose, loc)),
+            Some(Symbols.ArrayDelimiter),
+            loc
         )
       case ExprMap(value, loc) =>
         BoundedContainer(
@@ -1044,7 +1044,7 @@ case class WdlFormatter(targetVersion: Option[WdlVersion] = None,
             inString = inString || inCommand,
             bounds = loc
         )
-      case ExprCompoundString(value, loc) if !inPlaceholder =>
+      case ExprCompoundString(value, loc) =>
         CompoundString(value.map(nested(_, inString = true)),
                        quoting = !(inString || inCommand),
                        loc)

--- a/src/main/scala/wdlTools/generators/code/WdlFormatter.scala
+++ b/src/main/scala/wdlTools/generators/code/WdlFormatter.scala
@@ -930,7 +930,7 @@ case class WdlFormatter(targetVersion: Option[WdlVersion] = None,
     }
 
     def option(name: String, value: Expr): Span = {
-      val exprSpan = nested(value)
+      val exprSpan = nested(value, inPlaceholder = true)
       val eqLiteral = Literal.fromNext(Symbols.Assignment, exprSpan)
       val nameLiteral = Literal.fromNext(name, eqLiteral)
       SpanSequence(Vector(nameLiteral, eqLiteral, exprSpan))

--- a/src/test/resources/format/before/sum_array.wdl
+++ b/src/test/resources/format/before/sum_array.wdl
@@ -1,0 +1,15 @@
+version 1.0
+
+task SumArray {
+  input {
+    Array[Int] numbers
+  }
+
+  command <<<
+    python3 -c "print(~{sep=" + " numbers})"
+  >>>
+
+  output {
+    Int result = read_int(stdout())
+  }
+}

--- a/src/test/scala/wdlTools/format/GeneratorTest.scala
+++ b/src/test/scala/wdlTools/format/GeneratorTest.scala
@@ -137,4 +137,8 @@ class GeneratorTest extends AnyFlatSpec with Matchers {
   it should "escape strings" in {
     generate("escape_sequences.wdl", validateContentSelf = true)
   }
+
+  it should "include quotes for strings in placeholders" in {
+    generate("sum_array.wdl", validateContentSelf = true)
+  }
 }


### PR DESCRIPTION
The previous fix for placeholders was not quite correct - it failed to put quotes around literal values. It also assumed you can't have nested placeholders, which is incorrect. This fixes both issues.