### PR TITLE
Exclude `loc` field from `equals` and `hashCode` in AST case classes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Change log
 
+## in develop
+
+* **Breaking changes**:
+    * `loc` is moved from the first to second parameter section in all AST case classes to prevent it from being included in the `equals` and `hashCode` implementations
+    * Some fields of AST case classes are renamed for greater clarity
+
 ## 0.12.11 (2021-05-07)
 
 * Fixes regession in code generator and formatter

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 wdlTools {
-    version = "0.12.12-SNAPSHOT"
+    version = "0.13.0-SNAPSHOT"
 }
 
 #

--- a/src/main/scala/wdlTools/eval/Eval.scala
+++ b/src/main/scala/wdlTools/eval/Eval.scala
@@ -153,9 +153,9 @@ case class Eval(paths: EvalPaths,
     // builds a Vector of name components
     def inner(innerExpr: TAT.Expr, innerFieldName: String): Option[Vector[String]] = {
       innerExpr match {
-        case TAT.ExprIdentifier(id, wdlType, _) if canResolveField(wdlType, innerFieldName) =>
+        case TAT.ExprIdentifier(id, wdlType) if canResolveField(wdlType, innerFieldName) =>
           Some(Vector(id, innerFieldName))
-        case TAT.ExprGetName(e, fieldName, _, _) =>
+        case TAT.ExprGetName(e, fieldName, _) =>
           inner(e, fieldName).map(v => v :+ innerFieldName)
         case _ => None
       }
@@ -237,17 +237,17 @@ case class Eval(paths: EvalPaths,
         case x: TAT.ValueDirectory => V_Directory(x.value)
 
         // complex types
-        case TAT.ExprPair(left, right, _, _) =>
+        case TAT.ExprPair(left, right, _) =>
           V_Pair(inner(left, updatedCtx), inner(right, updatedCtx))
-        case TAT.ExprArray(value, _, _) =>
+        case TAT.ExprArray(value, _) =>
           V_Array(value.map { x =>
             inner(x, updatedCtx)
           })
-        case TAT.ExprMap(value, _, _) =>
+        case TAT.ExprMap(value, _) =>
           V_Map(value.map {
             case (k, v) => inner(k, updatedCtx) -> inner(v, updatedCtx)
           })
-        case TAT.ExprObject(value, _, _) =>
+        case TAT.ExprObject(value, _) =>
           V_Object(
               value
                 .map {
@@ -266,20 +266,20 @@ case class Eval(paths: EvalPaths,
                 .to(TreeSeqMap)
           )
 
-        case TAT.ExprIdentifier(id, _, _) if updatedCtx.bindings.contains(id) =>
+        case TAT.ExprIdentifier(id, _) if updatedCtx.bindings.contains(id) =>
           updatedCtx.bindings(id)
-        case TAT.ExprIdentifier(id, _, _) =>
+        case TAT.ExprIdentifier(id, _) =>
           throw new EvalException(s"identifier ${id} not found")
 
         // interpolation
-        case TAT.ExprCompoundString(value, _, _) =>
+        case TAT.ExprCompoundString(value, _) =>
           // concatenate an array of strings inside an expression/command block
           val strArray: Vector[String] = value.map { expr =>
             val v = inner(expr, updatedCtx.advanceState(Some(ExprState.InString)))
             interpolationValueToString(v, expr.loc)
           }
           V_String(strArray.mkString(""))
-        case TAT.ExprPlaceholder(t, f, sep, default, expr, _, _) =>
+        case TAT.ExprPlaceholder(t, f, sep, default, expr, _) =>
           val ctxInPlaceholder = updatedCtx.advanceState(Some(ExprState.InPlaceholder))
           val exprValue = inner(expr, ctxInPlaceholder)
           (exprValue, t, f, sep, default) match {
@@ -305,16 +305,16 @@ case class Eval(paths: EvalPaths,
               )
           }
 
-        case TAT.ExprIfThenElse(cond, tBranch, fBranch, _, loc) =>
+        case TAT.ExprIfThenElse(cond, tBranch, fBranch, _) =>
           // if (x == 1) then "Sunday" else "Weekday"
           inner(cond, updatedCtx) match {
             case V_Boolean(true)  => inner(tBranch, updatedCtx)
             case V_Boolean(false) => inner(fBranch, updatedCtx)
             case _ =>
-              throw new EvalException(s"condition is not boolean", loc)
+              throw new EvalException(s"condition is not boolean", nestedExpr.loc)
           }
 
-        case TAT.ExprAt(collection, index, _, loc) =>
+        case TAT.ExprAt(collection, index, _) =>
           // Access an array element at [index: Int] or map value at [key: K]
           val collectionVal = inner(collection, updatedCtx)
           val indexVal = inner(index, updatedCtx)
@@ -325,10 +325,11 @@ case class Eval(paths: EvalPaths,
               val arraySize = av.size
               throw new EvalException(
                   s"array access out of bounds (size=${arraySize}, element accessed=${n})",
-                  loc
+                  nestedExpr.loc
               )
             case (_: V_Array, _) =>
-              throw new EvalException(s"array access requires an array and an integer", loc)
+              throw new EvalException(s"array access requires an array and an integer",
+                                      nestedExpr.loc)
             case (V_Map(value), key) =>
               value
                 .collectFirst {
@@ -337,7 +338,7 @@ case class Eval(paths: EvalPaths,
                 .getOrElse(
                     throw new EvalException(
                         s"map ${value} does not contain key ${key}",
-                        loc
+                        nestedExpr.loc
                     )
                 )
             case _ =>
@@ -346,7 +347,7 @@ case class Eval(paths: EvalPaths,
               )
           }
 
-        case TAT.ExprGetName(e: TAT.Expr, fieldName, _, loc) =>
+        case TAT.ExprGetName(e: TAT.Expr, fieldName, _) =>
           Option
             .when(updatedCtx.hasFullyQualifiedBindings) {
               // if the context has fully-qualified identifiers, try to
@@ -358,16 +359,16 @@ case class Eval(paths: EvalPaths,
             .getOrElse {
               // evaluate the LHS expression, then access the RHS field
               val ev = inner(e, updatedCtx)
-              exprGetName(ev, fieldName, loc)
+              exprGetName(ev, fieldName, nestedExpr.loc)
             }
 
-        case TAT.ExprApply(funcName, _, elements, _, loc) =>
+        case TAT.ExprApply(funcName, _, elements, _) =>
           // Apply a standard library function (including built-in operators)
           // to arguments. For example:
           //   1 + 1
           //   read_int("4")
           val funcArgs = elements.map(e => inner(e, updatedCtx))
-          standardLibrary.call(funcName, funcArgs, loc, updatedCtx.exprState)
+          standardLibrary.call(funcName, funcArgs, nestedExpr.loc, updatedCtx.exprState)
 
         case other =>
           throw new Exception(s"expression ${other} not implemented")
@@ -412,11 +413,11 @@ case class Eval(paths: EvalPaths,
       bindings: Bindings[String, V] = WdlValueBindings.empty
   ): Bindings[String, V] = {
     decls.foldLeft(bindings) {
-      case (accu: Bindings[String, V], TAT.PrivateVariable(name, wdlType, expr, loc)) =>
+      case (accu: Bindings[String, V], pv: TAT.PrivateVariable) =>
         val ctx = Context(accu)
-        val value = apply(expr, ctx)
-        val coerced = Coercion.coerceTo(wdlType, value, loc, allowNonstandardCoercions)
-        accu.add(name, coerced)
+        val value = apply(pv.expr, ctx)
+        val coerced = Coercion.coerceTo(pv.wdlType, value, pv.loc, allowNonstandardCoercions)
+        accu.add(pv.name, coerced)
       case (_, ast) =>
         throw new Exception(s"Cannot evaluate element ${ast.getClass}")
     }

--- a/src/main/scala/wdlTools/eval/Meta.scala
+++ b/src/main/scala/wdlTools/eval/Meta.scala
@@ -9,13 +9,13 @@ class MetaMap(values: Map[String, TAT.MetaValue]) {
                         value: TAT.MetaValue,
                         wdlTypes: Vector[WdlTypes.T] = Vector.empty): WdlValues.V = {
     val wdlValue = value match {
-      case TAT.MetaValueNull(_)       => V_Null
-      case TAT.MetaValueString(s, _)  => V_String(s)
-      case TAT.MetaValueInt(i, _)     => V_Int(i)
-      case TAT.MetaValueFloat(f, _)   => V_Float(f)
-      case TAT.MetaValueBoolean(b, _) => V_Boolean(b)
-      case TAT.MetaValueArray(a, _)   => V_Array(a.map(x => applyKv(id, x)))
-      case TAT.MetaValueObject(m, _) =>
+      case TAT.MetaValueNull()     => V_Null
+      case TAT.MetaValueString(s)  => V_String(s)
+      case TAT.MetaValueInt(i)     => V_Int(i)
+      case TAT.MetaValueFloat(f)   => V_Float(f)
+      case TAT.MetaValueBoolean(b) => V_Boolean(b)
+      case TAT.MetaValueArray(a)   => V_Array(a.map(x => applyKv(id, x)))
+      case TAT.MetaValueObject(m) =>
         V_Object(m.map {
           case (k, v) => k -> applyKv(k, v)
         })

--- a/src/main/scala/wdlTools/exec/InputOutput.scala
+++ b/src/main/scala/wdlTools/exec/InputOutput.scala
@@ -32,15 +32,15 @@ object InputOutput {
           case param: RequiredInputParameter if inputValues.contains(param.name) =>
             // ensure the required value is not T_Optional
             WdlValueUtils.unwrapOptional(inputValues(decl.name))
-          case RequiredInputParameter(_, WdlTypes.T_Array(_, false), _) if nullCollectionAsEmpty =>
+          case RequiredInputParameter(_, WdlTypes.T_Array(_, false)) if nullCollectionAsEmpty =>
             // Special handling for required input Arrays that are non-optional but
             // allowed to be empty and do not have a value specified - set the value
             // to the empty array rather than throwing an exception.
             WdlValues.V_Array()
-          case RequiredInputParameter(_, _: WdlTypes.T_Map, _) if nullCollectionAsEmpty =>
+          case RequiredInputParameter(_, _: WdlTypes.T_Map) if nullCollectionAsEmpty =>
             // Special handling for required input Maps that are non-optional
             WdlValues.V_Map()
-          case RequiredInputParameter(_, WdlTypes.T_Object, _) if nullCollectionAsEmpty =>
+          case RequiredInputParameter(_, WdlTypes.T_Object) if nullCollectionAsEmpty =>
             // Special handling for required input Objects that are non-optional
             WdlValues.V_Object()
           case param: RequiredInputParameter =>
@@ -53,7 +53,7 @@ object InputOutput {
             inputValues(param.name)
           case _: OptionalInputParameter =>
             WdlValues.V_Null
-          case OverridableInputParameterWithDefault(name, wdlType, defaultExpr, loc) =>
+          case OverridableInputParameterWithDefault(name, wdlType, defaultExpr) =>
             // An input definition that has a default value supplied.
             // Typical WDL example would be a declaration like: "Int x = 5"
             try {
@@ -69,7 +69,7 @@ object InputOutput {
                 throw new ExecException(
                     s"Could not evaluate default value expression for input parameter ${name}",
                     t,
-                    loc
+                    decl.loc
                 )
             }
         }
@@ -87,9 +87,9 @@ object InputOutput {
     // the output parameter expression using the union of the input
     // and output bindings
     outputParameters.foldLeft(init) {
-      case (outCtx, OutputParameter(name, _, _, _)) if ctx.contains(name) =>
+      case (outCtx, OutputParameter(name, _, _)) if ctx.contains(name) =>
         outCtx.add(name, ctx.bindings(name))
-      case (outCtx, OutputParameter(name, wdlType, expr, _)) =>
+      case (outCtx, OutputParameter(name, wdlType, expr)) =>
         // if the output parameter is optional, then it is okay if the
         // expression fails to evaluate - we set the value to None
         try {

--- a/src/main/scala/wdlTools/exec/TaskContext.scala
+++ b/src/main/scala/wdlTools/exec/TaskContext.scala
@@ -16,8 +16,8 @@ case class TaskContext(task: Task,
                        logger: Logger = Logger.get) {
   private lazy val dockerUtils = DockerUtils(fileResolver, logger)
   private lazy val hasCommand: Boolean = task.command.parts.exists {
-    case ValueString(s, _, _) => s.trim.nonEmpty
-    case _                    => true
+    case ValueString(s, _) => s.trim.nonEmpty
+    case _                 => true
   }
   // The inputs and runtime section are evaluated using the host paths
   // (which will be the same as the guest paths, unless we're running in a container)

--- a/src/main/scala/wdlTools/generators/code/WdlGenerator.scala
+++ b/src/main/scala/wdlTools/generators/code/WdlGenerator.scala
@@ -580,27 +580,27 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
 
     expr match {
       // literal values
-      case ValueNone(_, _)             => Literal(Symbols.None)
-      case ValueString(value, _, _)    => string(value)
-      case ValueFile(value, _, _)      => string(value)
-      case ValueDirectory(value, _, _) => string(value)
-      case ValueBoolean(value, _, _)   => Literal(value)
-      case ValueInt(value, _, _)       => Literal(value)
-      case ValueFloat(value, _, _)     => Literal(value)
-      case ExprArray(value, _, _) =>
+      case ValueNone(_)             => Literal(Symbols.None)
+      case ValueString(value, _)    => string(value)
+      case ValueFile(value, _)      => string(value)
+      case ValueDirectory(value, _) => string(value)
+      case ValueBoolean(value, _)   => Literal(value)
+      case ValueInt(value, _)       => Literal(value)
+      case ValueFloat(value, _)     => Literal(value)
+      case ExprArray(value, _) =>
         Container(
             value.map(nested(_)),
             Some(Symbols.ArrayDelimiter),
             Some(Literal(Symbols.ArrayLiteralOpen), Literal(Symbols.ArrayLiteralClose)),
             wrapping = Wrapping.AllOrNone
         )
-      case ExprPair(left, right, _, _) =>
+      case ExprPair(left, right, _) =>
         Container(
             Vector(nested(left), nested(right)),
             Some(Symbols.ArrayDelimiter),
             Some(Literal(Symbols.GroupOpen), Literal(Symbols.GroupClose))
         )
-      case ExprMap(value, _, _) =>
+      case ExprMap(value, _) =>
         Container(
             value.map {
               case (k, v) => KeyValue(nested(k), nested(v))
@@ -610,7 +610,7 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
             Wrapping.Always,
             continue = false
         )
-      case ExprObject(value, wdlType, _) =>
+      case ExprObject(value, wdlType) =>
         val name = wdlType match {
           case T_Struct(name, _) if targetVersion.exists(_ >= WdlVersion.V2) =>
             name
@@ -621,7 +621,7 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
         }
         Container(
             value.map {
-              case (ValueString(k, _, _), v) =>
+              case (ValueString(k, _), v) =>
                 KeyValue(Literal(k), nested(v))
               case other =>
                 throw new Exception(s"invalid object member ${other}")
@@ -633,7 +633,7 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
             continue = false
         )
       // placeholders
-      case ExprPlaceholder(t, f, sep, default, value, _, _) =>
+      case ExprPlaceholder(t, f, sep, default, value, _) =>
         Placeholder(
             nested(value, inPlaceholder = true),
             placeholderOpen,
@@ -647,13 +647,13 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
             ),
             inString = inString || inCommand
         )
-      case ExprCompoundString(value, _, _) =>
+      case ExprCompoundString(value, _) =>
         // Often/always an ExprCompoundString contains one or more empty
         // ValueStrings that we want to get rid of because they're useless
         // and can mess up formatting
         val filteredExprs = value.filter {
-          case ValueString(s, _, _) => s.nonEmpty
-          case _                    => true
+          case ValueString(s, _) => s.nonEmpty
+          case _                 => true
         }
         CompoundString(filteredExprs.map(nested(_, inString = true)),
                        quoting = !(inString || inCommand))
@@ -661,8 +661,8 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
       // appear in a string or command block
       case other =>
         val sized = other match {
-          case ExprIdentifier(id, _, _) => Literal(id)
-          case ExprAt(array, index, _, _) =>
+          case ExprIdentifier(id, _) => Literal(id)
+          case ExprAt(array, index, _) =>
             val arraySized = nested(array, inPlaceholder = inString || inCommand)
             val prefix = Sequence(
                 Vector(arraySized, Literal(Symbols.IndexOpen))
@@ -673,7 +673,7 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
                 Some(Symbols.ArrayDelimiter),
                 Some(prefix, suffix)
             )
-          case ExprIfThenElse(cond, tBranch, fBranch, _, _) =>
+          case ExprIfThenElse(cond, tBranch, fBranch, _) =>
             val condSized = nested(cond, inOperation = false, inPlaceholder = inString || inCommand)
             val tSized = nested(tBranch, inOperation = false, inPlaceholder = inString || inCommand)
             val fSized = nested(fBranch, inOperation = false, inPlaceholder = inString || inCommand)
@@ -687,7 +687,7 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
                     fSized
                 )
             )
-          case ExprApply(oper, _, Vector(ExprArray(args, _, _)), _, _)
+          case ExprApply(oper, _, Vector(ExprArray(args, _)), _)
               if Operator.Vectorizable.contains(oper) =>
             val symbol = Operator.Vectorizable(oper).symbol
             val operands = args.map(
@@ -700,10 +700,10 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
                       operands,
                       grouped = inOperation && !parentOperation.contains(oper),
                       inString = inString || inCommand)
-          case ExprApply(oper, _, Vector(value), _, _) if Operator.All.contains(oper) =>
+          case ExprApply(oper, _, Vector(value), _) if Operator.All.contains(oper) =>
             val symbol = Operator.All(oper).symbol
             Sequence(Vector(Literal(symbol), nested(value, inOperation = true)))
-          case ExprApply(oper, _, Vector(lhs, rhs), _, _) if Operator.All.contains(oper) =>
+          case ExprApply(oper, _, Vector(lhs, rhs), _) if Operator.All.contains(oper) =>
             val symbol = Operator.All(oper).symbol
             Operation(
                 symbol,
@@ -720,7 +720,7 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
                 grouped = inOperation && !parentOperation.contains(oper),
                 inString = inString || inCommand
             )
-          case ExprApply(funcName, _, elements, _, _) =>
+          case ExprApply(funcName, _, elements, _) =>
             val prefix = Sequence(
                 Vector(Literal(funcName), Literal(Symbols.FunctionCallOpen))
             )
@@ -730,7 +730,7 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
                 Some(Symbols.ArrayDelimiter),
                 Some(prefix, suffix)
             )
-          case ExprGetName(e, id, _, _) =>
+          case ExprGetName(e, id, _) =>
             val exprSized = nested(e, inPlaceholder = inString || inCommand)
             val idLiteral = Literal(id)
             Sequence(
@@ -872,23 +872,23 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
       extends BlockStatement(Symbols.Input) {
     override def body: Option[Statement] =
       Some(Section(inputs.map {
-        case RequiredInputParameter(name, wdlType, _) => DeclarationStatement(name, wdlType)
-        case OverridableInputParameterWithDefault(name, wdlType, defaultExpr, _) =>
+        case RequiredInputParameter(name, wdlType) => DeclarationStatement(name, wdlType)
+        case OverridableInputParameterWithDefault(name, wdlType, defaultExpr) =>
           DeclarationStatement(name, wdlType, Some(defaultExpr))
-        case OptionalInputParameter(name, wdlType, _) => DeclarationStatement(name, wdlType)
+        case OptionalInputParameter(name, wdlType) => DeclarationStatement(name, wdlType)
       }))
   }
 
   private def buildMeta(metaValue: MetaValue): Sized = {
     metaValue match {
       // literal values
-      case MetaValueNull(_) => Literal(Symbols.Null)
-      case MetaValueString(value, _) =>
+      case MetaValueNull() => Literal(Symbols.Null)
+      case MetaValueString(value) =>
         Literal(value, quoting = true)
-      case MetaValueBoolean(value, _) => Literal(value)
-      case MetaValueInt(value, _)     => Literal(value)
-      case MetaValueFloat(value, _)   => Literal(value)
-      case MetaValueArray(value, _) =>
+      case MetaValueBoolean(value) => Literal(value)
+      case MetaValueInt(value)     => Literal(value)
+      case MetaValueFloat(value)   => Literal(value)
+      case MetaValueArray(value) =>
         Container(
             value.map(buildMeta),
             Some(Symbols.ArrayDelimiter),
@@ -896,7 +896,7 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
             wrapping = Wrapping.AllOrNone,
             continue = false
         )
-      case MetaValueObject(value, _) =>
+      case MetaValueObject(value) =>
         Container(
             value.map {
               case (name, value) => KeyValue(Literal(name), buildMeta(value))
@@ -980,7 +980,7 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
   private case class CallInputsStatement(inputs: Map[String, Expr]) extends BaseStatement {
     private val key = Literal(Symbols.Input)
     private val value = inputs.flatMap {
-      case (_, ValueNone(_, _)) if omitNullInputs => None
+      case (_, ValueNone(_)) if omitNullInputs => None
       case (name, expr) =>
         val nameToken = Literal(name)
         val exprSized = buildExpression(expr)
@@ -1102,8 +1102,8 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
     // check whether there is at least one non-whitespace command part
     private def hasCommand: Boolean = {
       command.parts.exists {
-        case ValueString(value, _, _) => value.trim.nonEmpty
-        case _                        => true
+        case ValueString(value, _) => value.trim.nonEmpty
+        case _                     => true
       }
     }
 
@@ -1127,7 +1127,7 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
                           s.isEmpty || s.startsWith(Symbols.Comment)
                       ) && rest.trim.isEmpty && command.parts.size == 1 =>
                     // command block is empty
-                    (v.copy(value = ""), None)
+                    (v.copy(value = "")(v.loc), None)
                   case s if s.startsWith(Symbols.Comment) && rest.trim.isEmpty =>
                     // weird case, like there is a placeholder in the comment -
                     // we don't want to break anything so we'll just format the whole
@@ -1140,16 +1140,16 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
                       case _                                        => (None, rest)
                     }
                     // the first line will be indented, so we need to trim the indent from `rest`
-                    (v.copy(value = trimmedRest), ws)
+                    (v.copy(value = trimmedRest)(v.loc), ws)
                   case s if rest.trim.isEmpty =>
                     // single-line expression
-                    (v.copy(value = s), None)
+                    (v.copy(value = s)(v.loc), None)
                   case s =>
                     // opening line has some real content, so just trim any leading whitespace
                     val ws = leadingWhitespaceRegexp
                       .findFirstMatchIn(rest)
                       .map(m => m.group(1))
-                    (v.copy(value = s"${s}\n${rest}"), ws)
+                    (v.copy(value = s"${s}\n${rest}")(v.loc), ws)
                 }
               case other =>
                 throw new RuntimeException(s"unexpected command part ${other}")
@@ -1160,9 +1160,9 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
 
         def trimLast(last: Expr): Expr = {
           last match {
-            case ValueString(s, wdlType, text) =>
+            case ValueString(s, wdlType) =>
               // If the last part is just the whitespace before the close block, throw it out
-              ValueString(commandEndRegexp.replaceFirstIn(s, ""), wdlType, text)
+              ValueString(commandEndRegexp.replaceFirstIn(s, ""), wdlType)(last.loc)
             case other =>
               other
           }

--- a/src/main/scala/wdlTools/generators/project/TestsGenerator.scala
+++ b/src/main/scala/wdlTools/generators/project/TestsGenerator.scala
@@ -9,19 +9,19 @@ object TestsGenerator {
 
     def getExampleValue(value: Type): JsValue = {
       value match {
-        case _: TypeString      => JsString("foo")
-        case _: TypeFile        => JsObject(Map("url" -> JsString("http://url/of/data/file")))
-        case _: TypeInt         => JsNumber(0)
-        case _: TypeFloat       => JsNumber(1.0)
-        case _: TypeBoolean     => JsBoolean(true)
-        case TypeArray(t, _, _) => JsArray(getExampleValue(t))
-        case TypeMap(k, v, _)   => JsObject(k.toString -> getExampleValue(v))
-        case _: TypeObject      => JsObject("foo" -> JsString("bar"))
-        case TypePair(l, r, _) =>
+        case _: TypeString   => JsString("foo")
+        case _: TypeFile     => JsObject(Map("url" -> JsString("http://url/of/data/file")))
+        case _: TypeInt      => JsNumber(0)
+        case _: TypeFloat    => JsNumber(1.0)
+        case _: TypeBoolean  => JsBoolean(true)
+        case TypeArray(t, _) => JsArray(getExampleValue(t))
+        case TypeMap(k, v)   => JsObject(k.toString -> getExampleValue(v))
+        case _: TypeObject   => JsObject("foo" -> JsString("bar"))
+        case TypePair(l, r) =>
           JsObject("left" -> getExampleValue(l), "right" -> getExampleValue(r))
-        case TypeStruct(_, members, _) =>
+        case TypeStruct(_, members) =>
           JsObject(members.collect {
-            case StructMember(name, dataType, _) if !dataType.isInstanceOf[TypeOptional] =>
+            case StructMember(name, dataType) if !dataType.isInstanceOf[TypeOptional] =>
               name -> getExampleValue(dataType)
           }.toMap)
         case other => throw new Exception(s"Unrecognized type ${other}")
@@ -30,7 +30,7 @@ object TestsGenerator {
 
     def addData(declarations: Vector[Declaration]): JsObject = {
       JsObject(declarations.collect {
-        case Declaration(name, wdlType, expr, _)
+        case Declaration(name, wdlType, expr)
             if expr.isEmpty && !wdlType.isInstanceOf[TypeOptional] && !data.contains(name) =>
           val dataName = s"input_${name}"
           data += (dataName -> getExampleValue(wdlType))

--- a/src/main/scala/wdlTools/syntax/AbstractSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/AbstractSyntax.scala
@@ -12,20 +12,20 @@ object AbstractSyntax {
 
   // type system
   sealed trait Type extends Element
-  case class TypeOptional(t: Type, loc: SourceLocation) extends Type
-  case class TypeArray(t: Type, nonEmpty: Boolean = false, loc: SourceLocation) extends Type
-  case class TypeMap(k: Type, v: Type, loc: SourceLocation) extends Type
-  case class TypePair(l: Type, r: Type, loc: SourceLocation) extends Type
-  case class TypeString(loc: SourceLocation) extends Type
-  case class TypeFile(loc: SourceLocation) extends Type
-  case class TypeDirectory(loc: SourceLocation) extends Type
-  case class TypeBoolean(loc: SourceLocation) extends Type
-  case class TypeInt(loc: SourceLocation) extends Type
-  case class TypeFloat(loc: SourceLocation) extends Type
-  case class TypeIdentifier(id: String, loc: SourceLocation) extends Type
-  case class TypeObject(loc: SourceLocation) extends Type
-  case class StructMember(name: String, wdlType: Type, loc: SourceLocation) extends Element
-  case class TypeStruct(name: String, members: Vector[StructMember], loc: SourceLocation)
+  case class TypeOptional(t: Type)(val loc: SourceLocation) extends Type
+  case class TypeArray(t: Type, nonEmpty: Boolean = false)(val loc: SourceLocation) extends Type
+  case class TypeMap(k: Type, v: Type)(val loc: SourceLocation) extends Type
+  case class TypePair(l: Type, r: Type)(val loc: SourceLocation) extends Type
+  case class TypeString()(val loc: SourceLocation) extends Type
+  case class TypeFile()(val loc: SourceLocation) extends Type
+  case class TypeDirectory()(val loc: SourceLocation) extends Type
+  case class TypeBoolean()(val loc: SourceLocation) extends Type
+  case class TypeInt()(val loc: SourceLocation) extends Type
+  case class TypeFloat()(val loc: SourceLocation) extends Type
+  case class TypeIdentifier(id: String)(val loc: SourceLocation) extends Type
+  case class TypeObject()(val loc: SourceLocation) extends Type
+  case class StructMember(name: String, wdlType: Type)(val loc: SourceLocation) extends Element
+  case class TypeStruct(name: String, members: Vector[StructMember])(val loc: SourceLocation)
       extends Type
       with DocumentElement
 
@@ -34,24 +34,25 @@ object AbstractSyntax {
 
   // values
   sealed trait Value extends Expr
-  case class ValueNone(loc: SourceLocation) extends Value
-  case class ValueString(value: String, loc: SourceLocation) extends Value
-  case class ValueBoolean(value: Boolean, loc: SourceLocation) extends Value
-  case class ValueInt(value: Long, loc: SourceLocation) extends Value
-  case class ValueFloat(value: Double, loc: SourceLocation) extends Value
+  case class ValueNone()(val loc: SourceLocation) extends Value
+  case class ValueString(value: String)(val loc: SourceLocation) extends Value
+  case class ValueBoolean(value: Boolean)(val loc: SourceLocation) extends Value
+  case class ValueInt(value: Long)(val loc: SourceLocation) extends Value
+  case class ValueFloat(value: Double)(val loc: SourceLocation) extends Value
 
-  case class ExprIdentifier(id: String, loc: SourceLocation) extends Expr
+  case class ExprIdentifier(id: String)(val loc: SourceLocation) extends Expr
 
   // represents strings with interpolation.
   // For example:
   //  "some string part ~{ident + ident} some string part after"
-  case class ExprCompoundString(value: Vector[Expr], loc: SourceLocation) extends Expr
-  case class ExprPair(l: Expr, r: Expr, loc: SourceLocation) extends Expr
-  case class ExprArray(value: Vector[Expr], loc: SourceLocation) extends Expr
-  case class ExprMember(key: Expr, value: Expr, loc: SourceLocation) extends Expr
-  case class ExprMap(value: Vector[ExprMember], loc: SourceLocation) extends Expr
-  case class ExprObject(value: Vector[ExprMember], loc: SourceLocation) extends Expr
-  case class ExprStruct(name: String, members: Vector[ExprMember], loc: SourceLocation) extends Expr
+  case class ExprCompoundString(value: Vector[Expr])(val loc: SourceLocation) extends Expr
+  case class ExprPair(l: Expr, r: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprArray(value: Vector[Expr])(val loc: SourceLocation) extends Expr
+  case class ExprMember(key: Expr, value: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprMap(value: Vector[ExprMember])(val loc: SourceLocation) extends Expr
+  case class ExprObject(value: Vector[ExprMember])(val loc: SourceLocation) extends Expr
+  case class ExprStruct(name: String, members: Vector[ExprMember])(val loc: SourceLocation)
+      extends Expr
 
   // These are expressions of kind:
   //
@@ -62,27 +63,27 @@ object AbstractSyntax {
                              f: Option[Expr],
                              sep: Option[Expr],
                              default: Option[Expr],
-                             value: Expr,
-                             loc: SourceLocation)
+                             value: Expr)(val loc: SourceLocation)
       extends Expr
 
   // Access an array element at [index]
-  case class ExprAt(array: Expr, index: Expr, loc: SourceLocation) extends Expr
+  case class ExprAt(array: Expr, index: Expr)(val loc: SourceLocation) extends Expr
 
   // conditional:
   // if (x == 1) then "Sunday" else "Weekday"
-  case class ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr, loc: SourceLocation)
+  case class ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr)(val loc: SourceLocation)
       extends Expr
 
   // Apply a standard library function to arguments. For example:
   //   read_int("4")
-  case class ExprApply(funcName: String, elements: Vector[Expr], loc: SourceLocation) extends Expr
+  case class ExprApply(funcName: String, elements: Vector[Expr])(val loc: SourceLocation)
+      extends Expr
 
   // Access a field in a struct or an object. For example:
   //   Int z = x.a
-  case class ExprGetName(e: Expr, id: String, loc: SourceLocation) extends Expr
+  case class ExprGetName(e: Expr, id: String)(val loc: SourceLocation) extends Expr
 
-  case class Declaration(name: String, wdlType: Type, expr: Option[Expr], loc: SourceLocation)
+  case class Declaration(name: String, wdlType: Type, expr: Option[Expr])(val loc: SourceLocation)
       extends WorkflowElement
 
   // sections
@@ -90,8 +91,8 @@ object AbstractSyntax {
     * and bound declarations that require evaluation cannot be treated as inputs. Thus, the draft-2
     * `InputSection` `SourceLocation` may overlap with other elements.
     */
-  case class InputSection(parameters: Vector[Declaration], loc: SourceLocation) extends Element
-  case class OutputSection(parameters: Vector[Declaration], loc: SourceLocation) extends Element
+  case class InputSection(parameters: Vector[Declaration])(val loc: SourceLocation) extends Element
+  case class OutputSection(parameters: Vector[Declaration])(val loc: SourceLocation) extends Element
 
   // A command can be simple, with just one continuous string:
   //
@@ -106,38 +107,37 @@ object AbstractSyntax {
   //     ls ~{input_file}
   //     echo ~{input_string}
   // >>>
-  case class CommandSection(parts: Vector[Expr], loc: SourceLocation) extends Element
+  case class CommandSection(parts: Vector[Expr])(val loc: SourceLocation) extends Element
 
-  case class RuntimeKV(id: String, expr: Expr, loc: SourceLocation) extends Element
-  case class RuntimeSection(kvs: Vector[RuntimeKV], loc: SourceLocation) extends Element
+  case class RuntimeKV(id: String, expr: Expr)(val loc: SourceLocation) extends Element
+  case class RuntimeSection(kvs: Vector[RuntimeKV])(val loc: SourceLocation) extends Element
 
   // A specialized JSON-like object language for meta values only.
   sealed trait MetaValue extends Element
-  case class MetaValueNull(loc: SourceLocation) extends MetaValue
-  case class MetaValueBoolean(value: Boolean, loc: SourceLocation) extends MetaValue
-  case class MetaValueInt(value: Long, loc: SourceLocation) extends MetaValue
-  case class MetaValueFloat(value: Double, loc: SourceLocation) extends MetaValue
-  case class MetaValueString(value: String, loc: SourceLocation) extends MetaValue
-  case class MetaValueObject(value: Vector[MetaKV], loc: SourceLocation) extends MetaValue
-  case class MetaValueArray(value: Vector[MetaValue], loc: SourceLocation) extends MetaValue
+  case class MetaValueNull()(val loc: SourceLocation) extends MetaValue
+  case class MetaValueBoolean(value: Boolean)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueInt(value: Long)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueFloat(value: Double)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueString(value: String)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueObject(value: Vector[MetaKV])(val loc: SourceLocation) extends MetaValue
+  case class MetaValueArray(value: Vector[MetaValue])(val loc: SourceLocation) extends MetaValue
   // meta section
-  case class MetaKV(id: String, value: MetaValue, loc: SourceLocation) extends Element
-  case class ParameterMetaSection(kvs: Vector[MetaKV], loc: SourceLocation) extends Element
-  case class MetaSection(kvs: Vector[MetaKV], loc: SourceLocation) extends Element
+  case class MetaKV(id: String, value: MetaValue)(val loc: SourceLocation) extends Element
+  case class ParameterMetaSection(kvs: Vector[MetaKV])(val loc: SourceLocation) extends Element
+  case class MetaSection(kvs: Vector[MetaKV])(val loc: SourceLocation) extends Element
   // hints section
-  case class HintsSection(kvs: Vector[MetaKV], loc: SourceLocation) extends Element
+  case class HintsSection(kvs: Vector[MetaKV])(val loc: SourceLocation) extends Element
 
-  case class Version(value: WdlVersion, loc: SourceLocation) extends Element
+  case class Version(value: WdlVersion)(val loc: SourceLocation) extends Element
 
   // import statement with the AST for the referenced document
-  case class ImportAddr(value: String, loc: SourceLocation) extends Element
-  case class ImportName(value: String, loc: SourceLocation) extends Element
-  case class ImportAlias(id1: String, id2: String, loc: SourceLocation) extends Element
+  case class ImportAddr(value: String)(val loc: SourceLocation) extends Element
+  case class ImportName(value: String)(val loc: SourceLocation) extends Element
+  case class ImportAlias(id1: String, id2: String)(val loc: SourceLocation) extends Element
   case class ImportDoc(name: Option[ImportName],
                        aliases: Vector[ImportAlias],
                        addr: ImportAddr,
-                       doc: Option[Document],
-                       loc: SourceLocation)
+                       doc: Option[Document])(val loc: SourceLocation)
       extends DocumentElement
 
   // A task
@@ -149,28 +149,24 @@ object AbstractSyntax {
                   meta: Option[MetaSection],
                   parameterMeta: Option[ParameterMetaSection],
                   runtime: Option[RuntimeSection],
-                  hints: Option[HintsSection],
-                  loc: SourceLocation)
+                  hints: Option[HintsSection])(val loc: SourceLocation)
       extends DocumentElement
 
-  case class CallAlias(name: String, loc: SourceLocation) extends Element
-  case class CallAfter(name: String, loc: SourceLocation) extends Element
-  case class CallInput(name: String, expr: Expr, loc: SourceLocation) extends Element
-  case class CallInputs(value: Vector[CallInput], loc: SourceLocation) extends Element
+  case class CallAlias(name: String)(val loc: SourceLocation) extends Element
+  case class CallAfter(name: String)(val loc: SourceLocation) extends Element
+  case class CallInput(name: String, expr: Expr)(val loc: SourceLocation) extends Element
+  case class CallInputs(value: Vector[CallInput])(val loc: SourceLocation) extends Element
   case class Call(name: String,
                   alias: Option[CallAlias],
                   afters: Vector[CallAfter],
-                  inputs: Option[CallInputs],
-                  loc: SourceLocation)
+                  inputs: Option[CallInputs])(val loc: SourceLocation)
       extends WorkflowElement
 
-  case class Scatter(identifier: String,
-                     expr: Expr,
-                     body: Vector[WorkflowElement],
-                     loc: SourceLocation)
-      extends WorkflowElement
+  case class Scatter(identifier: String, expr: Expr, body: Vector[WorkflowElement])(
+      val loc: SourceLocation
+  ) extends WorkflowElement
 
-  case class Conditional(expr: Expr, body: Vector[WorkflowElement], loc: SourceLocation)
+  case class Conditional(expr: Expr, body: Vector[WorkflowElement])(val loc: SourceLocation)
       extends WorkflowElement
 
   // A workflow
@@ -179,15 +175,13 @@ object AbstractSyntax {
                       output: Option[OutputSection],
                       meta: Option[MetaSection],
                       parameterMeta: Option[ParameterMetaSection],
-                      body: Vector[WorkflowElement],
-                      loc: SourceLocation)
+                      body: Vector[WorkflowElement])(val loc: SourceLocation)
       extends Element
 
   case class Document(source: FileNode,
                       version: Version,
                       elements: Vector[DocumentElement],
                       workflow: Option[Workflow],
-                      loc: SourceLocation,
-                      comments: CommentMap)
+                      comments: CommentMap)(val loc: SourceLocation)
       extends Element
 }

--- a/src/main/scala/wdlTools/syntax/AbstractSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/AbstractSyntax.scala
@@ -46,7 +46,7 @@ object AbstractSyntax {
   // For example:
   //  "some string part ~{ident + ident} some string part after"
   case class ExprCompoundString(value: Vector[Expr])(val loc: SourceLocation) extends Expr
-  case class ExprPair(l: Expr, r: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprPair(left: Expr, right: Expr)(val loc: SourceLocation) extends Expr
   case class ExprArray(value: Vector[Expr])(val loc: SourceLocation) extends Expr
   case class ExprMember(key: Expr, value: Expr)(val loc: SourceLocation) extends Expr
   case class ExprMap(value: Vector[ExprMember])(val loc: SourceLocation) extends Expr
@@ -59,10 +59,10 @@ object AbstractSyntax {
   // ~{true="--yes" false="--no" boolean_value}
   // ~{default="foo" optional_value}
   // ~{sep=", " array_value}
-  case class ExprPlaceholder(t: Option[Expr],
-                             f: Option[Expr],
-                             sep: Option[Expr],
-                             default: Option[Expr],
+  case class ExprPlaceholder(trueOpt: Option[Expr],
+                             falseOpt: Option[Expr],
+                             sepOpt: Option[Expr],
+                             defaultOpt: Option[Expr],
                              value: Expr)(val loc: SourceLocation)
       extends Expr
 
@@ -71,7 +71,7 @@ object AbstractSyntax {
 
   // conditional:
   // if (x == 1) then "Sunday" else "Weekday"
-  case class ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr)(val loc: SourceLocation)
+  case class ExprIfThenElse(cond: Expr, trueExpr: Expr, falseExpr: Expr)(val loc: SourceLocation)
       extends Expr
 
   // Apply a standard library function to arguments. For example:
@@ -81,7 +81,7 @@ object AbstractSyntax {
 
   // Access a field in a struct or an object. For example:
   //   Int z = x.a
-  case class ExprGetName(e: Expr, id: String)(val loc: SourceLocation) extends Expr
+  case class ExprGetName(expr: Expr, id: String)(val loc: SourceLocation) extends Expr
 
   case class Declaration(name: String, wdlType: Type, expr: Option[Expr])(val loc: SourceLocation)
       extends WorkflowElement

--- a/src/main/scala/wdlTools/syntax/SyntaxUtils.scala
+++ b/src/main/scala/wdlTools/syntax/SyntaxUtils.scala
@@ -19,37 +19,37 @@ object SyntaxUtils {
         return callbackValue.get
       }
       innerExpr match {
-        case ValueNone(_)                    => "None"
-        case ValueString(value, _)           => value
-        case ValueBoolean(value: Boolean, _) => value.toString
-        case ValueInt(value, _)              => value.toString
-        case ValueFloat(value, _)            => value.toString
-        case ExprIdentifier(id: String, _)   => id
+        case ValueNone()                  => "None"
+        case ValueString(value)           => value
+        case ValueBoolean(value: Boolean) => value.toString
+        case ValueInt(value)              => value.toString
+        case ValueFloat(value)            => value.toString
+        case ExprIdentifier(id: String)   => id
 
-        case ExprCompoundString(value: Vector[Expr], _) =>
+        case ExprCompoundString(value: Vector[Expr]) =>
           val vec = value.map(x => inner(x)).mkString(", ")
           s"CompoundString(${vec})"
-        case ExprPair(l, r, _) => s"(${inner(l)}, ${inner(r)})"
-        case ExprArray(value: Vector[Expr], _) =>
+        case ExprPair(l, r) => s"(${inner(l)}, ${inner(r)})"
+        case ExprArray(value: Vector[Expr]) =>
           "[" + value.map(x => inner(x)).mkString(", ") + "]"
-        case ExprMember(key, value, _) =>
+        case ExprMember(key, value) =>
           s"${inner(key)} : ${inner(value)}"
-        case ExprMap(value: Vector[ExprMember], _) =>
+        case ExprMap(value: Vector[ExprMember]) =>
           val m = value
             .map(x => inner(x))
             .mkString(", ")
           "{ " + m + " }"
-        case ExprObject(value: Vector[ExprMember], _) =>
+        case ExprObject(value: Vector[ExprMember]) =>
           val m = value
             .map(x => inner(x))
             .mkString(", ")
           s"object {$m}"
-        case ExprStruct(name, members: Vector[ExprMember], _) =>
+        case ExprStruct(name, members: Vector[ExprMember]) =>
           val m = members
             .map(x => inner(x))
             .mkString(", ")
           s"${name} {$m}"
-        case ExprPlaceholder(t, f, sep, default, value, _) =>
+        case ExprPlaceholder(t, f, sep, default, value) =>
           val optStr = Vector(
               t.map(e => s"true=${inner(e)}"),
               f.map(e => s"false=${inner(e)}"),
@@ -59,31 +59,30 @@ object SyntaxUtils {
           s"{${optStr} ${inner(value)}"
 
         // Access an array element at [index]
-        case ExprAt(array: Expr, index: Expr, _) =>
+        case ExprAt(array: Expr, index: Expr) =>
           s"${inner(array)}[${index}]"
 
         // conditional:
         // if (x == 1) then "Sunday" else "Weekday"
-        case ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr, _) =>
+        case ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr) =>
           s"if (${inner(cond)}) then ${inner(tBranch)} else ${inner(fBranch)}"
 
         // Apply a builtin unary operator
-        case ExprApply(funcName: String, Vector(unaryValue), _)
-            if Operator.All.contains(funcName) =>
+        case ExprApply(funcName: String, Vector(unaryValue)) if Operator.All.contains(funcName) =>
           val symbol = Operator.All(funcName).symbol
           s"${symbol}${inner(unaryValue)}"
         // Apply a buildin binary operator
-        case ExprApply(funcName: String, Vector(lhs, rhs), _) if Operator.All.contains(funcName) =>
+        case ExprApply(funcName: String, Vector(lhs, rhs)) if Operator.All.contains(funcName) =>
           val symbol = Operator.All(funcName).symbol
           s"${inner(lhs)} ${symbol} ${inner(rhs)}"
 
         // Apply a standard library function to arguments. For example:
         //   read_int("4")
-        case ExprApply(funcName: String, elements: Vector[Expr], _) =>
+        case ExprApply(funcName: String, elements: Vector[Expr]) =>
           val args = elements.map(x => inner(x)).mkString(", ")
           s"${funcName}(${args})"
 
-        case ExprGetName(e: Expr, id: String, _) =>
+        case ExprGetName(e: Expr, id: String) =>
           s"${inner(e)}.${id}"
       }
     }
@@ -99,14 +98,14 @@ object SyntaxUtils {
       }
     }
     value match {
-      case MetaValueNull(_)                    => "null"
-      case MetaValueString(value, _)           => value
-      case MetaValueBoolean(value: Boolean, _) => value.toString
-      case MetaValueInt(value, _)              => value.toString
-      case MetaValueFloat(value, _)            => value.toString
-      case MetaValueArray(value, _) =>
+      case MetaValueNull()                  => "null"
+      case MetaValueString(value)           => value
+      case MetaValueBoolean(value: Boolean) => value.toString
+      case MetaValueInt(value)              => value.toString
+      case MetaValueFloat(value)            => value.toString
+      case MetaValueArray(value) =>
         "[" + value.map(x => prettyFormatMetaValue(x, callback)).mkString(", ") + "]"
-      case MetaValueObject(value, _) =>
+      case MetaValueObject(value) =>
         val m = value
           .map(x => s"${x.id} : ${prettyFormatMetaValue(x.value, callback)}")
           .mkString(", ")

--- a/src/main/scala/wdlTools/syntax/WdlParser.scala
+++ b/src/main/scala/wdlTools/syntax/WdlParser.scala
@@ -66,7 +66,7 @@ abstract class WdlParser(followImports: Boolean = false,
   case class Walker[T](fileSource: FileNode, start: T) extends DocumentWalker[T] {
     def extractDependencies(document: Document): Map[FileNode, Document] = {
       document.elements.flatMap {
-        case ImportDoc(_, _, addr, doc, _) if doc.isDefined =>
+        case ImportDoc(_, _, addr, doc) if doc.isDefined =>
           Some(FileSourceResolver.get.resolve(addr.value) -> doc.get)
         case _ => None
       }.toMap

--- a/src/main/scala/wdlTools/syntax/draft_2/ConcreteSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/draft_2/ConcreteSyntax.scala
@@ -18,35 +18,35 @@ object ConcreteSyntax {
 
   // type system
   sealed trait Type extends Element
-  case class TypeOptional(t: Type, loc: SourceLocation) extends Type
-  case class TypeArray(t: Type, nonEmpty: Boolean, loc: SourceLocation) extends Type
-  case class TypeMap(k: Type, v: Type, loc: SourceLocation) extends Type
-  case class TypePair(l: Type, r: Type, loc: SourceLocation) extends Type
-  case class TypeString(loc: SourceLocation) extends Type
-  case class TypeFile(loc: SourceLocation) extends Type
-  case class TypeBoolean(loc: SourceLocation) extends Type
-  case class TypeInt(loc: SourceLocation) extends Type
-  case class TypeFloat(loc: SourceLocation) extends Type
-  case class TypeIdentifier(id: String, loc: SourceLocation) extends Type
-  case class TypeObject(loc: SourceLocation) extends Type
+  case class TypeOptional(t: Type)(val loc: SourceLocation) extends Type
+  case class TypeArray(t: Type, nonEmpty: Boolean)(val loc: SourceLocation) extends Type
+  case class TypeMap(k: Type, v: Type)(val loc: SourceLocation) extends Type
+  case class TypePair(l: Type, r: Type)(val loc: SourceLocation) extends Type
+  case class TypeString()(val loc: SourceLocation) extends Type
+  case class TypeFile()(val loc: SourceLocation) extends Type
+  case class TypeBoolean()(val loc: SourceLocation) extends Type
+  case class TypeInt()(val loc: SourceLocation) extends Type
+  case class TypeFloat()(val loc: SourceLocation) extends Type
+  case class TypeIdentifier(id: String)(val loc: SourceLocation) extends Type
+  case class TypeObject()(val loc: SourceLocation) extends Type
 
   // expressions
   sealed trait Expr extends Element
-  case class ExprString(value: String, loc: SourceLocation) extends Expr
-  case class ExprBoolean(value: Boolean, loc: SourceLocation) extends Expr
-  case class ExprInt(value: Long, loc: SourceLocation) extends Expr
-  case class ExprFloat(value: Double, loc: SourceLocation) extends Expr
+  case class ExprString(value: String)(val loc: SourceLocation) extends Expr
+  case class ExprBoolean(value: Boolean)(val loc: SourceLocation) extends Expr
+  case class ExprInt(value: Long)(val loc: SourceLocation) extends Expr
+  case class ExprFloat(value: Double)(val loc: SourceLocation) extends Expr
 
   // represents strings with interpolation.
   // For example:
   //  "some string part ~{ident + ident} some string part after"
-  case class ExprCompoundString(value: Vector[Expr], loc: SourceLocation) extends Expr
-  case class ExprMember(key: Expr, value: Expr, loc: SourceLocation) extends Expr
-  case class ExprMapLiteral(value: Vector[ExprMember], loc: SourceLocation) extends Expr
-  case class ExprObjectLiteral(value: Vector[ExprMember], loc: SourceLocation) extends Expr
-  case class ExprArrayLiteral(value: Vector[Expr], loc: SourceLocation) extends Expr
+  case class ExprCompoundString(value: Vector[Expr])(val loc: SourceLocation) extends Expr
+  case class ExprMember(key: Expr, value: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprMapLiteral(value: Vector[ExprMember])(val loc: SourceLocation) extends Expr
+  case class ExprObjectLiteral(value: Vector[ExprMember])(val loc: SourceLocation) extends Expr
+  case class ExprArrayLiteral(value: Vector[Expr])(val loc: SourceLocation) extends Expr
 
-  case class ExprIdentifier(id: String, loc: SourceLocation) extends Expr
+  case class ExprIdentifier(id: String)(val loc: SourceLocation) extends Expr
 
   // These are full expressions of the same kind
   //
@@ -57,34 +57,34 @@ object ConcreteSyntax {
                              f: Option[Expr],
                              sep: Option[Expr],
                              default: Option[Expr],
-                             value: Expr,
-                             loc: SourceLocation)
+                             value: Expr)(val loc: SourceLocation)
       extends Expr
 
-  case class ExprUnaryPlus(value: Expr, loc: SourceLocation) extends Expr
-  case class ExprUnaryMinus(value: Expr, loc: SourceLocation) extends Expr
-  case class ExprLor(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprLand(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprNegate(value: Expr, loc: SourceLocation) extends Expr
-  case class ExprEqeq(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprLt(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprGte(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprNeq(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprLte(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprGt(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprAdd(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprSub(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprMod(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprMul(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprDivide(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprPair(l: Expr, r: Expr, loc: SourceLocation) extends Expr
-  case class ExprAt(array: Expr, index: Expr, loc: SourceLocation) extends Expr
-  case class ExprApply(funcName: String, elements: Vector[Expr], loc: SourceLocation) extends Expr
-  case class ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr, loc: SourceLocation)
+  case class ExprUnaryPlus(value: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprUnaryMinus(value: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprLor(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprLand(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprNegate(value: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprEqeq(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprLt(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprGte(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprNeq(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprLte(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprGt(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprAdd(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprSub(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprMod(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprMul(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprDivide(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprPair(l: Expr, r: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprAt(array: Expr, index: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprApply(funcName: String, elements: Vector[Expr])(val loc: SourceLocation)
       extends Expr
-  case class ExprGetName(e: Expr, id: String, loc: SourceLocation) extends Expr
+  case class ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr)(val loc: SourceLocation)
+      extends Expr
+  case class ExprGetName(e: Expr, id: String)(val loc: SourceLocation) extends Expr
 
-  case class Declaration(name: String, wdlType: Type, expr: Option[Expr], loc: SourceLocation)
+  case class Declaration(name: String, wdlType: Type, expr: Option[Expr])(val loc: SourceLocation)
       extends WorkflowElement
 
   // sections
@@ -93,8 +93,10 @@ object ConcreteSyntax {
     * and bound declarations that require evaluation cannot be treated as inputs. Thus, the draft-2
     * `InputSection` `SourceLocation` may overlap with other elements.
     */
-  case class InputSection(declarations: Vector[Declaration], loc: SourceLocation) extends Element
-  case class OutputSection(declarations: Vector[Declaration], loc: SourceLocation) extends Element
+  case class InputSection(declarations: Vector[Declaration])(val loc: SourceLocation)
+      extends Element
+  case class OutputSection(declarations: Vector[Declaration])(val loc: SourceLocation)
+      extends Element
 
   // A command can be simple, with just one continuous string:
   //
@@ -109,22 +111,22 @@ object ConcreteSyntax {
   //     ls ~{input_file}
   //     echo ~{input_string}
   // >>>
-  case class CommandSection(parts: Vector[Expr], loc: SourceLocation) extends Element
+  case class CommandSection(parts: Vector[Expr])(val loc: SourceLocation) extends Element
 
-  case class RuntimeKV(id: String, expr: Expr, loc: SourceLocation) extends Element
-  case class RuntimeSection(kvs: Vector[RuntimeKV], loc: SourceLocation) extends Element
+  case class RuntimeKV(id: String, expr: Expr)(val loc: SourceLocation) extends Element
+  case class RuntimeSection(kvs: Vector[RuntimeKV])(val loc: SourceLocation) extends Element
 
   // meta section
-  case class MetaKV(id: String, value: String, loc: SourceLocation) extends Element
-  case class ParameterMetaSection(kvs: Vector[MetaKV], loc: SourceLocation) extends Element
-  case class MetaSection(kvs: Vector[MetaKV], loc: SourceLocation) extends Element
+  case class MetaKV(id: String, value: String)(val loc: SourceLocation) extends Element
+  case class ParameterMetaSection(kvs: Vector[MetaKV])(val loc: SourceLocation) extends Element
+  case class MetaSection(kvs: Vector[MetaKV])(val loc: SourceLocation) extends Element
 
   // imports
-  case class ImportAddr(value: String, loc: SourceLocation) extends Element
-  case class ImportName(value: String, loc: SourceLocation) extends Element
+  case class ImportAddr(value: String)(val loc: SourceLocation) extends Element
+  case class ImportName(value: String)(val loc: SourceLocation) extends Element
 
   // import statement as read from the document
-  case class ImportDoc(name: Option[ImportName], addr: ImportAddr, loc: SourceLocation)
+  case class ImportDoc(name: Option[ImportName], addr: ImportAddr)(val loc: SourceLocation)
       extends DocumentElement
 
   // top level definitions
@@ -135,24 +137,19 @@ object ConcreteSyntax {
                   declarations: Vector[Declaration],
                   meta: Option[MetaSection],
                   parameterMeta: Option[ParameterMetaSection],
-                  runtime: Option[RuntimeSection],
-                  loc: SourceLocation)
+                  runtime: Option[RuntimeSection])(val loc: SourceLocation)
       extends DocumentElement
 
-  case class CallAlias(name: String, loc: SourceLocation) extends Element
-  case class CallInput(name: String, expr: Expr, loc: SourceLocation) extends Element
-  case class CallInputs(value: Vector[CallInput], loc: SourceLocation) extends Element
-  case class Call(name: String,
-                  alias: Option[CallAlias],
-                  inputs: Option[CallInputs],
-                  loc: SourceLocation)
-      extends WorkflowElement
-  case class Scatter(identifier: String,
-                     expr: Expr,
-                     body: Vector[WorkflowElement],
-                     loc: SourceLocation)
-      extends WorkflowElement
-  case class Conditional(expr: Expr, body: Vector[WorkflowElement], loc: SourceLocation)
+  case class CallAlias(name: String)(val loc: SourceLocation) extends Element
+  case class CallInput(name: String, expr: Expr)(val loc: SourceLocation) extends Element
+  case class CallInputs(value: Vector[CallInput])(val loc: SourceLocation) extends Element
+  case class Call(name: String, alias: Option[CallAlias], inputs: Option[CallInputs])(
+      val loc: SourceLocation
+  ) extends WorkflowElement
+  case class Scatter(identifier: String, expr: Expr, body: Vector[WorkflowElement])(
+      val loc: SourceLocation
+  ) extends WorkflowElement
+  case class Conditional(expr: Expr, body: Vector[WorkflowElement])(val loc: SourceLocation)
       extends WorkflowElement
 
   case class Workflow(name: String,
@@ -160,14 +157,12 @@ object ConcreteSyntax {
                       output: Option[OutputSection],
                       meta: Option[MetaSection],
                       parameterMeta: Option[ParameterMetaSection],
-                      body: Vector[WorkflowElement],
-                      loc: SourceLocation)
+                      body: Vector[WorkflowElement])(val loc: SourceLocation)
       extends Element
 
   case class Document(source: FileNode,
                       elements: Vector[DocumentElement],
                       workflow: Option[Workflow],
-                      loc: SourceLocation,
-                      comments: CommentMap)
+                      comments: CommentMap)(val loc: SourceLocation)
       extends Element
 }

--- a/src/main/scala/wdlTools/syntax/draft_2/ConcreteSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/draft_2/ConcreteSyntax.scala
@@ -53,10 +53,10 @@ object ConcreteSyntax {
   // ${true="--yes" false="--no" boolean_value}
   // ${default="foo" optional_value}
   // ${sep=", " array_value}
-  case class ExprPlaceholder(t: Option[Expr],
-                             f: Option[Expr],
-                             sep: Option[Expr],
-                             default: Option[Expr],
+  case class ExprPlaceholder(trueOpt: Option[Expr],
+                             falseOpt: Option[Expr],
+                             sepOpt: Option[Expr],
+                             defaultOpt: Option[Expr],
                              value: Expr)(val loc: SourceLocation)
       extends Expr
 
@@ -82,7 +82,7 @@ object ConcreteSyntax {
       extends Expr
   case class ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr)(val loc: SourceLocation)
       extends Expr
-  case class ExprGetName(e: Expr, id: String)(val loc: SourceLocation) extends Expr
+  case class ExprGetName(expr: Expr, id: String)(val loc: SourceLocation) extends Expr
 
   case class Declaration(name: String, wdlType: Type, expr: Option[Expr])(val loc: SourceLocation)
       extends WorkflowElement

--- a/src/main/scala/wdlTools/syntax/draft_2/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/draft_2/ParseAll.scala
@@ -24,131 +24,135 @@ case class ParseAll(followImports: Boolean = false,
     extends WdlParser(followImports, fileResolver, logger) {
 
   private case class Translator(docSource: FileNode) {
-    def translateType(t: CST.Type): AST.Type = {
-      t match {
-        case CST.TypeOptional(t, srcText) =>
-          AST.TypeOptional(translateType(t), srcText)
-        case CST.TypeArray(t, nonEmpty, srcText) =>
-          AST.TypeArray(translateType(t), nonEmpty, srcText)
-        case CST.TypeMap(k, v, srcText) =>
-          AST.TypeMap(translateType(k), translateType(v), srcText)
-        case CST.TypePair(l, r, srcText) =>
-          AST.TypePair(translateType(l), translateType(r), srcText)
-        case CST.TypeString(srcText)         => AST.TypeString(srcText)
-        case CST.TypeFile(srcText)           => AST.TypeFile(srcText)
-        case CST.TypeBoolean(srcText)        => AST.TypeBoolean(srcText)
-        case CST.TypeInt(srcText)            => AST.TypeInt(srcText)
-        case CST.TypeFloat(srcText)          => AST.TypeFloat(srcText)
-        case CST.TypeIdentifier(id, srcText) => AST.TypeIdentifier(id, srcText)
-        case CST.TypeObject(srcText)         => AST.TypeObject(srcText)
+    def translateType(cstType: CST.Type): AST.Type = {
+      cstType match {
+        case t: CST.TypeOptional =>
+          AST.TypeOptional(translateType(t.t))(t.loc)
+        case t: CST.TypeArray =>
+          AST.TypeArray(translateType(t.t), t.nonEmpty)(t.loc)
+        case t: CST.TypeMap =>
+          AST.TypeMap(translateType(t.k), translateType(t.v))(t.loc)
+        case t: CST.TypePair =>
+          AST.TypePair(translateType(t.l), translateType(t.r))(t.loc)
+        case t: CST.TypeString     => AST.TypeString()(t.loc)
+        case t: CST.TypeFile       => AST.TypeFile()(t.loc)
+        case t: CST.TypeBoolean    => AST.TypeBoolean()(t.loc)
+        case t: CST.TypeInt        => AST.TypeInt()(t.loc)
+        case t: CST.TypeFloat      => AST.TypeFloat()(t.loc)
+        case t: CST.TypeIdentifier => AST.TypeIdentifier(t.id)(t.loc)
+        case t: CST.TypeObject     => AST.TypeObject()(t.loc)
       }
     }
 
-    def translateExpr(e: CST.Expr): AST.Expr = {
-      e match {
+    def translateExpr(cstExpr: CST.Expr): AST.Expr = {
+      cstExpr match {
         // values
-        case CST.ExprString(value, srcText)  => AST.ValueString(value, srcText)
-        case CST.ExprBoolean(value, srcText) => AST.ValueBoolean(value, srcText)
-        case CST.ExprInt(value, srcText)     => AST.ValueInt(value, srcText)
-        case CST.ExprFloat(value, srcText)   => AST.ValueFloat(value, srcText)
+        case e: CST.ExprString  => AST.ValueString(e.value)(e.loc)
+        case e: CST.ExprBoolean => AST.ValueBoolean(e.value)(e.loc)
+        case e: CST.ExprInt     => AST.ValueInt(e.value)(e.loc)
+        case e: CST.ExprFloat   => AST.ValueFloat(e.value)(e.loc)
 
         // compound values
-        case CST.ExprIdentifier(id, srcText) => AST.ExprIdentifier(id, srcText)
-        case CST.ExprCompoundString(vec, srcText) =>
-          AST.ExprCompoundString(vec.map(translateExpr), srcText)
-        case CST.ExprPair(l, r, srcText) =>
-          AST.ExprPair(translateExpr(l), translateExpr(r), srcText)
-        case CST.ExprArrayLiteral(vec, srcText) =>
-          AST.ExprArray(vec.map(translateExpr), srcText)
-        case CST.ExprMapLiteral(m, srcText) =>
-          AST.ExprMap(m.map { item =>
-            AST.ExprMember(translateExpr(item.key), translateExpr(item.value), item.loc)
-          }, srcText)
-        case CST.ExprObjectLiteral(m, srcText) =>
-          AST.ExprObject(m.map { member =>
-            AST.ExprMember(translateExpr(member.key), translateExpr(member.value), member.loc)
-          }, srcText)
+        case e: CST.ExprIdentifier => AST.ExprIdentifier(e.id)(e.loc)
+        case e: CST.ExprCompoundString =>
+          AST.ExprCompoundString(e.value.map(translateExpr))(e.loc)
+        case e: CST.ExprPair =>
+          AST.ExprPair(translateExpr(e.l), translateExpr(e.r))(e.loc)
+        case e: CST.ExprArrayLiteral =>
+          AST.ExprArray(e.value.map(translateExpr))(e.loc)
+        case e: CST.ExprMapLiteral =>
+          AST.ExprMap(e.value.map { item =>
+            AST.ExprMember(translateExpr(item.key), translateExpr(item.value))(item.loc)
+          })(e.loc)
+        case e: CST.ExprObjectLiteral =>
+          AST.ExprObject(e.value.map { member =>
+            AST.ExprMember(translateExpr(member.key), translateExpr(member.value))(member.loc)
+          })(e.loc)
 
         // string place holders
-        case CST.ExprPlaceholder(t, f, sep, default, value, srcText) =>
-          AST.ExprPlaceholder(t.map(translateExpr),
-                              f.map(translateExpr),
-                              sep.map(translateExpr),
-                              default.map(translateExpr),
-                              translateExpr(value),
-                              srcText)
+        case e: CST.ExprPlaceholder =>
+          AST.ExprPlaceholder(e.t.map(translateExpr),
+                              e.f.map(translateExpr),
+                              e.sep.map(translateExpr),
+                              e.default.map(translateExpr),
+                              translateExpr(e.value))(e.loc)
 
         // operators on one argument
-        case CST.ExprUnaryPlus(value, srcText) =>
-          AST.ExprApply(Operator.UnaryPlus.name, Vector(translateExpr(value)), srcText)
-        case CST.ExprUnaryMinus(value, srcText) =>
-          AST.ExprApply(Operator.UnaryMinus.name, Vector(translateExpr(value)), srcText)
-        case CST.ExprNegate(value, srcText) =>
-          AST.ExprApply(Operator.LogicalNot.name, Vector(translateExpr(value)), srcText)
+        case e: CST.ExprUnaryPlus =>
+          AST.ExprApply(Operator.UnaryPlus.name, Vector(translateExpr(e.value)))(e.loc)
+        case e: CST.ExprUnaryMinus =>
+          AST.ExprApply(Operator.UnaryMinus.name, Vector(translateExpr(e.value)))(e.loc)
+        case e: CST.ExprNegate =>
+          AST.ExprApply(Operator.LogicalNot.name, Vector(translateExpr(e.value)))(e.loc)
 
         // operators on two arguments
-        case CST.ExprLor(a, b, srcText) =>
-          AST.ExprApply(Operator.LogicalOr.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        srcText)
-        case CST.ExprLand(a, b, srcText) =>
-          AST.ExprApply(Operator.LogicalAnd.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        srcText)
-        case CST.ExprEqeq(a, b, srcText) =>
-          AST.ExprApply(Operator.Equality.name, Vector(translateExpr(a), translateExpr(b)), srcText)
-        case CST.ExprNeq(a, b, srcText) =>
-          AST.ExprApply(Operator.Inequality.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        srcText)
-        case CST.ExprLt(a, b, srcText) =>
-          AST.ExprApply(Operator.LessThan.name, Vector(translateExpr(a), translateExpr(b)), srcText)
-        case CST.ExprLte(a, b, srcText) =>
+        case e: CST.ExprLor =>
+          AST.ExprApply(Operator.LogicalOr.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprLand =>
+          AST.ExprApply(Operator.LogicalAnd.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprEqeq =>
+          AST.ExprApply(Operator.Equality.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprNeq =>
+          AST.ExprApply(Operator.Inequality.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprLt =>
+          AST.ExprApply(Operator.LessThan.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprLte =>
           AST.ExprApply(Operator.LessThanOrEqual.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        srcText)
-        case CST.ExprGt(a, b, srcText) =>
-          AST.ExprApply(Operator.GreaterThan.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        srcText)
-        case CST.ExprGte(a, b, srcText) =>
+                        Vector(translateExpr(e.a), translateExpr(e.b)))(e.loc)
+        case e: CST.ExprGt =>
+          AST.ExprApply(Operator.GreaterThan.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprGte =>
           AST.ExprApply(Operator.GreaterThanOrEqual.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        srcText)
-        case CST.ExprAdd(a, b, srcText) =>
-          AST.ExprApply(Operator.Addition.name, Vector(translateExpr(a), translateExpr(b)), srcText)
-        case CST.ExprSub(a, b, srcText) =>
-          AST.ExprApply(Operator.Subtraction.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        srcText)
-        case CST.ExprMul(a, b, srcText) =>
+                        Vector(translateExpr(e.a), translateExpr(e.b)))(e.loc)
+        case e: CST.ExprAdd =>
+          AST.ExprApply(Operator.Addition.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprSub =>
+          AST.ExprApply(Operator.Subtraction.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprMul =>
           AST.ExprApply(Operator.Multiplication.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        srcText)
-        case CST.ExprDivide(a, b, srcText) =>
-          AST.ExprApply(Operator.Division.name, Vector(translateExpr(a), translateExpr(b)), srcText)
-        case CST.ExprMod(a, b, srcText) =>
-          AST.ExprApply(Operator.Remainder.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        srcText)
+                        Vector(translateExpr(e.a), translateExpr(e.b)))(e.loc)
+        case e: CST.ExprDivide =>
+          AST.ExprApply(Operator.Division.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprMod =>
+          AST.ExprApply(Operator.Remainder.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
 
         // Access an array element at [index]
-        case CST.ExprAt(array, index, srcText) =>
-          AST.ExprAt(translateExpr(array), translateExpr(index), srcText)
+        case e: CST.ExprAt =>
+          AST.ExprAt(translateExpr(e.array), translateExpr(e.index))(e.loc)
 
-        case CST.ExprIfThenElse(cond, tBranch, fBranch, srcText) =>
-          AST.ExprIfThenElse(translateExpr(cond),
-                             translateExpr(tBranch),
-                             translateExpr(fBranch),
-                             srcText)
-        case CST.ExprApply(funcName, elements, srcText) =>
-          if (Operator.All.contains(funcName)) {
-            throw new SyntaxException(s"${funcName} is reserved and not a valid function name",
-                                      srcText)
+        case e: CST.ExprIfThenElse =>
+          AST.ExprIfThenElse(translateExpr(e.cond),
+                             translateExpr(e.tBranch),
+                             translateExpr(e.fBranch))(e.loc)
+        case e: CST.ExprApply =>
+          if (Operator.All.contains(e.funcName)) {
+            throw new SyntaxException(s"${e.funcName} is reserved and not a valid function name")(
+                e.loc
+            )
           }
-          AST.ExprApply(funcName, elements.map(translateExpr), srcText)
-        case CST.ExprGetName(e, id, srcText) =>
-          AST.ExprGetName(translateExpr(e), id, srcText)
+          AST.ExprApply(e.funcName, e.elements.map(translateExpr))(e.loc)
+        case e: CST.ExprGetName =>
+          AST.ExprGetName(translateExpr(e.e), e.id)(e.loc)
 
         case other =>
           throw new Exception(s"invalid concrete syntax element ${other}")
@@ -160,14 +164,14 @@ case class ParseAll(followImports: Boolean = false,
       kvs
         .foldLeft(TreeSeqMap.empty[String, AST.MetaKV]) {
           case (accu, kv) =>
-            val metaValue = AST.MetaValueString(kv.value, kv.loc)
+            val metaValue = AST.MetaValueString(kv.value)(kv.loc)
             if (accu.contains(kv.id)) {
               logger.warning(
                   s"""duplicate ${sectionName} key ${kv.id}: earlier value ${accu(kv.id)} 
                      |is overridden by later value ${metaValue}""".stripMargin.replaceAll("\n", " ")
               )
             }
-            accu + (kv.id -> AST.MetaKV(kv.id, metaValue, kv.loc))
+            accu + (kv.id -> AST.MetaKV(kv.id, metaValue)(kv.loc))
         }
         .values
         .toVector
@@ -176,36 +180,35 @@ case class ParseAll(followImports: Boolean = false,
     private def translateInputSection(
         inp: CST.InputSection
     ): AST.InputSection = {
-      AST.InputSection(inp.declarations.map(translateDeclaration), inp.loc)
+      AST.InputSection(inp.declarations.map(translateDeclaration))(inp.loc)
     }
 
     private def translateOutputSection(
         output: CST.OutputSection
     ): AST.OutputSection = {
-      AST.OutputSection(output.declarations.map(translateDeclaration), output.loc)
+      AST.OutputSection(output.declarations.map(translateDeclaration))(output.loc)
     }
 
     private def translateCommandSection(
         cs: CST.CommandSection
     ): AST.CommandSection = {
-      AST.CommandSection(cs.parts.map(translateExpr), cs.loc)
+      AST.CommandSection(cs.parts.map(translateExpr))(cs.loc)
     }
 
     private def translateDeclaration(decl: CST.Declaration): AST.Declaration = {
-      AST.Declaration(decl.name,
-                      translateType(decl.wdlType),
-                      decl.expr.map(translateExpr),
-                      decl.loc)
+      AST.Declaration(decl.name, translateType(decl.wdlType), decl.expr.map(translateExpr))(
+          decl.loc
+      )
     }
 
     private def translateMetaSection(meta: CST.MetaSection): AST.MetaSection = {
-      AST.MetaSection(translateMetaKVs(meta.kvs, "meta"), meta.loc)
+      AST.MetaSection(translateMetaKVs(meta.kvs, "meta"))(meta.loc)
     }
 
     private def translateParameterMetaSection(
         paramMeta: CST.ParameterMetaSection
     ): AST.ParameterMetaSection = {
-      AST.ParameterMetaSection(translateMetaKVs(paramMeta.kvs, "parameter_meta"), paramMeta.loc)
+      AST.ParameterMetaSection(translateMetaKVs(paramMeta.kvs, "parameter_meta"))(paramMeta.loc)
     }
 
     private def translateRuntimeSection(
@@ -214,17 +217,18 @@ case class ParseAll(followImports: Boolean = false,
       AST.RuntimeSection(
           runtime.kvs
             .foldLeft(TreeSeqMap.empty[String, AST.RuntimeKV]) {
-              case (accu, CST.RuntimeKV(id, expr, text)) =>
-                val tExpr = translateExpr(expr)
-                if (accu.contains(id)) {
+              case (accu, kv: CST.RuntimeKV) =>
+                val tExpr = translateExpr(kv.expr)
+                if (accu.contains(kv.id)) {
                   logger.warning(
-                      s"duplicate runtime key ${id}: earlier value ${accu(id)} is overridden by later value ${tExpr}"
+                      s"duplicate runtime key ${kv.id}: earlier value ${accu(kv.id)} is overridden by later value ${tExpr}"
                   )
                 }
-                accu + (id -> AST.RuntimeKV(id, tExpr, text))
+                accu + (kv.id -> AST.RuntimeKV(kv.id, tExpr)(kv.loc))
             }
             .values
-            .toVector,
+            .toVector
+      )(
           runtime.loc
       )
     }
@@ -233,31 +237,34 @@ case class ParseAll(followImports: Boolean = false,
         elem: CST.WorkflowElement
     ): AST.WorkflowElement = {
       elem match {
-        case CST.Declaration(name, wdlType, expr, text) =>
-          AST.Declaration(name, translateType(wdlType), expr.map(translateExpr), text)
-
-        case CST.Call(name, alias, inputs, text) =>
-          AST.Call(
-              name,
-              alias.map {
-                case CST.CallAlias(callName, callText) =>
-                  AST.CallAlias(callName, callText)
-              },
-              Vector.empty,
-              inputs.map {
-                case CST.CallInputs(inputsVec, inputsText) =>
-                  AST.CallInputs(inputsVec.map { inp =>
-                    AST.CallInput(inp.name, translateExpr(inp.expr), inp.loc)
-                  }, inputsText)
-              },
-              text
+        case decl: CST.Declaration =>
+          AST.Declaration(decl.name, translateType(decl.wdlType), decl.expr.map(translateExpr))(
+              decl.loc
           )
 
-        case CST.Scatter(identifier, expr, body, text) =>
-          AST.Scatter(identifier, translateExpr(expr), body.map(translateWorkflowElement), text)
+        case call: CST.Call =>
+          AST.Call(
+              call.name,
+              call.alias.map { alias: CST.CallAlias =>
+                AST.CallAlias(alias.name)(alias.loc)
+              },
+              Vector.empty,
+              call.inputs.map { inputs: CST.CallInputs =>
+                AST.CallInputs(inputs.value.map { inp =>
+                  AST.CallInput(inp.name, translateExpr(inp.expr))(inp.loc)
+                })(inputs.loc)
+              }
+          )(call.loc)
 
-        case CST.Conditional(expr, body, text) =>
-          AST.Conditional(translateExpr(expr), body.map(translateWorkflowElement), text)
+        case scatter: CST.Scatter =>
+          AST.Scatter(scatter.identifier,
+                      translateExpr(scatter.expr),
+                      scatter.body.map(translateWorkflowElement))(scatter.loc)
+
+        case cond: CST.Conditional =>
+          AST.Conditional(translateExpr(cond.expr), cond.body.map(translateWorkflowElement))(
+              cond.loc
+          )
       }
     }
 
@@ -268,20 +275,21 @@ case class ParseAll(followImports: Boolean = false,
           wf.output.map(translateOutputSection),
           wf.meta.map(translateMetaSection),
           wf.parameterMeta.map(translateParameterMetaSection),
-          wf.body.map(translateWorkflowElement),
+          wf.body.map(translateWorkflowElement)
+      )(
           wf.loc
       )
     }
 
     private def translateImportDoc(importDoc: CST.ImportDoc,
                                    importedDoc: Option[AST.Document]): AST.ImportDoc = {
-      val addrAbst = AST.ImportAddr(importDoc.addr.value, importDoc.addr.loc)
-      val nameAbst = importDoc.name.map {
-        case CST.ImportName(value, text) => AST.ImportName(value, text)
+      val addrAbst = AST.ImportAddr(importDoc.addr.value)(importDoc.addr.loc)
+      val nameAbst = importDoc.name.map { impName: CST.ImportName =>
+        AST.ImportName(impName.value)(impName.loc)
       }
 
       // Replace the original statement with a new one
-      AST.ImportDoc(nameAbst, Vector.empty, addrAbst, importedDoc, importDoc.loc)
+      AST.ImportDoc(nameAbst, Vector.empty, addrAbst, importedDoc)(importDoc.loc)
     }
 
     private def translateTask(task: CST.Task): AST.Task = {
@@ -294,7 +302,8 @@ case class ParseAll(followImports: Boolean = false,
           task.meta.map(translateMetaSection),
           task.parameterMeta.map(translateParameterMetaSection),
           task.runtime.map(translateRuntimeSection),
-          None,
+          None
+      )(
           task.loc
       )
     }
@@ -319,8 +328,8 @@ case class ParseAll(followImports: Boolean = false,
         case other                     => throw new Exception(s"unrecognized document element ${other}")
       }
       val aWf = doc.workflow.map(translateWorkflow)
-      val version = AST.Version(WdlVersion.Draft_2, SourceLocation.empty)
-      AST.Document(doc.source, version, elems, aWf, doc.loc, doc.comments)
+      val version = AST.Version(WdlVersion.Draft_2)(SourceLocation.empty)
+      AST.Document(doc.source, version, elems, aWf, doc.comments)(doc.loc)
     }
   }
 

--- a/src/main/scala/wdlTools/syntax/draft_2/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/draft_2/ParseAll.scala
@@ -71,10 +71,10 @@ case class ParseAll(followImports: Boolean = false,
 
         // string place holders
         case e: CST.ExprPlaceholder =>
-          AST.ExprPlaceholder(e.t.map(translateExpr),
-                              e.f.map(translateExpr),
-                              e.sep.map(translateExpr),
-                              e.default.map(translateExpr),
+          AST.ExprPlaceholder(e.trueOpt.map(translateExpr),
+                              e.falseOpt.map(translateExpr),
+                              e.sepOpt.map(translateExpr),
+                              e.defaultOpt.map(translateExpr),
                               translateExpr(e.value))(e.loc)
 
         // operators on one argument
@@ -146,13 +146,12 @@ case class ParseAll(followImports: Boolean = false,
                              translateExpr(e.fBranch))(e.loc)
         case e: CST.ExprApply =>
           if (Operator.All.contains(e.funcName)) {
-            throw new SyntaxException(s"${e.funcName} is reserved and not a valid function name")(
-                e.loc
-            )
+            throw new SyntaxException(s"${e.funcName} is reserved and not a valid function name",
+                                      e.loc)
           }
           AST.ExprApply(e.funcName, e.elements.map(translateExpr))(e.loc)
         case e: CST.ExprGetName =>
-          AST.ExprGetName(translateExpr(e.e), e.id)(e.loc)
+          AST.ExprGetName(translateExpr(e.expr), e.id)(e.loc)
 
         case other =>
           throw new Exception(s"invalid concrete syntax element ${other}")

--- a/src/main/scala/wdlTools/syntax/v1/ConcreteSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ConcreteSyntax.scala
@@ -14,39 +14,39 @@ object ConcreteSyntax {
 
   // type system
   sealed trait Type extends Element
-  case class TypeOptional(t: Type, loc: SourceLocation) extends Type
-  case class TypeArray(t: Type, nonEmpty: Boolean, loc: SourceLocation) extends Type
-  case class TypeMap(k: Type, v: Type, loc: SourceLocation) extends Type
-  case class TypePair(l: Type, r: Type, loc: SourceLocation) extends Type
+  case class TypeOptional(t: Type)(val loc: SourceLocation) extends Type
+  case class TypeArray(t: Type, nonEmpty: Boolean)(val loc: SourceLocation) extends Type
+  case class TypeMap(k: Type, v: Type)(val loc: SourceLocation) extends Type
+  case class TypePair(l: Type, r: Type)(val loc: SourceLocation) extends Type
   case class TypeString(loc: SourceLocation) extends Type
   case class TypeFile(loc: SourceLocation) extends Type
   case class TypeBoolean(loc: SourceLocation) extends Type
   case class TypeInt(loc: SourceLocation) extends Type
   case class TypeFloat(loc: SourceLocation) extends Type
-  case class TypeIdentifier(id: String, loc: SourceLocation) extends Type
+  case class TypeIdentifier(id: String)(val loc: SourceLocation) extends Type
   case class TypeObject(loc: SourceLocation) extends Type
-  case class StructMember(name: String, wdlType: Type, loc: SourceLocation) extends Element
-  case class TypeStruct(name: String, members: Vector[StructMember], loc: SourceLocation)
+  case class StructMember(name: String, wdlType: Type)(val loc: SourceLocation) extends Element
+  case class TypeStruct(name: String, members: Vector[StructMember])(val loc: SourceLocation)
       extends Type
       with DocumentElement
 
   // expressions
   sealed trait Expr extends Element
-  case class ExprString(value: String, loc: SourceLocation) extends Expr
-  case class ExprBoolean(value: Boolean, loc: SourceLocation) extends Expr
-  case class ExprInt(value: Long, loc: SourceLocation) extends Expr
-  case class ExprFloat(value: Double, loc: SourceLocation) extends Expr
+  case class ExprString(value: String)(val loc: SourceLocation) extends Expr
+  case class ExprBoolean(value: Boolean)(val loc: SourceLocation) extends Expr
+  case class ExprInt(value: Long)(val loc: SourceLocation) extends Expr
+  case class ExprFloat(value: Double)(val loc: SourceLocation) extends Expr
 
   // represents strings with interpolation.
   // For example:
   //  "some string part ~{ident + ident} some string part after"
-  case class ExprCompoundString(value: Vector[Expr], loc: SourceLocation) extends Expr
-  case class ExprMember(key: Expr, value: Expr, loc: SourceLocation) extends Expr
-  case class ExprMapLiteral(value: Vector[ExprMember], loc: SourceLocation) extends Expr
-  case class ExprObjectLiteral(value: Vector[ExprMember], loc: SourceLocation) extends Expr
-  case class ExprArrayLiteral(value: Vector[Expr], loc: SourceLocation) extends Expr
+  case class ExprCompoundString(value: Vector[Expr])(val loc: SourceLocation) extends Expr
+  case class ExprMember(key: Expr, value: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprMapLiteral(value: Vector[ExprMember])(val loc: SourceLocation) extends Expr
+  case class ExprObjectLiteral(value: Vector[ExprMember])(val loc: SourceLocation) extends Expr
+  case class ExprArrayLiteral(value: Vector[Expr])(val loc: SourceLocation) extends Expr
 
-  case class ExprIdentifier(id: String, loc: SourceLocation) extends Expr
+  case class ExprIdentifier(id: String)(val loc: SourceLocation) extends Expr
 
   // These are full expressions of the same kind
   //
@@ -61,35 +61,38 @@ object ConcreteSyntax {
                              loc: SourceLocation)
       extends Expr
 
-  case class ExprUnaryPlus(value: Expr, loc: SourceLocation) extends Expr
-  case class ExprUnaryMinus(value: Expr, loc: SourceLocation) extends Expr
-  case class ExprLor(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprLand(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprNegate(value: Expr, loc: SourceLocation) extends Expr
-  case class ExprEqeq(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprLt(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprGte(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprNeq(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprLte(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprGt(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprAdd(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprSub(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprMod(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprMul(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprDivide(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprPair(l: Expr, r: Expr, loc: SourceLocation) extends Expr
-  case class ExprAt(array: Expr, index: Expr, loc: SourceLocation) extends Expr
-  case class ExprApply(funcName: String, elements: Vector[Expr], loc: SourceLocation) extends Expr
-  case class ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr, loc: SourceLocation)
+  case class ExprUnaryPlus(value: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprUnaryMinus(value: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprLor(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprLand(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprNegate(value: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprEqeq(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprLt(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprGte(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprNeq(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprLte(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprGt(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprAdd(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprSub(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprMod(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprMul(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprDivide(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprPair(l: Expr, r: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprAt(array: Expr, index: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprApply(funcName: String, elements: Vector[Expr])(val loc: SourceLocation)
       extends Expr
-  case class ExprGetName(e: Expr, id: String, loc: SourceLocation) extends Expr
+  case class ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr)(val loc: SourceLocation)
+      extends Expr
+  case class ExprGetName(e: Expr, id: String)(val loc: SourceLocation) extends Expr
 
-  case class Declaration(name: String, wdlType: Type, expr: Option[Expr], loc: SourceLocation)
+  case class Declaration(name: String, wdlType: Type, expr: Option[Expr])(val loc: SourceLocation)
       extends WorkflowElement
 
   // sections
-  case class InputSection(declarations: Vector[Declaration], loc: SourceLocation) extends Element
-  case class OutputSection(declarations: Vector[Declaration], loc: SourceLocation) extends Element
+  case class InputSection(declarations: Vector[Declaration])(val loc: SourceLocation)
+      extends Element
+  case class OutputSection(declarations: Vector[Declaration])(val loc: SourceLocation)
+      extends Element
 
   // A command can be simple, with just one continuous string:
   //
@@ -104,36 +107,34 @@ object ConcreteSyntax {
   //     ls ~{input_file}
   //     echo ~{input_string}
   // >>>
-  case class CommandSection(parts: Vector[Expr], loc: SourceLocation) extends Element
+  case class CommandSection(parts: Vector[Expr])(val loc: SourceLocation) extends Element
 
-  case class RuntimeKV(id: String, expr: Expr, loc: SourceLocation) extends Element
-  case class RuntimeSection(kvs: Vector[RuntimeKV], loc: SourceLocation) extends Element
+  case class RuntimeKV(id: String, expr: Expr)(val loc: SourceLocation) extends Element
+  case class RuntimeSection(kvs: Vector[RuntimeKV])(val loc: SourceLocation) extends Element
 
   // A specialized JSON-like object language for meta values only.
   sealed trait MetaValue extends Element
   case class MetaValueNull(loc: SourceLocation) extends MetaValue
-  case class MetaValueBoolean(value: Boolean, loc: SourceLocation) extends MetaValue
-  case class MetaValueInt(value: Long, loc: SourceLocation) extends MetaValue
-  case class MetaValueFloat(value: Double, loc: SourceLocation) extends MetaValue
-  case class MetaValueString(value: String, loc: SourceLocation) extends MetaValue
-  case class MetaValueObject(value: Vector[MetaKV], loc: SourceLocation) extends MetaValue
-  case class MetaValueArray(value: Vector[MetaValue], loc: SourceLocation) extends MetaValue
+  case class MetaValueBoolean(value: Boolean)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueInt(value: Long)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueFloat(value: Double)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueString(value: String)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueObject(value: Vector[MetaKV])(val loc: SourceLocation) extends MetaValue
+  case class MetaValueArray(value: Vector[MetaValue])(val loc: SourceLocation) extends MetaValue
   // meta section
-  case class MetaKV(id: String, value: MetaValue, loc: SourceLocation) extends Element
-  case class ParameterMetaSection(kvs: Vector[MetaKV], loc: SourceLocation) extends Element
-  case class MetaSection(kvs: Vector[MetaKV], loc: SourceLocation) extends Element
+  case class MetaKV(id: String, value: MetaValue)(val loc: SourceLocation) extends Element
+  case class ParameterMetaSection(kvs: Vector[MetaKV])(val loc: SourceLocation) extends Element
+  case class MetaSection(kvs: Vector[MetaKV])(val loc: SourceLocation) extends Element
 
   // imports
-  case class ImportAddr(value: String, loc: SourceLocation) extends Element
-  case class ImportName(value: String, loc: SourceLocation) extends Element
-  case class ImportAlias(id1: String, id2: String, loc: SourceLocation) extends Element
+  case class ImportAddr(value: String)(val loc: SourceLocation) extends Element
+  case class ImportName(value: String)(val loc: SourceLocation) extends Element
+  case class ImportAlias(id1: String, id2: String)(val loc: SourceLocation) extends Element
 
   // import statement as read from the document
-  case class ImportDoc(name: Option[ImportName],
-                       aliases: Vector[ImportAlias],
-                       addr: ImportAddr,
-                       loc: SourceLocation)
-      extends DocumentElement
+  case class ImportDoc(name: Option[ImportName], aliases: Vector[ImportAlias], addr: ImportAddr)(
+      val loc: SourceLocation
+  ) extends DocumentElement
 
   // top level definitions
   case class Task(name: String,
@@ -147,20 +148,16 @@ object ConcreteSyntax {
                   loc: SourceLocation)
       extends DocumentElement
 
-  case class CallAlias(name: String, loc: SourceLocation) extends Element
-  case class CallInput(name: String, expr: Expr, loc: SourceLocation) extends Element
-  case class CallInputs(value: Vector[CallInput], loc: SourceLocation) extends Element
-  case class Call(name: String,
-                  alias: Option[CallAlias],
-                  inputs: Option[CallInputs],
-                  loc: SourceLocation)
-      extends WorkflowElement
-  case class Scatter(identifier: String,
-                     expr: Expr,
-                     body: Vector[WorkflowElement],
-                     loc: SourceLocation)
-      extends WorkflowElement
-  case class Conditional(expr: Expr, body: Vector[WorkflowElement], loc: SourceLocation)
+  case class CallAlias(name: String)(val loc: SourceLocation) extends Element
+  case class CallInput(name: String, expr: Expr)(val loc: SourceLocation) extends Element
+  case class CallInputs(value: Vector[CallInput])(val loc: SourceLocation) extends Element
+  case class Call(name: String, alias: Option[CallAlias], inputs: Option[CallInputs])(
+      val loc: SourceLocation
+  ) extends WorkflowElement
+  case class Scatter(identifier: String, expr: Expr, body: Vector[WorkflowElement])(
+      val loc: SourceLocation
+  ) extends WorkflowElement
+  case class Conditional(expr: Expr, body: Vector[WorkflowElement])(val loc: SourceLocation)
       extends WorkflowElement
 
   case class Workflow(name: String,
@@ -172,7 +169,7 @@ object ConcreteSyntax {
                       loc: SourceLocation)
       extends Element
 
-  case class Version(value: WdlVersion = WdlVersion.V1, loc: SourceLocation) extends Element
+  case class Version(value: WdlVersion = WdlVersion.V1)(val loc: SourceLocation) extends Element
   case class Document(source: FileNode,
                       version: Version,
                       elements: Vector[DocumentElement],

--- a/src/main/scala/wdlTools/syntax/v1/ConcreteSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ConcreteSyntax.scala
@@ -53,12 +53,11 @@ object ConcreteSyntax {
   // ${true="--yes" false="--no" boolean_value}
   // ${default="foo" optional_value}
   // ${sep=", " array_value}
-  case class ExprPlaceholder(t: Option[Expr],
-                             f: Option[Expr],
-                             sep: Option[Expr],
-                             default: Option[Expr],
-                             value: Expr,
-                             loc: SourceLocation)
+  case class ExprPlaceholder(trueOpt: Option[Expr],
+                             falseOpt: Option[Expr],
+                             sepOpt: Option[Expr],
+                             defaultOpt: Option[Expr],
+                             value: Expr)(val loc: SourceLocation)
       extends Expr
 
   case class ExprUnaryPlus(value: Expr)(val loc: SourceLocation) extends Expr
@@ -83,7 +82,7 @@ object ConcreteSyntax {
       extends Expr
   case class ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr)(val loc: SourceLocation)
       extends Expr
-  case class ExprGetName(e: Expr, id: String)(val loc: SourceLocation) extends Expr
+  case class ExprGetName(expr: Expr, id: String)(val loc: SourceLocation) extends Expr
 
   case class Declaration(name: String, wdlType: Type, expr: Option[Expr])(val loc: SourceLocation)
       extends WorkflowElement
@@ -144,8 +143,7 @@ object ConcreteSyntax {
                   declarations: Vector[Declaration],
                   meta: Option[MetaSection],
                   parameterMeta: Option[ParameterMetaSection],
-                  runtime: Option[RuntimeSection],
-                  loc: SourceLocation)
+                  runtime: Option[RuntimeSection])(val loc: SourceLocation)
       extends DocumentElement
 
   case class CallAlias(name: String)(val loc: SourceLocation) extends Element
@@ -165,8 +163,7 @@ object ConcreteSyntax {
                       output: Option[OutputSection],
                       meta: Option[MetaSection],
                       parameterMeta: Option[ParameterMetaSection],
-                      body: Vector[WorkflowElement],
-                      loc: SourceLocation)
+                      body: Vector[WorkflowElement])(val loc: SourceLocation)
       extends Element
 
   case class Version(value: WdlVersion = WdlVersion.V1)(val loc: SourceLocation) extends Element
@@ -174,7 +171,6 @@ object ConcreteSyntax {
                       version: Version,
                       elements: Vector[DocumentElement],
                       workflow: Option[Workflow],
-                      loc: SourceLocation,
-                      comments: CommentMap)
+                      comments: CommentMap)(val loc: SourceLocation)
       extends Element
 }

--- a/src/main/scala/wdlTools/syntax/v1/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ParseAll.scala
@@ -16,136 +16,141 @@ case class ParseAll(followImports: Boolean = false,
     extends WdlParser(followImports, fileResolver, logger) {
 
   private case class Translator(docSource: FileNode) {
-    def translateType(t: CST.Type): AST.Type = {
-      t match {
-        case CST.TypeOptional(t, srcText) =>
-          AST.TypeOptional(translateType(t), srcText)
-        case CST.TypeArray(t, nonEmpty, srcText) =>
-          AST.TypeArray(translateType(t), nonEmpty, srcText)
-        case CST.TypeMap(k, v, srcText) =>
-          AST.TypeMap(translateType(k), translateType(v), srcText)
-        case CST.TypePair(l, r, srcText) =>
-          AST.TypePair(translateType(l), translateType(r), srcText)
-        case CST.TypeString(srcText)         => AST.TypeString(srcText)
-        case CST.TypeFile(srcText)           => AST.TypeFile(srcText)
-        case CST.TypeBoolean(srcText)        => AST.TypeBoolean(srcText)
-        case CST.TypeInt(srcText)            => AST.TypeInt(srcText)
-        case CST.TypeFloat(srcText)          => AST.TypeFloat(srcText)
-        case CST.TypeIdentifier(id, srcText) => AST.TypeIdentifier(id, srcText)
-        case CST.TypeObject(srcText)         => AST.TypeObject(srcText)
-        case CST.TypeStruct(name, members, srcText) =>
-          AST.TypeStruct(name, members.map {
-            case CST.StructMember(name, t, text) =>
-              AST.StructMember(name, translateType(t), text)
-          }, srcText)
+    def translateType(cstType: CST.Type): AST.Type = {
+      cstType match {
+        case t: CST.TypeOptional =>
+          AST.TypeOptional(translateType(t.t))(t.loc)
+        case t: CST.TypeArray =>
+          AST.TypeArray(translateType(t.t), t.nonEmpty)(t.loc)
+        case t: CST.TypeMap =>
+          AST.TypeMap(translateType(t.k), translateType(t.v))(t.loc)
+        case t: CST.TypePair =>
+          AST.TypePair(translateType(t.l), translateType(t.r))(t.loc)
+        case t: CST.TypeString     => AST.TypeString()(t.loc)
+        case t: CST.TypeFile       => AST.TypeFile()(t.loc)
+        case t: CST.TypeBoolean    => AST.TypeBoolean()(t.loc)
+        case t: CST.TypeInt        => AST.TypeInt()(t.loc)
+        case t: CST.TypeFloat      => AST.TypeFloat()(t.loc)
+        case t: CST.TypeIdentifier => AST.TypeIdentifier(t.id)(t.loc)
+        case t: CST.TypeObject     => AST.TypeObject()(t.loc)
+        case t: CST.TypeStruct =>
+          AST.TypeStruct(t.name, t.members.map { member: CST.StructMember =>
+            AST.StructMember(member.name, translateType(member.wdlType))(member.loc)
+          })(t.loc)
       }
     }
 
-    def translateExpr(e: CST.Expr): AST.Expr = {
-      e match {
+    def translateExpr(cstExpr: CST.Expr): AST.Expr = {
+      cstExpr match {
         // values
-        case CST.ExprString(value, srcText)  => AST.ValueString(value, srcText)
-        case CST.ExprBoolean(value, srcText) => AST.ValueBoolean(value, srcText)
-        case CST.ExprInt(value, srcText)     => AST.ValueInt(value, srcText)
-        case CST.ExprFloat(value, srcText)   => AST.ValueFloat(value, srcText)
+        case e: CST.ExprString  => AST.ValueString(e.value)(e.loc)
+        case e: CST.ExprBoolean => AST.ValueBoolean(e.value)(e.loc)
+        case e: CST.ExprInt     => AST.ValueInt(e.value)(e.loc)
+        case e: CST.ExprFloat   => AST.ValueFloat(e.value)(e.loc)
 
         // compound values
-        case CST.ExprIdentifier(id, srcText) => AST.ExprIdentifier(id, srcText)
-        case CST.ExprCompoundString(vec, srcText) =>
-          AST.ExprCompoundString(vec.map(translateExpr), srcText)
-        case CST.ExprPair(l, r, srcText) =>
-          AST.ExprPair(translateExpr(l), translateExpr(r), srcText)
-        case CST.ExprArrayLiteral(vec, srcText) =>
-          AST.ExprArray(vec.map(translateExpr), srcText)
-        case CST.ExprMapLiteral(m, srcText) =>
-          AST.ExprMap(m.map { item =>
-            AST.ExprMember(translateExpr(item.key), translateExpr(item.value), item.loc)
-          }, srcText)
-        case CST.ExprObjectLiteral(m, srcText) =>
-          AST.ExprObject(m.map { member =>
-            AST.ExprMember(translateExpr(member.key), translateExpr(member.value), member.loc)
-          }, srcText)
+        case e: CST.ExprIdentifier => AST.ExprIdentifier(e.id)(e.loc)
+        case e: CST.ExprCompoundString =>
+          AST.ExprCompoundString(e.value.map(translateExpr))(e.loc)
+        case e: CST.ExprPair =>
+          AST.ExprPair(translateExpr(e.l), translateExpr(e.r))(e.loc)
+        case e: CST.ExprArrayLiteral =>
+          AST.ExprArray(e.value.map(translateExpr))(e.loc)
+        case e: CST.ExprMapLiteral =>
+          AST.ExprMap(e.value.map { item =>
+            AST.ExprMember(translateExpr(item.key), translateExpr(item.value))(item.loc)
+          })(e.loc)
+        case e: CST.ExprObjectLiteral =>
+          AST.ExprObject(e.value.map { member =>
+            AST.ExprMember(translateExpr(member.key), translateExpr(member.value))(member.loc)
+          })(e.loc)
 
         // string place holders
-        case CST.ExprPlaceholder(t, f, sep, default, value, srcText) =>
-          AST.ExprPlaceholder(t.map(translateExpr),
-                              f.map(translateExpr),
-                              sep.map(translateExpr),
-                              default.map(translateExpr),
-                              translateExpr(value),
-                              srcText)
+        case e: CST.ExprPlaceholder =>
+          AST.ExprPlaceholder(e.t.map(translateExpr),
+                              e.f.map(translateExpr),
+                              e.sep.map(translateExpr),
+                              e.default.map(translateExpr),
+                              translateExpr(e.value))(e.loc)
 
         // operators on one argument
-        case CST.ExprUnaryPlus(value, srcText) =>
-          AST.ExprApply(Operator.UnaryPlus.name, Vector(translateExpr(value)), srcText)
-        case CST.ExprUnaryMinus(value, srcText) =>
-          AST.ExprApply(Operator.UnaryMinus.name, Vector(translateExpr(value)), srcText)
-        case CST.ExprNegate(value, srcText) =>
-          AST.ExprApply(Operator.LogicalNot.name, Vector(translateExpr(value)), srcText)
+        case e: CST.ExprUnaryPlus =>
+          AST.ExprApply(Operator.UnaryPlus.name, Vector(translateExpr(e.value)))(e.loc)
+        case e: CST.ExprUnaryMinus =>
+          AST.ExprApply(Operator.UnaryMinus.name, Vector(translateExpr(e.value)))(e.loc)
+        case e: CST.ExprNegate =>
+          AST.ExprApply(Operator.LogicalNot.name, Vector(translateExpr(e.value)))(e.loc)
 
         // operators on two arguments
-        case CST.ExprLor(a, b, srcText) =>
-          AST.ExprApply(Operator.LogicalOr.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        srcText)
-        case CST.ExprLand(a, b, srcText) =>
-          AST.ExprApply(Operator.LogicalAnd.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        srcText)
-        case CST.ExprEqeq(a, b, srcText) =>
-          AST.ExprApply(Operator.Equality.name, Vector(translateExpr(a), translateExpr(b)), srcText)
-        case CST.ExprNeq(a, b, srcText) =>
-          AST.ExprApply(Operator.Inequality.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        srcText)
-        case CST.ExprLt(a, b, srcText) =>
-          AST.ExprApply(Operator.LessThan.name, Vector(translateExpr(a), translateExpr(b)), srcText)
-        case CST.ExprLte(a, b, srcText) =>
+        case e: CST.ExprLor =>
+          AST.ExprApply(Operator.LogicalOr.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprLand =>
+          AST.ExprApply(Operator.LogicalAnd.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprEqeq =>
+          AST.ExprApply(Operator.Equality.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprNeq =>
+          AST.ExprApply(Operator.Inequality.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprLt =>
+          AST.ExprApply(Operator.LessThan.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprLte =>
           AST.ExprApply(Operator.LessThanOrEqual.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        srcText)
-        case CST.ExprGt(a, b, srcText) =>
-          AST.ExprApply(Operator.GreaterThan.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        srcText)
-        case CST.ExprGte(a, b, srcText) =>
+                        Vector(translateExpr(e.a), translateExpr(e.b)))(e.loc)
+        case e: CST.ExprGt =>
+          AST.ExprApply(Operator.GreaterThan.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprGte =>
           AST.ExprApply(Operator.GreaterThanOrEqual.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        srcText)
-        case CST.ExprAdd(a, b, srcText) =>
-          AST.ExprApply(Operator.Addition.name, Vector(translateExpr(a), translateExpr(b)), srcText)
-        case CST.ExprSub(a, b, srcText) =>
-          AST.ExprApply(Operator.Subtraction.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        srcText)
-        case CST.ExprMul(a, b, srcText) =>
+                        Vector(translateExpr(e.a), translateExpr(e.b)))(e.loc)
+        case e: CST.ExprAdd =>
+          AST.ExprApply(Operator.Addition.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprSub =>
+          AST.ExprApply(Operator.Subtraction.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprMul =>
           AST.ExprApply(Operator.Multiplication.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        srcText)
-        case CST.ExprDivide(a, b, srcText) =>
-          AST.ExprApply(Operator.Division.name, Vector(translateExpr(a), translateExpr(b)), srcText)
-        case CST.ExprMod(a, b, srcText) =>
-          AST.ExprApply(Operator.Remainder.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        srcText)
+                        Vector(translateExpr(e.a), translateExpr(e.b)))(e.loc)
+        case e: CST.ExprDivide =>
+          AST.ExprApply(Operator.Division.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprMod =>
+          AST.ExprApply(Operator.Remainder.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
 
         // Access an array element at [index]
-        case CST.ExprAt(array, index, srcText) =>
-          AST.ExprAt(translateExpr(array), translateExpr(index), srcText)
+        case e: CST.ExprAt =>
+          AST.ExprAt(translateExpr(e.array), translateExpr(e.index))(e.loc)
 
-        case CST.ExprIfThenElse(cond, tBranch, fBranch, srcText) =>
-          AST.ExprIfThenElse(translateExpr(cond),
-                             translateExpr(tBranch),
-                             translateExpr(fBranch),
-                             srcText)
-        case CST.ExprApply(funcName, elements, srcText) =>
-          if (Operator.All.contains(funcName)) {
-            throw new SyntaxException(s"${funcName} is reserved and not a valid function name",
-                                      srcText)
+        case e: CST.ExprIfThenElse =>
+          AST.ExprIfThenElse(translateExpr(e.cond),
+                             translateExpr(e.tBranch),
+                             translateExpr(e.fBranch))(
+              e.loc
+          )
+        case e: CST.ExprApply =>
+          if (Operator.All.contains(e.funcName)) {
+            throw new SyntaxException(s"${e.funcName} is reserved and not a valid function name")(
+                e.loc
+            )
           }
-          AST.ExprApply(funcName, elements.map(translateExpr), srcText)
-        case CST.ExprGetName(e, id, srcText) =>
-          AST.ExprGetName(translateExpr(e), id, srcText)
+          AST.ExprApply(e.funcName, e.elements.map(translateExpr))(e.loc)
+        case e: CST.ExprGetName =>
+          AST.ExprGetName(translateExpr(e), e.id)(e.loc)
 
         case other =>
           throw new Exception(s"invalid concrete syntax element ${other}")
@@ -161,18 +166,17 @@ case class ParseAll(followImports: Boolean = false,
     private def translateMetaValue(value: CST.MetaValue): AST.MetaValue = {
       value match {
         // values
-        case CST.MetaValueString(value, srcText)  => AST.MetaValueString(value, srcText)
-        case CST.MetaValueBoolean(value, srcText) => AST.MetaValueBoolean(value, srcText)
-        case CST.MetaValueInt(value, srcText)     => AST.MetaValueInt(value, srcText)
-        case CST.MetaValueFloat(value, srcText)   => AST.MetaValueFloat(value, srcText)
-        case CST.MetaValueNull(srcText)           => AST.MetaValueNull(srcText)
-        case CST.MetaValueArray(vec, srcText) =>
-          AST.MetaValueArray(vec.map(translateMetaValue), srcText)
-        case CST.MetaValueObject(m, srcText) =>
-          AST.MetaValueObject(m.map {
-            case CST.MetaKV(fieldName, v, text) =>
-              AST.MetaKV(fieldName, translateMetaValue(v), text)
-          }, srcText)
+        case v: CST.MetaValueString  => AST.MetaValueString(v.value)(v.loc)
+        case v: CST.MetaValueBoolean => AST.MetaValueBoolean(v.value)(v.loc)
+        case v: CST.MetaValueInt     => AST.MetaValueInt(v.value)(v.loc)
+        case v: CST.MetaValueFloat   => AST.MetaValueFloat(v.value)(v.loc)
+        case v: CST.MetaValueNull    => AST.MetaValueNull()(v.loc)
+        case v: CST.MetaValueArray =>
+          AST.MetaValueArray(v.value.map(translateMetaValue))(v.loc)
+        case v: CST.MetaValueObject =>
+          AST.MetaValueObject(v.value.map { kv: CST.MetaKV =>
+            AST.MetaKV(kv.id, translateMetaValue(kv.value))(kv.loc)
+          })(v.loc)
         case other =>
           throw new SyntaxException("illegal expression in meta section", other.loc)
       }
@@ -190,7 +194,7 @@ case class ParseAll(followImports: Boolean = false,
                      |is overridden by later value ${metaValue}""".stripMargin.replaceAll("\n", " ")
               )
             }
-            accu + (kv.id -> AST.MetaKV(kv.id, metaValue, kv.loc))
+            accu + (kv.id -> AST.MetaKV(kv.id, metaValue)(kv.loc))
         }
         .values
         .toVector
@@ -199,36 +203,35 @@ case class ParseAll(followImports: Boolean = false,
     def translateInputSection(
         inp: CST.InputSection
     ): AST.InputSection = {
-      AST.InputSection(inp.declarations.map(translateDeclaration), inp.loc)
+      AST.InputSection(inp.declarations.map(translateDeclaration))(inp.loc)
     }
 
     def translateOutputSection(
         output: CST.OutputSection
     ): AST.OutputSection = {
-      AST.OutputSection(output.declarations.map(translateDeclaration), output.loc)
+      AST.OutputSection(output.declarations.map(translateDeclaration))(output.loc)
     }
 
     def translateCommandSection(
         cs: CST.CommandSection
     ): AST.CommandSection = {
-      AST.CommandSection(cs.parts.map(translateExpr), cs.loc)
+      AST.CommandSection(cs.parts.map(translateExpr))(cs.loc)
     }
 
     def translateDeclaration(decl: CST.Declaration): AST.Declaration = {
-      AST.Declaration(decl.name,
-                      translateType(decl.wdlType),
-                      decl.expr.map(translateExpr),
-                      decl.loc)
+      AST.Declaration(decl.name, translateType(decl.wdlType), decl.expr.map(translateExpr))(
+          decl.loc
+      )
     }
 
     def translateMetaSection(meta: CST.MetaSection): AST.MetaSection = {
-      AST.MetaSection(translateMetaKVs(meta.kvs, "meta"), meta.loc)
+      AST.MetaSection(translateMetaKVs(meta.kvs, "meta"))(meta.loc)
     }
 
     def translateParameterMetaSection(
         paramMeta: CST.ParameterMetaSection
     ): AST.ParameterMetaSection = {
-      AST.ParameterMetaSection(translateMetaKVs(paramMeta.kvs, "parameter_meta"), paramMeta.loc)
+      AST.ParameterMetaSection(translateMetaKVs(paramMeta.kvs, "parameter_meta"))(paramMeta.loc)
     }
 
     def translateRuntimeSection(
@@ -237,17 +240,18 @@ case class ParseAll(followImports: Boolean = false,
       AST.RuntimeSection(
           runtime.kvs
             .foldLeft(TreeSeqMap.empty[String, AST.RuntimeKV]) {
-              case (accu, CST.RuntimeKV(id, expr, text)) =>
-                val tExpr = translateExpr(expr)
-                if (accu.contains(id)) {
+              case (accu, kv: CST.RuntimeKV) =>
+                val tExpr = translateExpr(kv.expr)
+                if (accu.contains(kv.id)) {
                   logger.warning(
-                      s"duplicate runtime key ${id}: earlier value ${accu(id)} is overridden by later value ${tExpr}"
+                      s"duplicate runtime key ${kv.id}: earlier value ${accu(kv.id)} is overridden by later value ${tExpr}"
                   )
                 }
-                accu + (id -> AST.RuntimeKV(id, tExpr, text))
+                accu + (kv.id -> AST.RuntimeKV(kv.id, tExpr)(kv.loc))
             }
             .values
-            .toVector,
+            .toVector
+      )(
           runtime.loc
       )
     }
@@ -256,31 +260,34 @@ case class ParseAll(followImports: Boolean = false,
         elem: CST.WorkflowElement
     ): AST.WorkflowElement = {
       elem match {
-        case CST.Declaration(name, wdlType, expr, text) =>
-          AST.Declaration(name, translateType(wdlType), expr.map(translateExpr), text)
-
-        case CST.Call(name, alias, inputs, text) =>
-          AST.Call(
-              name,
-              alias.map {
-                case CST.CallAlias(callName, callText) =>
-                  AST.CallAlias(callName, callText)
-              },
-              Vector.empty,
-              inputs.map {
-                case CST.CallInputs(inputsMap, inputsText) =>
-                  AST.CallInputs(inputsMap.map { inp =>
-                    AST.CallInput(inp.name, translateExpr(inp.expr), inp.loc)
-                  }, inputsText)
-              },
-              text
+        case decl: CST.Declaration =>
+          AST.Declaration(decl.name, translateType(decl.wdlType), decl.expr.map(translateExpr))(
+              decl.loc
           )
 
-        case CST.Scatter(identifier, expr, body, text) =>
-          AST.Scatter(identifier, translateExpr(expr), body.map(translateWorkflowElement), text)
+        case call: CST.Call =>
+          AST.Call(
+              call.name,
+              call.alias.map { alias: CST.CallAlias =>
+                AST.CallAlias(alias.name)(alias.loc)
+              },
+              Vector.empty,
+              call.inputs.map { inputs: CST.CallInputs =>
+                AST.CallInputs(inputs.value.map { inp =>
+                  AST.CallInput(inp.name, translateExpr(inp.expr))(inp.loc)
+                })(inputs.loc)
+              }
+          )(call.loc)
 
-        case CST.Conditional(expr, body, text) =>
-          AST.Conditional(translateExpr(expr), body.map(translateWorkflowElement), text)
+        case scatter: CST.Scatter =>
+          AST.Scatter(scatter.identifier,
+                      translateExpr(scatter.expr),
+                      scatter.body.map(translateWorkflowElement))(scatter.loc)
+
+        case cond: CST.Conditional =>
+          AST.Conditional(translateExpr(cond.expr), cond.body.map(translateWorkflowElement))(
+              cond.loc
+          )
       }
     }
 
@@ -291,34 +298,33 @@ case class ParseAll(followImports: Boolean = false,
           wf.output.map(translateOutputSection),
           wf.meta.map(translateMetaSection),
           wf.parameterMeta.map(translateParameterMetaSection),
-          wf.body.map(translateWorkflowElement),
+          wf.body.map(translateWorkflowElement)
+      )(
           wf.loc
       )
     }
 
     def translateStruct(struct: CST.TypeStruct): AST.TypeStruct = {
-      AST.TypeStruct(
-          struct.name,
-          struct.members.map {
-            case CST.StructMember(name, t, memberText) =>
-              AST.StructMember(name, translateType(t), memberText)
-          },
+      AST.TypeStruct(struct.name, struct.members.map { member: CST.StructMember =>
+        AST.StructMember(member.name, translateType(member.wdlType))(member.loc)
+      })(
           struct.loc
       )
     }
 
     def translateImportDoc(importDoc: CST.ImportDoc,
                            importedDoc: Option[AST.Document]): AST.ImportDoc = {
-      val addrAbst = AST.ImportAddr(importDoc.addr.value, importDoc.loc)
-      val nameAbst = importDoc.name.map {
-        case CST.ImportName(value, text) => AST.ImportName(value, text)
+      val addrAbst = AST.ImportAddr(importDoc.addr.value)(importDoc.loc)
+      val nameAbst = importDoc.name.map { impName: CST.ImportName =>
+        AST.ImportName(impName.value)(impName.loc)
       }
       val aliasesAbst: Vector[AST.ImportAlias] = importDoc.aliases.map {
-        case CST.ImportAlias(x, y, alText) => AST.ImportAlias(x, y, alText)
+        impAlias: CST.ImportAlias =>
+          AST.ImportAlias(impAlias.id1, impAlias.id2)(impAlias.loc)
       }
 
       // Replace the original statement with a new one
-      AST.ImportDoc(nameAbst, aliasesAbst, addrAbst, importedDoc, importDoc.loc)
+      AST.ImportDoc(nameAbst, aliasesAbst, addrAbst, importedDoc)(importDoc.loc)
     }
 
     def translateTask(task: CST.Task): AST.Task = {
@@ -331,7 +337,8 @@ case class ParseAll(followImports: Boolean = false,
           task.meta.map(translateMetaSection),
           task.parameterMeta.map(translateParameterMetaSection),
           task.runtime.map(translateRuntimeSection),
-          None,
+          None
+      )(
           task.loc
       )
     }
@@ -357,8 +364,8 @@ case class ParseAll(followImports: Boolean = false,
         case other                     => throw new Exception(s"unrecognized document element ${other}")
       }
       val aWf = doc.workflow.map(translateWorkflow)
-      val version = AST.Version(doc.version.value, doc.version.loc)
-      AST.Document(doc.source, version, elems, aWf, doc.loc, doc.comments)
+      val version = AST.Version(doc.version.value)(doc.version.loc)
+      AST.Document(doc.source, version, elems, aWf, doc.comments)(doc.loc)
     }
   }
 

--- a/src/main/scala/wdlTools/syntax/v1/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ParseAll.scala
@@ -67,10 +67,10 @@ case class ParseAll(followImports: Boolean = false,
 
         // string place holders
         case e: CST.ExprPlaceholder =>
-          AST.ExprPlaceholder(e.t.map(translateExpr),
-                              e.f.map(translateExpr),
-                              e.sep.map(translateExpr),
-                              e.default.map(translateExpr),
+          AST.ExprPlaceholder(e.trueOpt.map(translateExpr),
+                              e.falseOpt.map(translateExpr),
+                              e.sepOpt.map(translateExpr),
+                              e.defaultOpt.map(translateExpr),
                               translateExpr(e.value))(e.loc)
 
         // operators on one argument
@@ -144,13 +144,12 @@ case class ParseAll(followImports: Boolean = false,
           )
         case e: CST.ExprApply =>
           if (Operator.All.contains(e.funcName)) {
-            throw new SyntaxException(s"${e.funcName} is reserved and not a valid function name")(
-                e.loc
-            )
+            throw new SyntaxException(s"${e.funcName} is reserved and not a valid function name",
+                                      e.loc)
           }
           AST.ExprApply(e.funcName, e.elements.map(translateExpr))(e.loc)
         case e: CST.ExprGetName =>
-          AST.ExprGetName(translateExpr(e), e.id)(e.loc)
+          AST.ExprGetName(translateExpr(e.expr), e.id)(e.loc)
 
         case other =>
           throw new Exception(s"invalid concrete syntax element ${other}")

--- a/src/main/scala/wdlTools/syntax/v1/ParseTop.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ParseTop.scala
@@ -88,27 +88,29 @@ type_base
 	;
    */
   override def visitType_base(ctx: WdlV1Parser.Type_baseContext): Type = {
-    if (ctx.array_type() != null)
-      return visitArray_type(ctx.array_type())
-    if (ctx.map_type() != null)
-      return visitMap_type(ctx.map_type())
-    if (ctx.pair_type() != null)
-      return visitPair_type(ctx.pair_type())
-    if (ctx.STRING() != null)
-      return TypeString(getSourceLocation(grammar.docSource, ctx))
-    if (ctx.FILE() != null)
-      return TypeFile(getSourceLocation(grammar.docSource, ctx))
-    if (ctx.BOOLEAN() != null)
-      return TypeBoolean(getSourceLocation(grammar.docSource, ctx))
-    if (ctx.OBJECT() != null)
-      return TypeObject(getSourceLocation(grammar.docSource, ctx))
-    if (ctx.INT() != null)
-      return TypeInt(getSourceLocation(grammar.docSource, ctx))
-    if (ctx.FLOAT() != null)
-      return TypeFloat(getSourceLocation(grammar.docSource, ctx))
-    if (ctx.Identifier() != null)
-      return TypeIdentifier(ctx.getText)(getSourceLocation(grammar.docSource, ctx))
-    throw new SyntaxException("unrecgonized type")(getSourceLocation(grammar.docSource, ctx))
+    if (ctx.array_type() != null) {
+      visitArray_type(ctx.array_type())
+    } else if (ctx.map_type() != null) {
+      visitMap_type(ctx.map_type())
+    } else if (ctx.pair_type() != null) {
+      visitPair_type(ctx.pair_type())
+    } else if (ctx.STRING() != null) {
+      TypeString(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.FILE() != null) {
+      TypeFile(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.BOOLEAN() != null) {
+      TypeBoolean(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.OBJECT() != null) {
+      TypeObject(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.INT() != null) {
+      TypeInt(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.FLOAT() != null) {
+      TypeFloat(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.Identifier() != null) {
+      TypeIdentifier(ctx.getText)(getSourceLocation(grammar.docSource, ctx))
+    } else {
+      throw new SyntaxException("unrecgonized type", getSourceLocation(grammar.docSource, ctx))
+    }
   }
 
   /*
@@ -117,8 +119,9 @@ wdl_type
   ;
    */
   override def visitWdl_type(ctx: WdlV1Parser.Wdl_typeContext): Type = {
-    if (ctx.type_base == null)
-      throw new SyntaxException("bad type")(getSourceLocation(grammar.docSource, ctx))
+    if (ctx.type_base == null) {
+      throw new SyntaxException("missing type", getSourceLocation(grammar.docSource, ctx))
+    }
     val t = visitType_base(ctx.type_base())
     if (ctx.OPTIONAL() != null) {
       TypeOptional(t)(getSourceLocation(grammar.docSource, ctx))
@@ -131,13 +134,13 @@ wdl_type
 
   override def visitNumber(ctx: WdlV1Parser.NumberContext): Expr = {
     if (ctx.IntLiteral() != null) {
-      return ExprInt(ctx.getText.toLong)(getSourceLocation(grammar.docSource, ctx))
+      ExprInt(ctx.getText.toLong)(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.FloatLiteral() != null) {
+      ExprFloat(ctx.getText.toDouble)(getSourceLocation(grammar.docSource, ctx))
+    } else {
+      throw new SyntaxException(s"unrecognized number ${ctx.getText}",
+                                getSourceLocation(grammar.docSource, ctx))
     }
-    if (ctx.FloatLiteral() != null) {
-      return ExprFloat(ctx.getText.toDouble)(getSourceLocation(grammar.docSource, ctx))
-    }
-    throw new SyntaxException(s"Not an integer nor a float ${ctx.getText}",
-                              getSourceLocation(grammar.docSource, ctx))
   }
 
   private def visitEscapse_sequence(terminalNode: TerminalNode): String = {
@@ -169,7 +172,7 @@ wdl_type
           getSourceLocation(grammar.docSource, ctx)
       )
     } else {
-      throw new SyntaxException(s"invalid string_part ${ctx}",
+      throw new SyntaxException(s"unrecognized string_part ${ctx}",
                                 getSourceLocation(grammar.docSource, ctx))
     }
   }
@@ -235,7 +238,7 @@ wdl_type
     } else if (ctx.SEP() != null) {
       ("sep", expr)
     } else {
-      throw new SyntaxException(s"Not one of three known variants of a placeholder",
+      throw new SyntaxException(s"unrecognized placeholder",
                                 getSourceLocation(grammar.docSource, ctx))
     }
   }
@@ -256,19 +259,17 @@ wdl_type
       expr
     } else {
       val loc = getSourceLocation(grammar.docSource, ctx)
-      val placeholder = ExprPlaceholder(
-          options.get("true"),
-          options.get("false"),
-          options.get("sep"),
-          options.get("default"),
-          expr,
-          loc
-      )
+      val placeholder = ExprPlaceholder(options.get("true"),
+                                        options.get("false"),
+                                        options.get("sep"),
+                                        options.get("default"),
+                                        expr)(loc)
       // according to the spec, only one of true/false, sep, or default is allowed; however,
       // some "industry standard" workflows are not spec compliant and mix default with either
       // sep or true/false, so we are compelled to allow it
-      if (placeholder.t.isDefined != placeholder.f.isDefined || placeholder.t.isDefined && placeholder.sep.isDefined) {
-        throw new SyntaxException("invalid place holder")(getSourceLocation(grammar.docSource, ctx))
+      if (placeholder.trueOpt.isDefined != placeholder.falseOpt.isDefined ||
+          (placeholder.trueOpt.isDefined && placeholder.sepOpt.isDefined)) {
+        throw new SyntaxException("invalid place holder", getSourceLocation(grammar.docSource, ctx))
       }
       placeholder
     }
@@ -337,19 +338,17 @@ string
   override def visitPrimitive_literal(ctx: WdlV1Parser.Primitive_literalContext): Expr = {
     if (ctx.BoolLiteral() != null) {
       val value = ctx.getText.toLowerCase() == "true"
-      return ExprBoolean(value)(getSourceLocation(grammar.docSource, ctx))
+      ExprBoolean(value)(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.number() != null) {
+      visitNumber(ctx.number())
+    } else if (ctx.string() != null) {
+      visitString(ctx.string())
+    } else if (ctx.Identifier() != null) {
+      ExprIdentifier(ctx.getText)(getSourceLocation(grammar.docSource, ctx))
+    } else {
+      throw new SyntaxException("unrecognized primitive_literal",
+                                getSourceLocation(grammar.docSource, ctx))
     }
-    if (ctx.number() != null) {
-      return visitNumber(ctx.number())
-    }
-    if (ctx.string() != null) {
-      return visitString(ctx.string())
-    }
-    if (ctx.Identifier() != null) {
-      return ExprIdentifier(ctx.getText)(getSourceLocation(grammar.docSource, ctx))
-    }
-    throw new SyntaxException("Not one of four supported variants of primitive_literal",
-                              getSourceLocation(grammar.docSource, ctx))
   }
 
   override def visitLor(ctx: WdlV1Parser.LorContext): Expr = {
@@ -369,6 +368,7 @@ string
     val arg1 = visitExpr_infix3(ctx.expr_infix3())
     ExprEqeq(arg0, arg1)(getSourceLocation(grammar.docSource, ctx))
   }
+
   override def visitLt(ctx: WdlV1Parser.LtContext): Expr = {
     val arg0 = visitExpr_infix2(ctx.expr_infix2())
     val arg1 = visitExpr_infix3(ctx.expr_infix3())
@@ -460,9 +460,10 @@ string
       .toVector
 
     val n = elements.size
-    if (n % 2 != 0)
+    if (n % 2 != 0) {
       throw new SyntaxException("the expressions in a map must come in pairs",
                                 getSourceLocation(grammar.docSource, ctx))
+    }
 
     val m: Vector[ExprMember] = Vector.tabulate(n / 2) { i =>
       val key = elements(2 * i)
@@ -520,7 +521,7 @@ string
     else if (ctx.MINUS() != null)
       ExprUnaryMinus(expr)(getSourceLocation(grammar.docSource, ctx))
     else
-      throw new SyntaxException("bad unary expression")(getSourceLocation(grammar.docSource, ctx))
+      throw new SyntaxException("bad unary expression", getSourceLocation(grammar.docSource, ctx))
   }
 
   // | expr_core LBRACK expr RBRACK #at
@@ -656,7 +657,7 @@ string
       visitChildren(ctx).asInstanceOf[Expr]
     } catch {
       case _: NullPointerException =>
-        throw new SyntaxException("bad expression")(getSourceLocation(grammar.docSource, ctx))
+        throw new SyntaxException("bad expression", getSourceLocation(grammar.docSource, ctx))
     }
   }
 
@@ -692,7 +693,7 @@ string
       case left_name: WdlV1Parser.Left_nameContext         => visitLeft_name(left_name)
       case get_name: WdlV1Parser.Get_nameContext           => visitGet_name(get_name)
       case _ =>
-        throw new SyntaxException("bad expression")(getSourceLocation(grammar.docSource, ctx))
+        throw new SyntaxException("bad expression", getSourceLocation(grammar.docSource, ctx))
     }
   }
 
@@ -703,8 +704,7 @@ unbound_decls
    */
   override def visitUnbound_decls(ctx: WdlV1Parser.Unbound_declsContext): Declaration = {
     if (ctx.wdl_type() == null) {
-      throw new SyntaxException("type missing in declaration",
-                                getSourceLocation(grammar.docSource, ctx))
+      throw new SyntaxException("missing type", getSourceLocation(grammar.docSource, ctx))
     }
     val wdlType: Type = visitWdl_type(ctx.wdl_type())
     val name: String = getIdentifierText(ctx.Identifier(), ctx)
@@ -717,9 +717,9 @@ bound_decls
 	;
    */
   override def visitBound_decls(ctx: WdlV1Parser.Bound_declsContext): Declaration = {
-    if (ctx.wdl_type() == null)
-      throw new SyntaxException("type missing in declaration",
-                                getSourceLocation(grammar.docSource, ctx))
+    if (ctx.wdl_type() == null) {
+      throw new SyntaxException("missing type", getSourceLocation(grammar.docSource, ctx))
+    }
     val wdlType = visitWdl_type(ctx.wdl_type())
     val name: String = getIdentifierText(ctx.Identifier(), ctx)
     if (ctx.expr() == null) {
@@ -737,11 +737,14 @@ any_decls
 	;
    */
   override def visitAny_decls(ctx: WdlV1Parser.Any_declsContext): Declaration = {
-    if (ctx.unbound_decls() != null)
-      return visitUnbound_decls(ctx.unbound_decls())
-    if (ctx.bound_decls() != null)
-      return visitBound_decls(ctx.bound_decls())
-    throw new SyntaxException("bad declaration format")(getSourceLocation(grammar.docSource, ctx))
+    if (ctx.unbound_decls() != null) {
+      visitUnbound_decls(ctx.unbound_decls())
+    } else if (ctx.bound_decls() != null) {
+      visitBound_decls(ctx.bound_decls())
+    } else {
+      throw new SyntaxException("unrecognized declaration",
+                                getSourceLocation(grammar.docSource, ctx))
+    }
   }
 
   /* meta_value
@@ -754,31 +757,26 @@ any_decls
     ; */
   override def visitMeta_value(ctx: WdlV1Parser.Meta_valueContext): MetaValue = {
     if (ctx.MetaNull() != null) {
-      return MetaValueNull(getSourceLocation(grammar.docSource, ctx))
-    }
-    if (ctx.MetaBool() != null) {
+      MetaValueNull(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.MetaBool() != null) {
       val value = ctx.getText.toLowerCase() == "true"
-      return MetaValueBoolean(value)(getSourceLocation(grammar.docSource, ctx))
-    }
-    if (ctx.MetaInt() != null) {
-      return MetaValueInt(ctx.MetaInt().getText.toLong)(getSourceLocation(grammar.docSource, ctx))
-    }
-    if (ctx.MetaFloat() != null) {
-      return MetaValueFloat(ctx.MetaFloat().getText.toDouble)(
+      MetaValueBoolean(value)(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.MetaInt() != null) {
+      MetaValueInt(ctx.MetaInt().getText.toLong)(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.MetaFloat() != null) {
+      MetaValueFloat(ctx.MetaFloat().getText.toDouble)(
           getSourceLocation(grammar.docSource, ctx)
       )
+    } else if (ctx.meta_string() != null) {
+      visitMeta_string(ctx.meta_string())
+    } else if (ctx.meta_array() != null) {
+      visitMeta_array(ctx.meta_array())
+    } else if (ctx.meta_object() != null) {
+      visitMeta_object(ctx.meta_object())
+    } else {
+      throw new SyntaxException("unrecognized meta_value",
+                                getSourceLocation(grammar.docSource, ctx))
     }
-    if (ctx.meta_string() != null) {
-      return visitMeta_string(ctx.meta_string())
-    }
-    if (ctx.meta_array() != null) {
-      return visitMeta_array(ctx.meta_array())
-    }
-    if (ctx.meta_object() != null) {
-      return visitMeta_object(ctx.meta_object())
-    }
-    throw new SyntaxException("Not one of the legal variants of meta_value",
-                              getSourceLocation(grammar.docSource, ctx))
   }
 
   override def visitMeta_string_part(ctx: WdlV1Parser.Meta_string_partContext): MetaValueString = {
@@ -831,8 +829,7 @@ any_decls
                            meta_value: WdlV1Parser.Meta_valueContext,
                            parent: ParserRuleContext) = {
     if (identifier == null) {
-      throw new SyntaxException("missing identifier - maybe you have a trailing comma?",
-                                getSourceLocation(grammar.docSource, parent))
+      throw new SyntaxException("missing identifier", getSourceLocation(grammar.docSource, parent))
     }
     val id = getIdentifierText(identifier, parent)
     if (meta_value == null) {
@@ -1094,16 +1091,8 @@ task_input
 
     parameterMeta.foreach(validateParamMeta(_, input, output, ctx))
 
-    Task(
-        name,
-        input = input,
-        output = output,
-        command = command,
-        declarations = decls,
-        meta = meta,
-        parameterMeta = parameterMeta,
-        runtime = runtime,
-        loc = getSourceLocation(grammar.docSource, ctx)
+    Task(name, input, output, command, decls, meta, parameterMeta, runtime)(
+        getSourceLocation(grammar.docSource, ctx)
     )
   }
 
@@ -1189,10 +1178,11 @@ task_input
 	: LBRACE call_inputs? RBRACE
 	; */
   override def visitCall_body(ctx: WdlV1Parser.Call_bodyContext): CallInputs = {
-    if (ctx.call_inputs() == null)
+    if (ctx.call_inputs() == null) {
       CallInputs(Vector.empty)(getSourceLocation(grammar.docSource, ctx))
-    else
+    } else {
       visitCall_inputs(ctx.call_inputs())
+    }
   }
 
   /* call
@@ -1280,15 +1270,17 @@ scatter
   override def visitInner_workflow_element(
       ctx: WdlV1Parser.Inner_workflow_elementContext
   ): WorkflowElement = {
-    if (ctx.bound_decls() != null)
-      return visitBound_decls(ctx.bound_decls())
-    if (ctx.call() != null)
-      return visitCall(ctx.call())
-    if (ctx.scatter() != null)
-      return visitScatter(ctx.scatter())
-    if (ctx.conditional() != null)
-      return visitConditional(ctx.conditional())
-    throw new Exception("sanity")
+    if (ctx.bound_decls() != null) {
+      visitBound_decls(ctx.bound_decls())
+    } else if (ctx.call() != null) {
+      visitCall(ctx.call())
+    } else if (ctx.scatter() != null) {
+      visitScatter(ctx.scatter())
+    } else if (ctx.conditional() != null) {
+      visitConditional(ctx.conditional())
+    } else {
+      throw new Exception("unrecognized workflow element")
+    }
   }
 
   /*
@@ -1332,13 +1324,9 @@ workflow
 
     parameterMeta.foreach(validateParamMeta(_, input, output, ctx))
 
-    Workflow(name,
-             input,
-             output,
-             meta,
-             parameterMeta,
-             wfElems,
-             getSourceLocation(grammar.docSource, ctx))
+    Workflow(name, input, output, meta, parameterMeta, wfElems)(
+        getSourceLocation(grammar.docSource, ctx)
+    )
   }
 
   /*
@@ -1357,7 +1345,7 @@ document_element
 	; */
   override def visitVersion(ctx: WdlV1Parser.VersionContext): Version = {
     if (ctx.ReleaseVersion() == null) {
-      throw new SyntaxException("version not specified")(getSourceLocation(grammar.docSource, ctx))
+      throw new SyntaxException("unrecognized version", getSourceLocation(grammar.docSource, ctx))
     }
     val value = ctx.ReleaseVersion().getText
     Version(WdlVersion.withName(value))(getSourceLocation(grammar.docSource, ctx))
@@ -1384,12 +1372,9 @@ document
       else
         Some(visitWorkflow(ctx.workflow()))
 
-    Document(grammar.docSource,
-             version,
-             elems,
-             workflow,
-             getSourceLocation(grammar.docSource, ctx),
-             comments)
+    Document(grammar.docSource, version, elems, workflow, comments)(
+        getSourceLocation(grammar.docSource, ctx)
+    )
   }
 
   def visitExprDocument(ctx: WdlV1Parser.Expr_documentContext): Expr = {

--- a/src/main/scala/wdlTools/syntax/v1_1/ConcreteSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/v1_1/ConcreteSyntax.scala
@@ -56,10 +56,10 @@ object ConcreteSyntax {
   // ${true="--yes" false="--no" boolean_value}
   // ${default="foo" optional_value}
   // ${sep=", " array_value}
-  case class ExprPlaceholder(t: Option[Expr],
-                             f: Option[Expr],
-                             sep: Option[Expr],
-                             default: Option[Expr],
+  case class ExprPlaceholder(trueOpt: Option[Expr],
+                             falseOpt: Option[Expr],
+                             sepOpt: Option[Expr],
+                             defaultOpt: Option[Expr],
                              value: Expr)(val loc: SourceLocation)
       extends Expr
 
@@ -85,7 +85,7 @@ object ConcreteSyntax {
       extends Expr
   case class ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr)(val loc: SourceLocation)
       extends Expr
-  case class ExprGetName(e: Expr, id: String)(val loc: SourceLocation) extends Expr
+  case class ExprGetName(expr: Expr, id: String)(val loc: SourceLocation) extends Expr
 
   case class Declaration(name: String, wdlType: Type, expr: Option[Expr])(val loc: SourceLocation)
       extends WorkflowElement

--- a/src/main/scala/wdlTools/syntax/v1_1/ConcreteSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/v1_1/ConcreteSyntax.scala
@@ -14,42 +14,42 @@ object ConcreteSyntax {
 
   // type system
   sealed trait Type extends Element
-  case class TypeOptional(t: Type, loc: SourceLocation) extends Type
-  case class TypeArray(t: Type, nonEmpty: Boolean, loc: SourceLocation) extends Type
-  case class TypeMap(k: Type, v: Type, loc: SourceLocation) extends Type
-  case class TypePair(l: Type, r: Type, loc: SourceLocation) extends Type
-  case class TypeString(loc: SourceLocation) extends Type
-  case class TypeFile(loc: SourceLocation) extends Type
-  case class TypeBoolean(loc: SourceLocation) extends Type
-  case class TypeInt(loc: SourceLocation) extends Type
-  case class TypeFloat(loc: SourceLocation) extends Type
-  case class TypeIdentifier(id: String, loc: SourceLocation) extends Type
-  case class TypeObject(loc: SourceLocation) extends Type
-  case class StructMember(name: String, wdlType: Type, loc: SourceLocation) extends Element
-  case class TypeStruct(name: String, members: Vector[StructMember], loc: SourceLocation)
+  case class TypeOptional(t: Type)(val loc: SourceLocation) extends Type
+  case class TypeArray(t: Type, nonEmpty: Boolean)(val loc: SourceLocation) extends Type
+  case class TypeMap(k: Type, v: Type)(val loc: SourceLocation) extends Type
+  case class TypePair(l: Type, r: Type)(val loc: SourceLocation) extends Type
+  case class TypeString()(val loc: SourceLocation) extends Type
+  case class TypeFile()(val loc: SourceLocation) extends Type
+  case class TypeBoolean()(val loc: SourceLocation) extends Type
+  case class TypeInt()(val loc: SourceLocation) extends Type
+  case class TypeFloat()(val loc: SourceLocation) extends Type
+  case class TypeIdentifier(id: String)(val loc: SourceLocation) extends Type
+  case class TypeObject()(val loc: SourceLocation) extends Type
+  case class StructMember(name: String, wdlType: Type)(val loc: SourceLocation) extends Element
+  case class TypeStruct(name: String, members: Vector[StructMember])(val loc: SourceLocation)
       extends Type
       with DocumentElement
 
   // expressions
   sealed trait Expr extends Element
-  case class ExprNone(loc: SourceLocation) extends Expr
-  case class ExprString(value: String, loc: SourceLocation) extends Expr
-  case class ExprBoolean(value: Boolean, loc: SourceLocation) extends Expr
-  case class ExprInt(value: Long, loc: SourceLocation) extends Expr
-  case class ExprFloat(value: Double, loc: SourceLocation) extends Expr
+  case class ExprNone()(val loc: SourceLocation) extends Expr
+  case class ExprString(value: String)(val loc: SourceLocation) extends Expr
+  case class ExprBoolean(value: Boolean)(val loc: SourceLocation) extends Expr
+  case class ExprInt(value: Long)(val loc: SourceLocation) extends Expr
+  case class ExprFloat(value: Double)(val loc: SourceLocation) extends Expr
 
   // represents strings with interpolation.
   // For example:
   //  "some string part ~{ident + ident} some string part after"
-  case class ExprCompoundString(value: Vector[Expr], loc: SourceLocation) extends Expr
-  case class ExprMember(key: Expr, value: Expr, loc: SourceLocation) extends Expr
-  case class ExprMapLiteral(value: Vector[ExprMember], loc: SourceLocation) extends Expr
-  case class ExprObjectLiteral(value: Vector[ExprMember], loc: SourceLocation) extends Expr
-  case class ExprStructLiteral(name: String, members: Vector[ExprMember], loc: SourceLocation)
+  case class ExprCompoundString(value: Vector[Expr])(val loc: SourceLocation) extends Expr
+  case class ExprMember(key: Expr, value: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprMapLiteral(value: Vector[ExprMember])(val loc: SourceLocation) extends Expr
+  case class ExprObjectLiteral(value: Vector[ExprMember])(val loc: SourceLocation) extends Expr
+  case class ExprStructLiteral(name: String, members: Vector[ExprMember])(val loc: SourceLocation)
       extends Expr
-  case class ExprArrayLiteral(value: Vector[Expr], loc: SourceLocation) extends Expr
+  case class ExprArrayLiteral(value: Vector[Expr])(val loc: SourceLocation) extends Expr
 
-  case class ExprIdentifier(id: String, loc: SourceLocation) extends Expr
+  case class ExprIdentifier(id: String)(val loc: SourceLocation) extends Expr
 
   // These are full expressions of the same kind
   //
@@ -60,39 +60,41 @@ object ConcreteSyntax {
                              f: Option[Expr],
                              sep: Option[Expr],
                              default: Option[Expr],
-                             value: Expr,
-                             loc: SourceLocation)
+                             value: Expr)(val loc: SourceLocation)
       extends Expr
 
-  case class ExprUnaryPlus(value: Expr, loc: SourceLocation) extends Expr
-  case class ExprUnaryMinus(value: Expr, loc: SourceLocation) extends Expr
-  case class ExprLor(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprLand(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprNegate(value: Expr, loc: SourceLocation) extends Expr
-  case class ExprEqeq(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprLt(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprGte(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprNeq(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprLte(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprGt(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprAdd(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprSub(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprMod(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprMul(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprDivide(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprPair(l: Expr, r: Expr, loc: SourceLocation) extends Expr
-  case class ExprAt(array: Expr, index: Expr, loc: SourceLocation) extends Expr
-  case class ExprApply(funcName: String, elements: Vector[Expr], loc: SourceLocation) extends Expr
-  case class ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr, loc: SourceLocation)
+  case class ExprUnaryPlus(value: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprUnaryMinus(value: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprLor(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprLand(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprNegate(value: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprEqeq(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprLt(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprGte(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprNeq(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprLte(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprGt(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprAdd(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprSub(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprMod(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprMul(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprDivide(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprPair(l: Expr, r: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprAt(array: Expr, index: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprApply(funcName: String, elements: Vector[Expr])(val loc: SourceLocation)
       extends Expr
-  case class ExprGetName(e: Expr, id: String, loc: SourceLocation) extends Expr
+  case class ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr)(val loc: SourceLocation)
+      extends Expr
+  case class ExprGetName(e: Expr, id: String)(val loc: SourceLocation) extends Expr
 
-  case class Declaration(name: String, wdlType: Type, expr: Option[Expr], loc: SourceLocation)
+  case class Declaration(name: String, wdlType: Type, expr: Option[Expr])(val loc: SourceLocation)
       extends WorkflowElement
 
   // sections
-  case class InputSection(declarations: Vector[Declaration], loc: SourceLocation) extends Element
-  case class OutputSection(declarations: Vector[Declaration], loc: SourceLocation) extends Element
+  case class InputSection(declarations: Vector[Declaration])(val loc: SourceLocation)
+      extends Element
+  case class OutputSection(declarations: Vector[Declaration])(val loc: SourceLocation)
+      extends Element
 
   // A command can be simple, with just one continuous string:
   //
@@ -107,36 +109,34 @@ object ConcreteSyntax {
   //     ls ~{input_file}
   //     echo ~{input_string}
   // >>>
-  case class CommandSection(parts: Vector[Expr], loc: SourceLocation) extends Element
+  case class CommandSection(parts: Vector[Expr])(val loc: SourceLocation) extends Element
 
-  case class RuntimeKV(id: String, expr: Expr, loc: SourceLocation) extends Element
-  case class RuntimeSection(kvs: Vector[RuntimeKV], loc: SourceLocation) extends Element
+  case class RuntimeKV(id: String, expr: Expr)(val loc: SourceLocation) extends Element
+  case class RuntimeSection(kvs: Vector[RuntimeKV])(val loc: SourceLocation) extends Element
 
   // A specialized JSON-like object language for meta values only.
   sealed trait MetaValue extends Element
-  case class MetaValueNull(loc: SourceLocation) extends MetaValue
-  case class MetaValueBoolean(value: Boolean, loc: SourceLocation) extends MetaValue
-  case class MetaValueInt(value: Long, loc: SourceLocation) extends MetaValue
-  case class MetaValueFloat(value: Double, loc: SourceLocation) extends MetaValue
-  case class MetaValueString(value: String, loc: SourceLocation) extends MetaValue
-  case class MetaValueObject(value: Vector[MetaKV], loc: SourceLocation) extends MetaValue
-  case class MetaValueArray(value: Vector[MetaValue], loc: SourceLocation) extends MetaValue
+  case class MetaValueNull()(val loc: SourceLocation) extends MetaValue
+  case class MetaValueBoolean(value: Boolean)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueInt(value: Long)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueFloat(value: Double)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueString(value: String)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueObject(value: Vector[MetaKV])(val loc: SourceLocation) extends MetaValue
+  case class MetaValueArray(value: Vector[MetaValue])(val loc: SourceLocation) extends MetaValue
   // meta section
-  case class MetaKV(id: String, value: MetaValue, loc: SourceLocation) extends Element
-  case class ParameterMetaSection(kvs: Vector[MetaKV], loc: SourceLocation) extends Element
-  case class MetaSection(kvs: Vector[MetaKV], loc: SourceLocation) extends Element
+  case class MetaKV(id: String, value: MetaValue)(val loc: SourceLocation) extends Element
+  case class ParameterMetaSection(kvs: Vector[MetaKV])(val loc: SourceLocation) extends Element
+  case class MetaSection(kvs: Vector[MetaKV])(val loc: SourceLocation) extends Element
 
   // imports
-  case class ImportAddr(value: String, loc: SourceLocation) extends Element
-  case class ImportName(value: String, loc: SourceLocation) extends Element
-  case class ImportAlias(id1: String, id2: String, loc: SourceLocation) extends Element
+  case class ImportAddr(value: String)(val loc: SourceLocation) extends Element
+  case class ImportName(value: String)(val loc: SourceLocation) extends Element
+  case class ImportAlias(id1: String, id2: String)(val loc: SourceLocation) extends Element
 
   // import statement as read from the document
-  case class ImportDoc(name: Option[ImportName],
-                       aliases: Vector[ImportAlias],
-                       addr: ImportAddr,
-                       loc: SourceLocation)
-      extends DocumentElement
+  case class ImportDoc(name: Option[ImportName], aliases: Vector[ImportAlias], addr: ImportAddr)(
+      val loc: SourceLocation
+  ) extends DocumentElement
 
   // top level definitions
   case class Task(name: String,
@@ -146,26 +146,22 @@ object ConcreteSyntax {
                   declarations: Vector[Declaration],
                   meta: Option[MetaSection],
                   parameterMeta: Option[ParameterMetaSection],
-                  runtime: Option[RuntimeSection],
-                  loc: SourceLocation)
+                  runtime: Option[RuntimeSection])(val loc: SourceLocation)
       extends DocumentElement
 
-  case class CallAlias(name: String, loc: SourceLocation) extends Element
-  case class CallAfter(name: String, loc: SourceLocation) extends Element
-  case class CallInput(name: String, expr: Expr, loc: SourceLocation) extends Element
-  case class CallInputs(value: Vector[CallInput], loc: SourceLocation) extends Element
+  case class CallAlias(name: String)(val loc: SourceLocation) extends Element
+  case class CallAfter(name: String)(val loc: SourceLocation) extends Element
+  case class CallInput(name: String, expr: Expr)(val loc: SourceLocation) extends Element
+  case class CallInputs(value: Vector[CallInput])(val loc: SourceLocation) extends Element
   case class Call(name: String,
                   alias: Option[CallAlias],
                   afters: Vector[CallAfter],
-                  inputs: Option[CallInputs],
-                  loc: SourceLocation)
+                  inputs: Option[CallInputs])(val loc: SourceLocation)
       extends WorkflowElement
-  case class Scatter(identifier: String,
-                     expr: Expr,
-                     body: Vector[WorkflowElement],
-                     loc: SourceLocation)
-      extends WorkflowElement
-  case class Conditional(expr: Expr, body: Vector[WorkflowElement], loc: SourceLocation)
+  case class Scatter(identifier: String, expr: Expr, body: Vector[WorkflowElement])(
+      val loc: SourceLocation
+  ) extends WorkflowElement
+  case class Conditional(expr: Expr, body: Vector[WorkflowElement])(val loc: SourceLocation)
       extends WorkflowElement
 
   case class Workflow(name: String,
@@ -173,16 +169,14 @@ object ConcreteSyntax {
                       output: Option[OutputSection],
                       meta: Option[MetaSection],
                       parameterMeta: Option[ParameterMetaSection],
-                      body: Vector[WorkflowElement],
-                      loc: SourceLocation)
+                      body: Vector[WorkflowElement])(val loc: SourceLocation)
       extends Element
 
-  case class Version(value: WdlVersion = WdlVersion.V2, loc: SourceLocation) extends Element
+  case class Version(value: WdlVersion = WdlVersion.V2)(val loc: SourceLocation) extends Element
   case class Document(source: FileNode,
                       version: Version,
                       elements: Vector[DocumentElement],
                       workflow: Option[Workflow],
-                      loc: SourceLocation,
-                      comments: CommentMap)
+                      comments: CommentMap)(val loc: SourceLocation)
       extends Element
 }

--- a/src/main/scala/wdlTools/syntax/v1_1/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/v1_1/ParseAll.scala
@@ -15,128 +15,144 @@ case class ParseAll(followImports: Boolean = false,
                     logger: Logger = Logger.get)
     extends WdlParser(followImports, fileResolver, logger) {
   private case class Translator(docSource: FileNode) {
-    def translateType(t: CST.Type): AST.Type = {
-      t match {
-        case CST.TypeOptional(t, loc) =>
-          AST.TypeOptional(translateType(t), loc)
-        case CST.TypeArray(t, nonEmpty, loc) =>
-          AST.TypeArray(translateType(t), nonEmpty, loc)
-        case CST.TypeMap(k, v, loc) =>
-          AST.TypeMap(translateType(k), translateType(v), loc)
-        case CST.TypePair(l, r, loc) =>
-          AST.TypePair(translateType(l), translateType(r), loc)
-        case CST.TypeObject(loc)         => AST.TypeObject(loc)
-        case CST.TypeString(loc)         => AST.TypeString(loc)
-        case CST.TypeFile(loc)           => AST.TypeFile(loc)
-        case CST.TypeBoolean(loc)        => AST.TypeBoolean(loc)
-        case CST.TypeInt(loc)            => AST.TypeInt(loc)
-        case CST.TypeFloat(loc)          => AST.TypeFloat(loc)
-        case CST.TypeIdentifier(id, loc) => AST.TypeIdentifier(id, loc)
-        case CST.TypeStruct(name, members, loc) =>
-          AST.TypeStruct(name, members.map {
-            case CST.StructMember(name, t, text) =>
-              AST.StructMember(name, translateType(t), text)
-          }, loc)
+    def translateType(cstType: CST.Type): AST.Type = {
+      cstType match {
+        case t: CST.TypeOptional =>
+          AST.TypeOptional(translateType(t.t))(t.loc)
+        case t: CST.TypeArray =>
+          AST.TypeArray(translateType(t.t), t.nonEmpty)(t.loc)
+        case t: CST.TypeMap =>
+          AST.TypeMap(translateType(t.k), translateType(t.v))(t.loc)
+        case t: CST.TypePair =>
+          AST.TypePair(translateType(t.l), translateType(t.r))(t.loc)
+        case t: CST.TypeObject     => AST.TypeObject()(t.loc)
+        case t: CST.TypeString     => AST.TypeString()(t.loc)
+        case t: CST.TypeFile       => AST.TypeFile()(t.loc)
+        case t: CST.TypeBoolean    => AST.TypeBoolean()(t.loc)
+        case t: CST.TypeInt        => AST.TypeInt()(t.loc)
+        case t: CST.TypeFloat      => AST.TypeFloat()(t.loc)
+        case t: CST.TypeIdentifier => AST.TypeIdentifier(t.id)(t.loc)
+        case t: CST.TypeStruct =>
+          AST.TypeStruct(t.name, t.members.map { member: CST.StructMember =>
+            AST.StructMember(member.name, translateType(member.wdlType))(member.loc)
+          })(t.loc)
       }
     }
 
     def translateExpr(e: CST.Expr): AST.Expr = {
       e match {
         // value
-        case CST.ExprNone(loc)           => AST.ValueNone(loc)
-        case CST.ExprString(value, loc)  => AST.ValueString(value, loc)
-        case CST.ExprBoolean(value, loc) => AST.ValueBoolean(value, loc)
-        case CST.ExprInt(value, loc)     => AST.ValueInt(value, loc)
-        case CST.ExprFloat(value, loc)   => AST.ValueFloat(value, loc)
+        case e: CST.ExprNone    => AST.ValueNone()(e.loc)
+        case e: CST.ExprString  => AST.ValueString(e.value)(e.loc)
+        case e: CST.ExprBoolean => AST.ValueBoolean(e.value)(e.loc)
+        case e: CST.ExprInt     => AST.ValueInt(e.value)(e.loc)
+        case e: CST.ExprFloat   => AST.ValueFloat(e.value)(e.loc)
 
         // compound values
-        case CST.ExprIdentifier(id, loc) => AST.ExprIdentifier(id, loc)
-        case CST.ExprCompoundString(parts, loc) =>
-          AST.ExprCompoundString(parts.map(translateExpr), loc)
-        case CST.ExprPair(left, right, loc) =>
-          AST.ExprPair(translateExpr(left), translateExpr(right), loc)
-        case CST.ExprArrayLiteral(array, loc) =>
-          AST.ExprArray(array.map(translateExpr), loc)
-        case CST.ExprMapLiteral(members, loc) =>
-          AST.ExprMap(members.map { item =>
-            AST.ExprMember(translateExpr(item.key), translateExpr(item.value), item.loc)
-          }, loc)
-        case CST.ExprObjectLiteral(members, loc) =>
-          AST.ExprObject(members.map { member =>
-            AST.ExprMember(translateExpr(member.key), translateExpr(member.value), member.loc)
-          }, loc)
-        case CST.ExprStructLiteral(name, members, loc) =>
-          AST.ExprStruct(name, members.map { member =>
-            AST.ExprMember(translateExpr(member.key), translateExpr(member.value), member.loc)
-          }, loc)
+        case e: CST.ExprIdentifier => AST.ExprIdentifier(e.id)(e.loc)
+        case e: CST.ExprCompoundString =>
+          AST.ExprCompoundString(e.value.map(translateExpr))(e.loc)
+        case e: CST.ExprPair =>
+          AST.ExprPair(translateExpr(e.l), translateExpr(e.r))(e.loc)
+        case e: CST.ExprArrayLiteral =>
+          AST.ExprArray(e.value.map(translateExpr))(e.loc)
+        case e: CST.ExprMapLiteral =>
+          AST.ExprMap(e.value.map { item =>
+            AST.ExprMember(translateExpr(item.key), translateExpr(item.value))(item.loc)
+          })(e.loc)
+        case e: CST.ExprObjectLiteral =>
+          AST.ExprObject(e.value.map { member =>
+            AST.ExprMember(translateExpr(member.key), translateExpr(member.value))(member.loc)
+          })(e.loc)
+        case e: CST.ExprStructLiteral =>
+          AST.ExprStruct(e.name, e.members.map { member =>
+            AST.ExprMember(translateExpr(member.key), translateExpr(member.value))(member.loc)
+          })(e.loc)
 
         // string place holders
-        case CST.ExprPlaceholder(t, f, sep, default, value, srcText) =>
-          AST.ExprPlaceholder(t.map(translateExpr),
-                              f.map(translateExpr),
-                              sep.map(translateExpr),
-                              default.map(translateExpr),
-                              translateExpr(value),
-                              srcText)
+        case e: CST.ExprPlaceholder =>
+          AST.ExprPlaceholder(e.t.map(translateExpr),
+                              e.f.map(translateExpr),
+                              e.sep.map(translateExpr),
+                              e.default.map(translateExpr),
+                              translateExpr(e.value))(e.loc)
 
         // operators on one argument
-        case CST.ExprUnaryPlus(value, loc) =>
-          AST.ExprApply(Operator.UnaryPlus.name, Vector(translateExpr(value)), loc)
-        case CST.ExprUnaryMinus(value, loc) =>
-          AST.ExprApply(Operator.UnaryMinus.name, Vector(translateExpr(value)), loc)
-        case CST.ExprNegate(value, loc) =>
-          AST.ExprApply(Operator.LogicalNot.name, Vector(translateExpr(value)), loc)
+        case e: CST.ExprUnaryPlus =>
+          AST.ExprApply(Operator.UnaryPlus.name, Vector(translateExpr(e.value)))(e.loc)
+        case e: CST.ExprUnaryMinus =>
+          AST.ExprApply(Operator.UnaryMinus.name, Vector(translateExpr(e.value)))(e.loc)
+        case e: CST.ExprNegate =>
+          AST.ExprApply(Operator.LogicalNot.name, Vector(translateExpr(e.value)))(e.loc)
 
         // operators on two arguments
-        case CST.ExprLor(a, b, loc) =>
-          AST.ExprApply(Operator.LogicalOr.name, Vector(translateExpr(a), translateExpr(b)), loc)
-        case CST.ExprLand(a, b, loc) =>
-          AST.ExprApply(Operator.LogicalAnd.name, Vector(translateExpr(a), translateExpr(b)), loc)
-        case CST.ExprEqeq(a, b, loc) =>
-          AST.ExprApply(Operator.Equality.name, Vector(translateExpr(a), translateExpr(b)), loc)
-        case CST.ExprNeq(a, b, loc) =>
-          AST.ExprApply(Operator.Inequality.name, Vector(translateExpr(a), translateExpr(b)), loc)
-        case CST.ExprLt(a, b, loc) =>
-          AST.ExprApply(Operator.LessThan.name, Vector(translateExpr(a), translateExpr(b)), loc)
-        case CST.ExprLte(a, b, loc) =>
+        case e: CST.ExprLor =>
+          AST.ExprApply(Operator.LogicalOr.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprLand =>
+          AST.ExprApply(Operator.LogicalAnd.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprEqeq =>
+          AST.ExprApply(Operator.Equality.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprNeq =>
+          AST.ExprApply(Operator.Inequality.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprLt =>
+          AST.ExprApply(Operator.LessThan.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprLte =>
           AST.ExprApply(Operator.LessThanOrEqual.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        loc)
-        case CST.ExprGt(a, b, loc) =>
-          AST.ExprApply(Operator.GreaterThan.name, Vector(translateExpr(a), translateExpr(b)), loc)
-        case CST.ExprGte(a, b, loc) =>
+                        Vector(translateExpr(e.a), translateExpr(e.b)))(e.loc)
+        case e: CST.ExprGt =>
+          AST.ExprApply(Operator.GreaterThan.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprGte =>
           AST.ExprApply(Operator.GreaterThanOrEqual.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        loc)
-        case CST.ExprAdd(a, b, loc) =>
-          AST.ExprApply(Operator.Addition.name, Vector(translateExpr(a), translateExpr(b)), loc)
-        case CST.ExprSub(a, b, loc) =>
-          AST.ExprApply(Operator.Subtraction.name, Vector(translateExpr(a), translateExpr(b)), loc)
-        case CST.ExprMul(a, b, loc) =>
+                        Vector(translateExpr(e.a), translateExpr(e.b)))(e.loc)
+        case e: CST.ExprAdd =>
+          AST.ExprApply(Operator.Addition.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprSub =>
+          AST.ExprApply(Operator.Subtraction.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprMul =>
           AST.ExprApply(Operator.Multiplication.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        loc)
-        case CST.ExprDivide(a, b, loc) =>
-          AST.ExprApply(Operator.Division.name, Vector(translateExpr(a), translateExpr(b)), loc)
-        case CST.ExprMod(a, b, loc) =>
-          AST.ExprApply(Operator.Remainder.name, Vector(translateExpr(a), translateExpr(b)), loc)
+                        Vector(translateExpr(e.a), translateExpr(e.b)))(e.loc)
+        case e: CST.ExprDivide =>
+          AST.ExprApply(Operator.Division.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprMod =>
+          AST.ExprApply(Operator.Remainder.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
 
         // Access an array element at [index]
-        case CST.ExprAt(array, index, loc) =>
-          AST.ExprAt(translateExpr(array), translateExpr(index), loc)
+        case e: CST.ExprAt =>
+          AST.ExprAt(translateExpr(e.array), translateExpr(e.index))(e.loc)
 
-        case CST.ExprIfThenElse(cond, tBranch, fBranch, loc) =>
-          AST.ExprIfThenElse(translateExpr(cond),
-                             translateExpr(tBranch),
-                             translateExpr(fBranch),
-                             loc)
-        case CST.ExprApply(funcName, elements, loc) =>
-          if (Operator.All.contains(funcName)) {
-            throw new SyntaxException(s"${funcName} is reserved and not a valid function name", loc)
+        case e: CST.ExprIfThenElse =>
+          AST.ExprIfThenElse(translateExpr(e.cond),
+                             translateExpr(e.tBranch),
+                             translateExpr(e.fBranch))(e.loc)
+        case e: CST.ExprApply =>
+          if (Operator.All.contains(e.funcName)) {
+            throw new SyntaxException(s"${e.funcName} is reserved and not a valid function name")(
+                e.loc
+            )
           }
-          AST.ExprApply(funcName, elements.map(translateExpr), loc)
-        case CST.ExprGetName(e, id, loc) =>
-          AST.ExprGetName(translateExpr(e), id, loc)
+          AST.ExprApply(e.funcName, e.elements.map(translateExpr))(e.loc)
+        case e: CST.ExprGetName =>
+          AST.ExprGetName(translateExpr(e), e.id)(e.loc)
 
         case other =>
           throw new Exception(s"invalid concrete syntax element ${other}")
@@ -152,18 +168,17 @@ case class ParseAll(followImports: Boolean = false,
     private def translateMetaValue(value: CST.MetaValue): AST.MetaValue = {
       value match {
         // values
-        case CST.MetaValueString(value, loc)  => AST.MetaValueString(value, loc)
-        case CST.MetaValueBoolean(value, loc) => AST.MetaValueBoolean(value, loc)
-        case CST.MetaValueInt(value, loc)     => AST.MetaValueInt(value, loc)
-        case CST.MetaValueFloat(value, loc)   => AST.MetaValueFloat(value, loc)
-        case CST.MetaValueNull(loc)           => AST.MetaValueNull(loc)
-        case CST.MetaValueArray(vec, loc) =>
-          AST.MetaValueArray(vec.map(translateMetaValue), loc)
-        case CST.MetaValueObject(m, loc) =>
-          AST.MetaValueObject(m.map {
-            case CST.MetaKV(fieldName: String, v, text) =>
-              AST.MetaKV(fieldName, translateMetaValue(v), text)
-          }, loc)
+        case v: CST.MetaValueString  => AST.MetaValueString(v.value)(v.loc)
+        case v: CST.MetaValueBoolean => AST.MetaValueBoolean(v.value)(v.loc)
+        case v: CST.MetaValueInt     => AST.MetaValueInt(v.value)(v.loc)
+        case v: CST.MetaValueFloat   => AST.MetaValueFloat(v.value)(v.loc)
+        case v: CST.MetaValueNull    => AST.MetaValueNull()(v.loc)
+        case v: CST.MetaValueArray =>
+          AST.MetaValueArray(v.value.map(translateMetaValue))(v.loc)
+        case v: CST.MetaValueObject =>
+          AST.MetaValueObject(v.value.map { kv: CST.MetaKV =>
+            AST.MetaKV(kv.id, translateMetaValue(kv.value))(kv.loc)
+          })(v.loc)
         case other =>
           throw new SyntaxException("illegal expression in meta section", other.loc)
       }
@@ -172,26 +187,25 @@ case class ParseAll(followImports: Boolean = false,
     private def translateInputSection(
         inp: CST.InputSection
     ): AST.InputSection = {
-      AST.InputSection(inp.declarations.map(translateDeclaration), inp.loc)
+      AST.InputSection(inp.declarations.map(translateDeclaration))(inp.loc)
     }
 
     private def translateOutputSection(
         output: CST.OutputSection
     ): AST.OutputSection = {
-      AST.OutputSection(output.declarations.map(translateDeclaration), output.loc)
+      AST.OutputSection(output.declarations.map(translateDeclaration))(output.loc)
     }
 
     private def translateCommandSection(
         cs: CST.CommandSection
     ): AST.CommandSection = {
-      AST.CommandSection(cs.parts.map(translateExpr), cs.loc)
+      AST.CommandSection(cs.parts.map(translateExpr))(cs.loc)
     }
 
     private def translateDeclaration(decl: CST.Declaration): AST.Declaration = {
-      AST.Declaration(decl.name,
-                      translateType(decl.wdlType),
-                      decl.expr.map(translateExpr),
-                      decl.loc)
+      AST.Declaration(decl.name, translateType(decl.wdlType), decl.expr.map(translateExpr))(
+          decl.loc
+      )
     }
 
     private def translateMetaKVs(kvs: Vector[CST.MetaKV],
@@ -206,20 +220,20 @@ case class ParseAll(followImports: Boolean = false,
                      |is overridden by later value ${metaValue}""".stripMargin.replaceAll("\n", " ")
               )
             }
-            accu + (kv.id -> AST.MetaKV(kv.id, metaValue, kv.loc))
+            accu + (kv.id -> AST.MetaKV(kv.id, metaValue)(kv.loc))
         }
         .values
         .toVector
     }
 
     private def translateMetaSection(meta: CST.MetaSection): AST.MetaSection = {
-      AST.MetaSection(translateMetaKVs(meta.kvs, "meta"), meta.loc)
+      AST.MetaSection(translateMetaKVs(meta.kvs, "meta"))(meta.loc)
     }
 
     private def translateParameterMetaSection(
         paramMeta: CST.ParameterMetaSection
     ): AST.ParameterMetaSection = {
-      AST.ParameterMetaSection(translateMetaKVs(paramMeta.kvs, "parameter_meta"), paramMeta.loc)
+      AST.ParameterMetaSection(translateMetaKVs(paramMeta.kvs, "parameter_meta"))(paramMeta.loc)
     }
 
     private def translateRuntimeSection(
@@ -228,17 +242,18 @@ case class ParseAll(followImports: Boolean = false,
       AST.RuntimeSection(
           runtime.kvs
             .foldLeft(TreeSeqMap.empty[String, AST.RuntimeKV]) {
-              case (accu, CST.RuntimeKV(id, expr, text)) =>
-                val tExpr = translateExpr(expr)
-                if (accu.contains(id)) {
+              case (accu, kv: CST.RuntimeKV) =>
+                val tExpr = translateExpr(kv.expr)
+                if (accu.contains(kv.id)) {
                   logger.warning(
-                      s"duplicate runtime key ${id}: earlier value ${accu(id)} is overridden by later value ${tExpr}"
+                      s"duplicate runtime key ${kv.id}: earlier value ${accu(kv.id)} is overridden by later value ${tExpr}"
                   )
                 }
-                accu + (id -> AST.RuntimeKV(id, tExpr, text))
+                accu + (kv.id -> AST.RuntimeKV(kv.id, tExpr)(kv.loc))
             }
             .values
-            .toVector,
+            .toVector
+      )(
           runtime.loc
       )
     }
@@ -247,34 +262,38 @@ case class ParseAll(followImports: Boolean = false,
         elem: CST.WorkflowElement
     ): AST.WorkflowElement = {
       elem match {
-        case CST.Declaration(name, wdlType, expr, text) =>
-          AST.Declaration(name, translateType(wdlType), expr.map(translateExpr), text)
-
-        case CST.Call(name, alias, afters, inputs, text) =>
-          AST.Call(
-              name,
-              alias.map {
-                case CST.CallAlias(callName, callText) =>
-                  AST.CallAlias(callName, callText)
-              },
-              afters.map {
-                case CST.CallAfter(afterName, afterText) =>
-                  AST.CallAfter(afterName, afterText)
-              },
-              inputs.map {
-                case CST.CallInputs(inputsMap, inputsText) =>
-                  AST.CallInputs(inputsMap.map { inp =>
-                    AST.CallInput(inp.name, translateExpr(inp.expr), inp.loc)
-                  }, inputsText)
-              },
-              text
+        case decl: CST.Declaration =>
+          AST.Declaration(decl.name, translateType(decl.wdlType), decl.expr.map(translateExpr))(
+              decl.loc
           )
 
-        case CST.Scatter(identifier, expr, body, text) =>
-          AST.Scatter(identifier, translateExpr(expr), body.map(translateWorkflowElement), text)
+        case call: CST.Call =>
+          AST.Call(
+              call.name,
+              call.alias.map { alias: CST.CallAlias =>
+                AST.CallAlias(alias.name)(alias.loc)
+              },
+              call.afters.map { after: CST.CallAfter =>
+                AST.CallAfter(after.name)(after.loc)
+              },
+              call.inputs.map { inputs: CST.CallInputs =>
+                AST.CallInputs(inputs.value.map { inp =>
+                  AST.CallInput(inp.name, translateExpr(inp.expr))(inp.loc)
+                })(inputs.loc)
+              }
+          )(
+              call.loc
+          )
 
-        case CST.Conditional(expr, body, text) =>
-          AST.Conditional(translateExpr(expr), body.map(translateWorkflowElement), text)
+        case scatter: CST.Scatter =>
+          AST.Scatter(scatter.identifier,
+                      translateExpr(scatter.expr),
+                      scatter.body.map(translateWorkflowElement))(scatter.loc)
+
+        case cond: CST.Conditional =>
+          AST.Conditional(translateExpr(cond.expr), cond.body.map(translateWorkflowElement))(
+              cond.loc
+          )
       }
     }
 
@@ -285,34 +304,33 @@ case class ParseAll(followImports: Boolean = false,
           wf.output.map(translateOutputSection),
           wf.meta.map(translateMetaSection),
           wf.parameterMeta.map(translateParameterMetaSection),
-          wf.body.map(translateWorkflowElement),
+          wf.body.map(translateWorkflowElement)
+      )(
           wf.loc
       )
     }
 
     private def translateStruct(struct: CST.TypeStruct): AST.TypeStruct = {
-      AST.TypeStruct(
-          struct.name,
-          struct.members.map {
-            case CST.StructMember(name, t, memberText) =>
-              AST.StructMember(name, translateType(t), memberText)
-          },
+      AST.TypeStruct(struct.name, struct.members.map { member: CST.StructMember =>
+        AST.StructMember(member.name, translateType(member.wdlType))(member.loc)
+      })(
           struct.loc
       )
     }
 
     private def translateImportDoc(importDoc: CST.ImportDoc,
                                    importedDoc: Option[AST.Document]): AST.ImportDoc = {
-      val addrAbst = AST.ImportAddr(importDoc.addr.value, importDoc.loc)
-      val nameAbst = importDoc.name.map {
-        case CST.ImportName(value, text) => AST.ImportName(value, text)
+      val addrAbst = AST.ImportAddr(importDoc.addr.value)(importDoc.loc)
+      val nameAbst = importDoc.name.map { impName: CST.ImportName =>
+        AST.ImportName(impName.value)(impName.loc)
       }
       val aliasesAbst: Vector[AST.ImportAlias] = importDoc.aliases.map {
-        case CST.ImportAlias(x, y, alText) => AST.ImportAlias(x, y, alText)
+        impAlias: CST.ImportAlias =>
+          AST.ImportAlias(impAlias.id1, impAlias.id2)(impAlias.loc)
       }
 
       // Replace the original statement with a new one
-      AST.ImportDoc(nameAbst, aliasesAbst, addrAbst, importedDoc, importDoc.loc)
+      AST.ImportDoc(nameAbst, aliasesAbst, addrAbst, importedDoc)(importDoc.loc)
     }
 
     private def translateTask(task: CST.Task): AST.Task = {
@@ -325,7 +343,8 @@ case class ParseAll(followImports: Boolean = false,
           task.meta.map(translateMetaSection),
           task.parameterMeta.map(translateParameterMetaSection),
           task.runtime.map(translateRuntimeSection),
-          None,
+          None
+      )(
           task.loc
       )
     }
@@ -351,8 +370,8 @@ case class ParseAll(followImports: Boolean = false,
         case other                     => throw new Exception(s"unrecognized document element ${other}")
       }
       val aWf = doc.workflow.map(translateWorkflow)
-      val version = AST.Version(doc.version.value, doc.version.loc)
-      AST.Document(doc.source, version, elems, aWf, doc.loc, doc.comments)
+      val version = AST.Version(doc.version.value)(doc.version.loc)
+      AST.Document(doc.source, version, elems, aWf, doc.comments)(doc.loc)
     }
   }
 

--- a/src/main/scala/wdlTools/syntax/v1_1/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/v1_1/ParseAll.scala
@@ -71,10 +71,10 @@ case class ParseAll(followImports: Boolean = false,
 
         // string place holders
         case e: CST.ExprPlaceholder =>
-          AST.ExprPlaceholder(e.t.map(translateExpr),
-                              e.f.map(translateExpr),
-                              e.sep.map(translateExpr),
-                              e.default.map(translateExpr),
+          AST.ExprPlaceholder(e.trueOpt.map(translateExpr),
+                              e.falseOpt.map(translateExpr),
+                              e.sepOpt.map(translateExpr),
+                              e.defaultOpt.map(translateExpr),
                               translateExpr(e.value))(e.loc)
 
         // operators on one argument
@@ -146,13 +146,12 @@ case class ParseAll(followImports: Boolean = false,
                              translateExpr(e.fBranch))(e.loc)
         case e: CST.ExprApply =>
           if (Operator.All.contains(e.funcName)) {
-            throw new SyntaxException(s"${e.funcName} is reserved and not a valid function name")(
-                e.loc
-            )
+            throw new SyntaxException(s"${e.funcName} is reserved and not a valid function name",
+                                      e.loc)
           }
           AST.ExprApply(e.funcName, e.elements.map(translateExpr))(e.loc)
         case e: CST.ExprGetName =>
-          AST.ExprGetName(translateExpr(e), e.id)(e.loc)
+          AST.ExprGetName(translateExpr(e.expr), e.id)(e.loc)
 
         case other =>
           throw new Exception(s"invalid concrete syntax element ${other}")

--- a/src/main/scala/wdlTools/syntax/v2/ConcreteSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/v2/ConcreteSyntax.scala
@@ -73,7 +73,7 @@ object ConcreteSyntax {
       extends Expr
   case class ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr)(val loc: SourceLocation)
       extends Expr
-  case class ExprGetName(e: Expr, id: String)(val loc: SourceLocation) extends Expr
+  case class ExprGetName(expr: Expr, id: String)(val loc: SourceLocation) extends Expr
 
   case class Declaration(name: String, wdlType: Type, expr: Option[Expr])(val loc: SourceLocation)
       extends WorkflowElement

--- a/src/main/scala/wdlTools/syntax/v2/ConcreteSyntax.scala
+++ b/src/main/scala/wdlTools/syntax/v2/ConcreteSyntax.scala
@@ -14,72 +14,75 @@ object ConcreteSyntax {
 
   // type system
   sealed trait Type extends Element
-  case class TypeOptional(t: Type, loc: SourceLocation) extends Type
-  case class TypeArray(t: Type, nonEmpty: Boolean, loc: SourceLocation) extends Type
-  case class TypeMap(k: Type, v: Type, loc: SourceLocation) extends Type
-  case class TypePair(l: Type, r: Type, loc: SourceLocation) extends Type
-  case class TypeString(loc: SourceLocation) extends Type
-  case class TypeFile(loc: SourceLocation) extends Type
-  case class TypeDirectory(loc: SourceLocation) extends Type
-  case class TypeBoolean(loc: SourceLocation) extends Type
-  case class TypeInt(loc: SourceLocation) extends Type
-  case class TypeFloat(loc: SourceLocation) extends Type
-  case class TypeIdentifier(id: String, loc: SourceLocation) extends Type
-  case class StructMember(name: String, wdlType: Type, loc: SourceLocation) extends Element
-  case class TypeStruct(name: String, members: Vector[StructMember], loc: SourceLocation)
+  case class TypeOptional(t: Type)(val loc: SourceLocation) extends Type
+  case class TypeArray(t: Type, nonEmpty: Boolean)(val loc: SourceLocation) extends Type
+  case class TypeMap(k: Type, v: Type)(val loc: SourceLocation) extends Type
+  case class TypePair(l: Type, r: Type)(val loc: SourceLocation) extends Type
+  case class TypeString()(val loc: SourceLocation) extends Type
+  case class TypeFile()(val loc: SourceLocation) extends Type
+  case class TypeDirectory()(val loc: SourceLocation) extends Type
+  case class TypeBoolean()(val loc: SourceLocation) extends Type
+  case class TypeInt()(val loc: SourceLocation) extends Type
+  case class TypeFloat()(val loc: SourceLocation) extends Type
+  case class TypeIdentifier(id: String)(val loc: SourceLocation) extends Type
+  case class StructMember(name: String, wdlType: Type)(val loc: SourceLocation) extends Element
+  case class TypeStruct(name: String, members: Vector[StructMember])(val loc: SourceLocation)
       extends Type
       with DocumentElement
 
   // expressions
   sealed trait Expr extends Element
-  case class ExprNone(loc: SourceLocation) extends Expr
-  case class ExprString(value: String, loc: SourceLocation) extends Expr
-  case class ExprBoolean(value: Boolean, loc: SourceLocation) extends Expr
-  case class ExprInt(value: Long, loc: SourceLocation) extends Expr
-  case class ExprFloat(value: Double, loc: SourceLocation) extends Expr
+  case class ExprNone()(val loc: SourceLocation) extends Expr
+  case class ExprString(value: String)(val loc: SourceLocation) extends Expr
+  case class ExprBoolean(value: Boolean)(val loc: SourceLocation) extends Expr
+  case class ExprInt(value: Long)(val loc: SourceLocation) extends Expr
+  case class ExprFloat(value: Double)(val loc: SourceLocation) extends Expr
 
   // represents strings with interpolation.
   // For example:
   //  "some string part ~{ident + ident} some string part after"
-  case class ExprCompoundString(value: Vector[Expr], loc: SourceLocation) extends Expr
-  case class ExprMember(key: Expr, value: Expr, loc: SourceLocation) extends Expr
-  case class ExprMapLiteral(value: Vector[ExprMember], loc: SourceLocation) extends Expr
-  case class ExprObjectLiteral(value: Vector[ExprMember], loc: SourceLocation) extends Expr
-  case class ExprStructLiteral(name: String, members: Vector[ExprMember], loc: SourceLocation)
+  case class ExprCompoundString(value: Vector[Expr])(val loc: SourceLocation) extends Expr
+  case class ExprMember(key: Expr, value: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprMapLiteral(value: Vector[ExprMember])(val loc: SourceLocation) extends Expr
+  case class ExprObjectLiteral(value: Vector[ExprMember])(val loc: SourceLocation) extends Expr
+  case class ExprStructLiteral(name: String, members: Vector[ExprMember])(val loc: SourceLocation)
       extends Expr
-  case class ExprArrayLiteral(value: Vector[Expr], loc: SourceLocation) extends Expr
+  case class ExprArrayLiteral(value: Vector[Expr])(val loc: SourceLocation) extends Expr
 
-  case class ExprIdentifier(id: String, loc: SourceLocation) extends Expr
+  case class ExprIdentifier(id: String)(val loc: SourceLocation) extends Expr
 
-  case class ExprUnaryPlus(value: Expr, loc: SourceLocation) extends Expr
-  case class ExprUnaryMinus(value: Expr, loc: SourceLocation) extends Expr
-  case class ExprLor(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprLand(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprNegate(value: Expr, loc: SourceLocation) extends Expr
-  case class ExprEqeq(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprLt(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprGte(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprNeq(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprLte(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprGt(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprAdd(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprSub(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprMod(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprMul(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprDivide(a: Expr, b: Expr, loc: SourceLocation) extends Expr
-  case class ExprPair(l: Expr, r: Expr, loc: SourceLocation) extends Expr
-  case class ExprAt(array: Expr, index: Expr, loc: SourceLocation) extends Expr
-  case class ExprApply(funcName: String, elements: Vector[Expr], loc: SourceLocation) extends Expr
-  case class ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr, loc: SourceLocation)
+  case class ExprUnaryPlus(value: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprUnaryMinus(value: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprLor(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprLand(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprNegate(value: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprEqeq(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprLt(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprGte(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprNeq(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprLte(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprGt(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprAdd(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprSub(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprMod(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprMul(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprDivide(a: Expr, b: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprPair(l: Expr, r: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprAt(array: Expr, index: Expr)(val loc: SourceLocation) extends Expr
+  case class ExprApply(funcName: String, elements: Vector[Expr])(val loc: SourceLocation)
       extends Expr
-  case class ExprGetName(e: Expr, id: String, loc: SourceLocation) extends Expr
+  case class ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr)(val loc: SourceLocation)
+      extends Expr
+  case class ExprGetName(e: Expr, id: String)(val loc: SourceLocation) extends Expr
 
-  case class Declaration(name: String, wdlType: Type, expr: Option[Expr], loc: SourceLocation)
+  case class Declaration(name: String, wdlType: Type, expr: Option[Expr])(val loc: SourceLocation)
       extends WorkflowElement
 
   // sections
-  case class InputSection(declarations: Vector[Declaration], loc: SourceLocation) extends Element
-  case class OutputSection(declarations: Vector[Declaration], loc: SourceLocation) extends Element
+  case class InputSection(declarations: Vector[Declaration])(val loc: SourceLocation)
+      extends Element
+  case class OutputSection(declarations: Vector[Declaration])(val loc: SourceLocation)
+      extends Element
 
   // A command can be simple, with just one continuous string:
   //
@@ -94,38 +97,36 @@ object ConcreteSyntax {
   //     ls ~{input_file}
   //     echo ~{input_string}
   // >>>
-  case class CommandSection(parts: Vector[Expr], loc: SourceLocation) extends Element
+  case class CommandSection(parts: Vector[Expr])(val loc: SourceLocation) extends Element
 
-  case class RuntimeKV(id: String, expr: Expr, loc: SourceLocation) extends Element
-  case class RuntimeSection(kvs: Vector[RuntimeKV], loc: SourceLocation) extends Element
+  case class RuntimeKV(id: String, expr: Expr)(val loc: SourceLocation) extends Element
+  case class RuntimeSection(kvs: Vector[RuntimeKV])(val loc: SourceLocation) extends Element
 
   // A specialized JSON-like object language for meta values only.
   sealed trait MetaValue extends Element
-  case class MetaValueNull(loc: SourceLocation) extends MetaValue
-  case class MetaValueBoolean(value: Boolean, loc: SourceLocation) extends MetaValue
-  case class MetaValueInt(value: Long, loc: SourceLocation) extends MetaValue
-  case class MetaValueFloat(value: Double, loc: SourceLocation) extends MetaValue
-  case class MetaValueString(value: String, loc: SourceLocation) extends MetaValue
-  case class MetaValueObject(value: Vector[MetaKV], loc: SourceLocation) extends MetaValue
-  case class MetaValueArray(value: Vector[MetaValue], loc: SourceLocation) extends MetaValue
+  case class MetaValueNull()(val loc: SourceLocation) extends MetaValue
+  case class MetaValueBoolean(value: Boolean)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueInt(value: Long)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueFloat(value: Double)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueString(value: String)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueObject(value: Vector[MetaKV])(val loc: SourceLocation) extends MetaValue
+  case class MetaValueArray(value: Vector[MetaValue])(val loc: SourceLocation) extends MetaValue
   // meta section
-  case class MetaKV(id: String, value: MetaValue, loc: SourceLocation) extends Element
-  case class ParameterMetaSection(kvs: Vector[MetaKV], loc: SourceLocation) extends Element
-  case class MetaSection(kvs: Vector[MetaKV], loc: SourceLocation) extends Element
+  case class MetaKV(id: String, value: MetaValue)(val loc: SourceLocation) extends Element
+  case class ParameterMetaSection(kvs: Vector[MetaKV])(val loc: SourceLocation) extends Element
+  case class MetaSection(kvs: Vector[MetaKV])(val loc: SourceLocation) extends Element
   // hints section
-  case class HintsSection(kvs: Vector[MetaKV], loc: SourceLocation) extends Element
+  case class HintsSection(kvs: Vector[MetaKV])(val loc: SourceLocation) extends Element
 
   // imports
-  case class ImportAddr(value: String, loc: SourceLocation) extends Element
-  case class ImportName(value: String, loc: SourceLocation) extends Element
-  case class ImportAlias(id1: String, id2: String, loc: SourceLocation) extends Element
+  case class ImportAddr(value: String)(val loc: SourceLocation) extends Element
+  case class ImportName(value: String)(val loc: SourceLocation) extends Element
+  case class ImportAlias(id1: String, id2: String)(val loc: SourceLocation) extends Element
 
   // import statement as read from the document
-  case class ImportDoc(name: Option[ImportName],
-                       aliases: Vector[ImportAlias],
-                       addr: ImportAddr,
-                       loc: SourceLocation)
-      extends DocumentElement
+  case class ImportDoc(name: Option[ImportName], aliases: Vector[ImportAlias], addr: ImportAddr)(
+      val loc: SourceLocation
+  ) extends DocumentElement
 
   // top level definitions
   case class Task(name: String,
@@ -136,26 +137,22 @@ object ConcreteSyntax {
                   meta: Option[MetaSection],
                   parameterMeta: Option[ParameterMetaSection],
                   runtime: Option[RuntimeSection],
-                  hints: Option[HintsSection],
-                  loc: SourceLocation)
+                  hints: Option[HintsSection])(val loc: SourceLocation)
       extends DocumentElement
 
-  case class CallAlias(name: String, loc: SourceLocation) extends Element
-  case class CallAfter(name: String, loc: SourceLocation) extends Element
-  case class CallInput(name: String, expr: Expr, loc: SourceLocation) extends Element
-  case class CallInputs(value: Vector[CallInput], loc: SourceLocation) extends Element
+  case class CallAlias(name: String)(val loc: SourceLocation) extends Element
+  case class CallAfter(name: String)(val loc: SourceLocation) extends Element
+  case class CallInput(name: String, expr: Expr)(val loc: SourceLocation) extends Element
+  case class CallInputs(value: Vector[CallInput])(val loc: SourceLocation) extends Element
   case class Call(name: String,
                   alias: Option[CallAlias],
                   afters: Vector[CallAfter],
-                  inputs: Option[CallInputs],
-                  loc: SourceLocation)
+                  inputs: Option[CallInputs])(val loc: SourceLocation)
       extends WorkflowElement
-  case class Scatter(identifier: String,
-                     expr: Expr,
-                     body: Vector[WorkflowElement],
-                     loc: SourceLocation)
-      extends WorkflowElement
-  case class Conditional(expr: Expr, body: Vector[WorkflowElement], loc: SourceLocation)
+  case class Scatter(identifier: String, expr: Expr, body: Vector[WorkflowElement])(
+      val loc: SourceLocation
+  ) extends WorkflowElement
+  case class Conditional(expr: Expr, body: Vector[WorkflowElement])(val loc: SourceLocation)
       extends WorkflowElement
 
   case class Workflow(name: String,
@@ -163,16 +160,14 @@ object ConcreteSyntax {
                       output: Option[OutputSection],
                       meta: Option[MetaSection],
                       parameterMeta: Option[ParameterMetaSection],
-                      body: Vector[WorkflowElement],
-                      loc: SourceLocation)
+                      body: Vector[WorkflowElement])(val loc: SourceLocation)
       extends Element
 
-  case class Version(value: WdlVersion = WdlVersion.V2, loc: SourceLocation) extends Element
+  case class Version(value: WdlVersion = WdlVersion.V2)(val loc: SourceLocation) extends Element
   case class Document(source: FileNode,
                       version: Version,
                       elements: Vector[DocumentElement],
                       workflow: Option[Workflow],
-                      loc: SourceLocation,
-                      comments: CommentMap)
+                      comments: CommentMap)(val loc: SourceLocation)
       extends Element
 }

--- a/src/main/scala/wdlTools/syntax/v2/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/v2/ParseAll.scala
@@ -145,7 +145,7 @@ case class ParseAll(followImports: Boolean = false,
           }
           AST.ExprApply(e.funcName, e.elements.map(translateExpr))(e.loc)
         case e: CST.ExprGetName =>
-          AST.ExprGetName(translateExpr(e), e.id)(e.loc)
+          AST.ExprGetName(translateExpr(e.expr), e.id)(e.loc)
 
         case other =>
           throw new Exception(s"invalid concrete syntax element ${other}")

--- a/src/main/scala/wdlTools/syntax/v2/ParseAll.scala
+++ b/src/main/scala/wdlTools/syntax/v2/ParseAll.scala
@@ -17,117 +17,135 @@ case class ParseAll(followImports: Boolean = false,
   private case class Translator(docSource: FileNode) {
     def translateType(t: CST.Type): AST.Type = {
       t match {
-        case CST.TypeOptional(t, loc) =>
-          AST.TypeOptional(translateType(t), loc)
-        case CST.TypeArray(t, nonEmpty, loc) =>
-          AST.TypeArray(translateType(t), nonEmpty, loc)
-        case CST.TypeMap(k, v, loc) =>
-          AST.TypeMap(translateType(k), translateType(v), loc)
-        case CST.TypePair(l, r, loc) =>
-          AST.TypePair(translateType(l), translateType(r), loc)
-        case CST.TypeString(loc)         => AST.TypeString(loc)
-        case CST.TypeFile(loc)           => AST.TypeFile(loc)
-        case CST.TypeDirectory(loc)      => AST.TypeDirectory(loc)
-        case CST.TypeBoolean(loc)        => AST.TypeBoolean(loc)
-        case CST.TypeInt(loc)            => AST.TypeInt(loc)
-        case CST.TypeFloat(loc)          => AST.TypeFloat(loc)
-        case CST.TypeIdentifier(id, loc) => AST.TypeIdentifier(id, loc)
-        case CST.TypeStruct(name, members, loc) =>
-          AST.TypeStruct(name, members.map {
-            case CST.StructMember(name, t, text) =>
-              AST.StructMember(name, translateType(t), text)
-          }, loc)
+        case t: CST.TypeOptional =>
+          AST.TypeOptional(translateType(t.t))(t.loc)
+        case t: CST.TypeArray =>
+          AST.TypeArray(translateType(t.t), t.nonEmpty)(t.loc)
+        case t: CST.TypeMap =>
+          AST.TypeMap(translateType(t.k), translateType(t.v))(t.loc)
+        case t: CST.TypePair =>
+          AST.TypePair(translateType(t.l), translateType(t.r))(t.loc)
+        case t: CST.TypeString     => AST.TypeString()(t.loc)
+        case t: CST.TypeFile       => AST.TypeFile()(t.loc)
+        case t: CST.TypeDirectory  => AST.TypeDirectory()(t.loc)
+        case t: CST.TypeBoolean    => AST.TypeBoolean()(t.loc)
+        case t: CST.TypeInt        => AST.TypeInt()(t.loc)
+        case t: CST.TypeFloat      => AST.TypeFloat()(t.loc)
+        case t: CST.TypeIdentifier => AST.TypeIdentifier(t.id)(t.loc)
+        case t: CST.TypeStruct =>
+          AST.TypeStruct(t.name, t.members.map { member: CST.StructMember =>
+            AST.StructMember(member.name, translateType(member.wdlType))(member.loc)
+          })(t.loc)
       }
     }
 
     def translateExpr(e: CST.Expr): AST.Expr = {
       e match {
         // value
-        case CST.ExprNone(loc)           => AST.ValueNone(loc)
-        case CST.ExprString(value, loc)  => AST.ValueString(value, loc)
-        case CST.ExprBoolean(value, loc) => AST.ValueBoolean(value, loc)
-        case CST.ExprInt(value, loc)     => AST.ValueInt(value, loc)
-        case CST.ExprFloat(value, loc)   => AST.ValueFloat(value, loc)
+        case e: CST.ExprNone    => AST.ValueNone()(e.loc)
+        case e: CST.ExprString  => AST.ValueString(e.value)(e.loc)
+        case e: CST.ExprBoolean => AST.ValueBoolean(e.value)(e.loc)
+        case e: CST.ExprInt     => AST.ValueInt(e.value)(e.loc)
+        case e: CST.ExprFloat   => AST.ValueFloat(e.value)(e.loc)
 
         // compound values
-        case CST.ExprIdentifier(id, loc) => AST.ExprIdentifier(id, loc)
-        case CST.ExprCompoundString(parts, loc) =>
-          AST.ExprCompoundString(parts.map(translateExpr), loc)
-        case CST.ExprPair(left, right, loc) =>
-          AST.ExprPair(translateExpr(left), translateExpr(right), loc)
-        case CST.ExprArrayLiteral(array, loc) =>
-          AST.ExprArray(array.map(translateExpr), loc)
-        case CST.ExprMapLiteral(members, loc) =>
-          AST.ExprMap(members.map { item =>
-            AST.ExprMember(translateExpr(item.key), translateExpr(item.value), item.loc)
-          }, loc)
-        case CST.ExprObjectLiteral(members, loc) =>
-          AST.ExprObject(members.map { member =>
-            AST.ExprMember(translateExpr(member.key), translateExpr(member.value), member.loc)
-          }, loc)
-        case CST.ExprStructLiteral(name, members, loc) =>
-          AST.ExprStruct(name, members.map { member =>
-            AST.ExprMember(translateExpr(member.key), translateExpr(member.value), member.loc)
-          }, loc)
+        case e: CST.ExprIdentifier => AST.ExprIdentifier(e.id)(e.loc)
+        case e: CST.ExprCompoundString =>
+          AST.ExprCompoundString(e.value.map(translateExpr))(e.loc)
+        case e: CST.ExprPair =>
+          AST.ExprPair(translateExpr(e.l), translateExpr(e.r))(e.loc)
+        case e: CST.ExprArrayLiteral =>
+          AST.ExprArray(e.value.map(translateExpr))(e.loc)
+        case e: CST.ExprMapLiteral =>
+          AST.ExprMap(e.value.map { item =>
+            AST.ExprMember(translateExpr(item.key), translateExpr(item.value))(item.loc)
+          })(e.loc)
+        case e: CST.ExprObjectLiteral =>
+          AST.ExprObject(e.value.map { member =>
+            AST.ExprMember(translateExpr(member.key), translateExpr(member.value))(member.loc)
+          })(e.loc)
+        case e: CST.ExprStructLiteral =>
+          AST.ExprStruct(e.name, e.members.map { member =>
+            AST.ExprMember(translateExpr(member.key), translateExpr(member.value))(member.loc)
+          })(e.loc)
 
         // operators on one argument
-        case CST.ExprUnaryPlus(value, loc) =>
-          AST.ExprApply(Operator.UnaryPlus.name, Vector(translateExpr(value)), loc)
-        case CST.ExprUnaryMinus(value, loc) =>
-          AST.ExprApply(Operator.UnaryMinus.name, Vector(translateExpr(value)), loc)
-        case CST.ExprNegate(value, loc) =>
-          AST.ExprApply(Operator.LogicalNot.name, Vector(translateExpr(value)), loc)
+        case e: CST.ExprUnaryPlus =>
+          AST.ExprApply(Operator.UnaryPlus.name, Vector(translateExpr(e.value)))(e.loc)
+        case e: CST.ExprUnaryMinus =>
+          AST.ExprApply(Operator.UnaryMinus.name, Vector(translateExpr(e.value)))(e.loc)
+        case e: CST.ExprNegate =>
+          AST.ExprApply(Operator.LogicalNot.name, Vector(translateExpr(e.value)))(e.loc)
 
         // operators on two arguments
-        case CST.ExprLor(a, b, loc) =>
-          AST.ExprApply(Operator.LogicalOr.name, Vector(translateExpr(a), translateExpr(b)), loc)
-        case CST.ExprLand(a, b, loc) =>
-          AST.ExprApply(Operator.LogicalAnd.name, Vector(translateExpr(a), translateExpr(b)), loc)
-        case CST.ExprEqeq(a, b, loc) =>
-          AST.ExprApply(Operator.Equality.name, Vector(translateExpr(a), translateExpr(b)), loc)
-        case CST.ExprNeq(a, b, loc) =>
-          AST.ExprApply(Operator.Inequality.name, Vector(translateExpr(a), translateExpr(b)), loc)
-        case CST.ExprLt(a, b, loc) =>
-          AST.ExprApply(Operator.LessThan.name, Vector(translateExpr(a), translateExpr(b)), loc)
-        case CST.ExprLte(a, b, loc) =>
+        case e: CST.ExprLor =>
+          AST.ExprApply(Operator.LogicalOr.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprLand =>
+          AST.ExprApply(Operator.LogicalAnd.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprEqeq =>
+          AST.ExprApply(Operator.Equality.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprNeq =>
+          AST.ExprApply(Operator.Inequality.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprLt =>
+          AST.ExprApply(Operator.LessThan.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprLte =>
           AST.ExprApply(Operator.LessThanOrEqual.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        loc)
-        case CST.ExprGt(a, b, loc) =>
-          AST.ExprApply(Operator.GreaterThan.name, Vector(translateExpr(a), translateExpr(b)), loc)
-        case CST.ExprGte(a, b, loc) =>
+                        Vector(translateExpr(e.a), translateExpr(e.b)))(e.loc)
+        case e: CST.ExprGt =>
+          AST.ExprApply(Operator.GreaterThan.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprGte =>
           AST.ExprApply(Operator.GreaterThanOrEqual.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        loc)
-        case CST.ExprAdd(a, b, loc) =>
-          AST.ExprApply(Operator.Addition.name, Vector(translateExpr(a), translateExpr(b)), loc)
-        case CST.ExprSub(a, b, loc) =>
-          AST.ExprApply(Operator.Subtraction.name, Vector(translateExpr(a), translateExpr(b)), loc)
-        case CST.ExprMul(a, b, loc) =>
+                        Vector(translateExpr(e.a), translateExpr(e.b)))(e.loc)
+        case e: CST.ExprAdd =>
+          AST.ExprApply(Operator.Addition.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprSub =>
+          AST.ExprApply(Operator.Subtraction.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprMul =>
           AST.ExprApply(Operator.Multiplication.name,
-                        Vector(translateExpr(a), translateExpr(b)),
-                        loc)
-        case CST.ExprDivide(a, b, loc) =>
-          AST.ExprApply(Operator.Division.name, Vector(translateExpr(a), translateExpr(b)), loc)
-        case CST.ExprMod(a, b, loc) =>
-          AST.ExprApply(Operator.Remainder.name, Vector(translateExpr(a), translateExpr(b)), loc)
+                        Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprDivide =>
+          AST.ExprApply(Operator.Division.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
+        case e: CST.ExprMod =>
+          AST.ExprApply(Operator.Remainder.name, Vector(translateExpr(e.a), translateExpr(e.b)))(
+              e.loc
+          )
 
         // Access an array element at [index]
-        case CST.ExprAt(array, index, loc) =>
-          AST.ExprAt(translateExpr(array), translateExpr(index), loc)
+        case e: CST.ExprAt =>
+          AST.ExprAt(translateExpr(e.array), translateExpr(e.index))(e.loc)
 
-        case CST.ExprIfThenElse(cond, tBranch, fBranch, loc) =>
-          AST.ExprIfThenElse(translateExpr(cond),
-                             translateExpr(tBranch),
-                             translateExpr(fBranch),
-                             loc)
-        case CST.ExprApply(funcName, elements, loc) =>
-          if (Operator.All.contains(funcName)) {
-            throw new SyntaxException(s"${funcName} is reserved and not a valid function name", loc)
+        case e: CST.ExprIfThenElse =>
+          AST.ExprIfThenElse(translateExpr(e.cond),
+                             translateExpr(e.tBranch),
+                             translateExpr(e.fBranch))(e.loc)
+        case e: CST.ExprApply =>
+          if (Operator.All.contains(e.funcName)) {
+            throw new SyntaxException(s"${e.funcName} is reserved and not a valid function name",
+                                      e.loc)
           }
-          AST.ExprApply(funcName, elements.map(translateExpr), loc)
-        case CST.ExprGetName(e, id, loc) =>
-          AST.ExprGetName(translateExpr(e), id, loc)
+          AST.ExprApply(e.funcName, e.elements.map(translateExpr))(e.loc)
+        case e: CST.ExprGetName =>
+          AST.ExprGetName(translateExpr(e), e.id)(e.loc)
 
         case other =>
           throw new Exception(s"invalid concrete syntax element ${other}")
@@ -143,18 +161,17 @@ case class ParseAll(followImports: Boolean = false,
     private def translateMetaValue(value: CST.MetaValue): AST.MetaValue = {
       value match {
         // values
-        case CST.MetaValueString(value, loc)  => AST.MetaValueString(value, loc)
-        case CST.MetaValueBoolean(value, loc) => AST.MetaValueBoolean(value, loc)
-        case CST.MetaValueInt(value, loc)     => AST.MetaValueInt(value, loc)
-        case CST.MetaValueFloat(value, loc)   => AST.MetaValueFloat(value, loc)
-        case CST.MetaValueNull(loc)           => AST.MetaValueNull(loc)
-        case CST.MetaValueArray(vec, loc) =>
-          AST.MetaValueArray(vec.map(translateMetaValue), loc)
-        case CST.MetaValueObject(m, loc) =>
-          AST.MetaValueObject(m.map {
-            case CST.MetaKV(fieldName: String, v, text) =>
-              AST.MetaKV(fieldName, translateMetaValue(v), text)
-          }, loc)
+        case v: CST.MetaValueString  => AST.MetaValueString(v.value)(v.loc)
+        case v: CST.MetaValueBoolean => AST.MetaValueBoolean(v.value)(v.loc)
+        case v: CST.MetaValueInt     => AST.MetaValueInt(v.value)(v.loc)
+        case v: CST.MetaValueFloat   => AST.MetaValueFloat(v.value)(v.loc)
+        case v: CST.MetaValueNull    => AST.MetaValueNull()(v.loc)
+        case v: CST.MetaValueArray =>
+          AST.MetaValueArray(v.value.map(translateMetaValue))(v.loc)
+        case v: CST.MetaValueObject =>
+          AST.MetaValueObject(v.value.map { kv: CST.MetaKV =>
+            AST.MetaKV(kv.id, translateMetaValue(kv.value))(kv.loc)
+          })(v.loc)
         case other =>
           throw new SyntaxException("illegal expression in meta section", other.loc)
       }
@@ -163,26 +180,25 @@ case class ParseAll(followImports: Boolean = false,
     private def translateInputSection(
         inp: CST.InputSection
     ): AST.InputSection = {
-      AST.InputSection(inp.declarations.map(translateDeclaration), inp.loc)
+      AST.InputSection(inp.declarations.map(translateDeclaration))(inp.loc)
     }
 
     private def translateOutputSection(
         output: CST.OutputSection
     ): AST.OutputSection = {
-      AST.OutputSection(output.declarations.map(translateDeclaration), output.loc)
+      AST.OutputSection(output.declarations.map(translateDeclaration))(output.loc)
     }
 
     private def translateCommandSection(
         cs: CST.CommandSection
     ): AST.CommandSection = {
-      AST.CommandSection(cs.parts.map(translateExpr), cs.loc)
+      AST.CommandSection(cs.parts.map(translateExpr))(cs.loc)
     }
 
     private def translateDeclaration(decl: CST.Declaration): AST.Declaration = {
-      AST.Declaration(decl.name,
-                      translateType(decl.wdlType),
-                      decl.expr.map(translateExpr),
-                      decl.loc)
+      AST.Declaration(decl.name, translateType(decl.wdlType), decl.expr.map(translateExpr))(
+          decl.loc
+      )
     }
 
     private def translateMetaKVs(kvs: Vector[CST.MetaKV],
@@ -197,26 +213,26 @@ case class ParseAll(followImports: Boolean = false,
                      |is overridden by later value ${metaValue}""".stripMargin.replaceAll("\n", " ")
               )
             }
-            accu + (kv.id -> AST.MetaKV(kv.id, metaValue, kv.loc))
+            accu + (kv.id -> AST.MetaKV(kv.id, metaValue)(kv.loc))
         }
         .values
         .toVector
     }
 
     private def translateMetaSection(meta: CST.MetaSection): AST.MetaSection = {
-      AST.MetaSection(translateMetaKVs(meta.kvs, "meta"), meta.loc)
+      AST.MetaSection(translateMetaKVs(meta.kvs, "meta"))(meta.loc)
     }
 
     private def translateParameterMetaSection(
         paramMeta: CST.ParameterMetaSection
     ): AST.ParameterMetaSection = {
-      AST.ParameterMetaSection(translateMetaKVs(paramMeta.kvs, "parameter_meta"), paramMeta.loc)
+      AST.ParameterMetaSection(translateMetaKVs(paramMeta.kvs, "parameter_meta"))(paramMeta.loc)
     }
 
     private def translateHintsSection(
         hints: CST.HintsSection
     ): AST.HintsSection = {
-      AST.HintsSection(translateMetaKVs(hints.kvs, "hints"), hints.loc)
+      AST.HintsSection(translateMetaKVs(hints.kvs, "hints"))(hints.loc)
     }
 
     private def translateRuntimeSection(
@@ -225,17 +241,18 @@ case class ParseAll(followImports: Boolean = false,
       AST.RuntimeSection(
           runtime.kvs
             .foldLeft(TreeSeqMap.empty[String, AST.RuntimeKV]) {
-              case (accu, CST.RuntimeKV(id, expr, text)) =>
-                val tExpr = translateExpr(expr)
-                if (accu.contains(id)) {
+              case (accu, kv: CST.RuntimeKV) =>
+                val tExpr = translateExpr(kv.expr)
+                if (accu.contains(kv.id)) {
                   logger.warning(
-                      s"duplicate runtime key ${id}: earlier value ${accu(id)} is overridden by later value ${tExpr}"
+                      s"duplicate runtime key ${kv.id}: earlier value ${accu(kv.id)} is overridden by later value ${tExpr}"
                   )
                 }
-                accu + (id -> AST.RuntimeKV(id, tExpr, text))
+                accu + (kv.id -> AST.RuntimeKV(kv.id, tExpr)(kv.loc))
             }
             .values
-            .toVector,
+            .toVector
+      )(
           runtime.loc
       )
     }
@@ -244,34 +261,38 @@ case class ParseAll(followImports: Boolean = false,
         elem: CST.WorkflowElement
     ): AST.WorkflowElement = {
       elem match {
-        case CST.Declaration(name, wdlType, expr, text) =>
-          AST.Declaration(name, translateType(wdlType), expr.map(translateExpr), text)
-
-        case CST.Call(name, alias, afters, inputs, text) =>
-          AST.Call(
-              name,
-              alias.map {
-                case CST.CallAlias(callName, callText) =>
-                  AST.CallAlias(callName, callText)
-              },
-              afters.map {
-                case CST.CallAfter(afterName, afterText) =>
-                  AST.CallAfter(afterName, afterText)
-              },
-              inputs.map {
-                case CST.CallInputs(inputsMap, inputsText) =>
-                  AST.CallInputs(inputsMap.map { inp =>
-                    AST.CallInput(inp.name, translateExpr(inp.expr), inp.loc)
-                  }, inputsText)
-              },
-              text
+        case decl: CST.Declaration =>
+          AST.Declaration(decl.name, translateType(decl.wdlType), decl.expr.map(translateExpr))(
+              decl.loc
           )
 
-        case CST.Scatter(identifier, expr, body, text) =>
-          AST.Scatter(identifier, translateExpr(expr), body.map(translateWorkflowElement), text)
+        case call: CST.Call =>
+          AST.Call(
+              call.name,
+              call.alias.map { alias: CST.CallAlias =>
+                AST.CallAlias(alias.name)(alias.loc)
+              },
+              call.afters.map { after: CST.CallAfter =>
+                AST.CallAfter(after.name)(after.loc)
+              },
+              call.inputs.map { inputs: CST.CallInputs =>
+                AST.CallInputs(inputs.value.map { inp =>
+                  AST.CallInput(inp.name, translateExpr(inp.expr))(inp.loc)
+                })(inputs.loc)
+              }
+          )(
+              call.loc
+          )
 
-        case CST.Conditional(expr, body, text) =>
-          AST.Conditional(translateExpr(expr), body.map(translateWorkflowElement), text)
+        case scatter: CST.Scatter =>
+          AST.Scatter(scatter.identifier,
+                      translateExpr(scatter.expr),
+                      scatter.body.map(translateWorkflowElement))(scatter.loc)
+
+        case cond: CST.Conditional =>
+          AST.Conditional(translateExpr(cond.expr), cond.body.map(translateWorkflowElement))(
+              cond.loc
+          )
       }
     }
 
@@ -282,34 +303,33 @@ case class ParseAll(followImports: Boolean = false,
           wf.output.map(translateOutputSection),
           wf.meta.map(translateMetaSection),
           wf.parameterMeta.map(translateParameterMetaSection),
-          wf.body.map(translateWorkflowElement),
+          wf.body.map(translateWorkflowElement)
+      )(
           wf.loc
       )
     }
 
     private def translateStruct(struct: CST.TypeStruct): AST.TypeStruct = {
-      AST.TypeStruct(
-          struct.name,
-          struct.members.map {
-            case CST.StructMember(name, t, memberText) =>
-              AST.StructMember(name, translateType(t), memberText)
-          },
+      AST.TypeStruct(struct.name, struct.members.map { member: CST.StructMember =>
+        AST.StructMember(member.name, translateType(member.wdlType))(member.loc)
+      })(
           struct.loc
       )
     }
 
     private def translateImportDoc(importDoc: CST.ImportDoc,
                                    importedDoc: Option[AST.Document]): AST.ImportDoc = {
-      val addrAbst = AST.ImportAddr(importDoc.addr.value, importDoc.loc)
-      val nameAbst = importDoc.name.map {
-        case CST.ImportName(value, text) => AST.ImportName(value, text)
+      val addrAbst = AST.ImportAddr(importDoc.addr.value)(importDoc.loc)
+      val nameAbst = importDoc.name.map { impName: CST.ImportName =>
+        AST.ImportName(impName.value)(impName.loc)
       }
       val aliasesAbst: Vector[AST.ImportAlias] = importDoc.aliases.map {
-        case CST.ImportAlias(x, y, alText) => AST.ImportAlias(x, y, alText)
+        impAlias: CST.ImportAlias =>
+          AST.ImportAlias(impAlias.id1, impAlias.id2)(impAlias.loc)
       }
 
       // Replace the original statement with a new one
-      AST.ImportDoc(nameAbst, aliasesAbst, addrAbst, importedDoc, importDoc.loc)
+      AST.ImportDoc(nameAbst, aliasesAbst, addrAbst, importedDoc)(importDoc.loc)
     }
 
     private def translateTask(task: CST.Task): AST.Task = {
@@ -322,7 +342,8 @@ case class ParseAll(followImports: Boolean = false,
           task.meta.map(translateMetaSection),
           task.parameterMeta.map(translateParameterMetaSection),
           task.runtime.map(translateRuntimeSection),
-          task.hints.map(translateHintsSection),
+          task.hints.map(translateHintsSection)
+      )(
           task.loc
       )
     }
@@ -348,8 +369,8 @@ case class ParseAll(followImports: Boolean = false,
         case other                     => throw new Exception(s"unrecognized document element ${other}")
       }
       val aWf = doc.workflow.map(translateWorkflow)
-      val version = AST.Version(doc.version.value, doc.version.loc)
-      AST.Document(doc.source, version, elems, aWf, doc.loc, doc.comments)
+      val version = AST.Version(doc.version.value)(doc.version.loc)
+      AST.Document(doc.source, version, elems, aWf, doc.comments)(doc.loc)
     }
   }
 

--- a/src/main/scala/wdlTools/syntax/v2/ParseTop.scala
+++ b/src/main/scala/wdlTools/syntax/v2/ParseTop.scala
@@ -16,7 +16,7 @@ case class ParseTop(grammar: WdlV2Grammar) extends WdlV2ParserBaseVisitor[Elemen
 
   private def getIdentifierText(identifier: TerminalNode, ctx: ParserRuleContext): String = {
     if (identifier == null) {
-      throw new SyntaxException("missing identifier")(getSourceLocation(grammar.docSource, ctx))
+      throw new SyntaxException("missing identifier", getSourceLocation(grammar.docSource, ctx))
     }
     identifier.getText
   }
@@ -90,27 +90,29 @@ type_base
 	;
    */
   override def visitType_base(ctx: WdlV2Parser.Type_baseContext): Type = {
-    if (ctx.array_type() != null)
-      return visitArray_type(ctx.array_type())
-    if (ctx.map_type() != null)
-      return visitMap_type(ctx.map_type())
-    if (ctx.pair_type() != null)
-      return visitPair_type(ctx.pair_type())
-    if (ctx.STRING() != null)
-      return TypeString()(getSourceLocation(grammar.docSource, ctx))
-    if (ctx.FILE() != null)
-      return TypeFile()(getSourceLocation(grammar.docSource, ctx))
-    if (ctx.DIRECTORY() != null)
-      return TypeDirectory()(getSourceLocation(grammar.docSource, ctx))
-    if (ctx.BOOLEAN() != null)
-      return TypeBoolean()(getSourceLocation(grammar.docSource, ctx))
-    if (ctx.INT() != null)
-      return TypeInt()(getSourceLocation(grammar.docSource, ctx))
-    if (ctx.FLOAT() != null)
-      return TypeFloat()(getSourceLocation(grammar.docSource, ctx))
-    if (ctx.Identifier() != null)
-      return TypeIdentifier(ctx.getText)(getSourceLocation(grammar.docSource, ctx))
-    throw new SyntaxException("unrecgonized type")(getSourceLocation(grammar.docSource, ctx))
+    if (ctx.array_type() != null) {
+      visitArray_type(ctx.array_type())
+    } else if (ctx.map_type() != null) {
+      visitMap_type(ctx.map_type())
+    } else if (ctx.pair_type() != null) {
+      visitPair_type(ctx.pair_type())
+    } else if (ctx.STRING() != null) {
+      TypeString()(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.FILE() != null) {
+      TypeFile()(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.DIRECTORY() != null) {
+      TypeDirectory()(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.BOOLEAN() != null) {
+      TypeBoolean()(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.INT() != null) {
+      TypeInt()(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.FLOAT() != null) {
+      TypeFloat()(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.Identifier() != null) {
+      TypeIdentifier(ctx.getText)(getSourceLocation(grammar.docSource, ctx))
+    } else {
+      throw new SyntaxException("unrecgonized type", getSourceLocation(grammar.docSource, ctx))
+    }
   }
 
   /*
@@ -119,8 +121,9 @@ wdl_type
   ;
    */
   override def visitWdl_type(ctx: WdlV2Parser.Wdl_typeContext): Type = {
-    if (ctx.type_base == null)
-      throw new SyntaxException("bad type")(getSourceLocation(grammar.docSource, ctx))
+    if (ctx.type_base == null) {
+      throw new SyntaxException("unrecognized type", getSourceLocation(grammar.docSource, ctx))
+    }
     val t = visitType_base(ctx.type_base())
     if (ctx.OPTIONAL() != null) {
       TypeOptional(t)(getSourceLocation(grammar.docSource, ctx))
@@ -133,13 +136,13 @@ wdl_type
 
   override def visitNumber(ctx: WdlV2Parser.NumberContext): Expr = {
     if (ctx.IntLiteral() != null) {
-      return ExprInt(ctx.getText.toLong)(getSourceLocation(grammar.docSource, ctx))
+      ExprInt(ctx.getText.toLong)(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.FloatLiteral() != null) {
+      ExprFloat(ctx.getText.toDouble)(getSourceLocation(grammar.docSource, ctx))
+    } else {
+      throw new SyntaxException(s"unrecognized number ${ctx.getText}",
+                                getSourceLocation(grammar.docSource, ctx))
     }
-    if (ctx.FloatLiteral() != null) {
-      return ExprFloat(ctx.getText.toDouble)(getSourceLocation(grammar.docSource, ctx))
-    }
-    throw new SyntaxException(s"Not an integer nor a float ${ctx.getText}",
-                              getSourceLocation(grammar.docSource, ctx))
   }
 
   private def visitEscapse_sequence(terminalNode: TerminalNode): String = {
@@ -171,7 +174,7 @@ wdl_type
           getSourceLocation(grammar.docSource, ctx)
       )
     } else {
-      throw new SyntaxException(s"invalid string_part ${ctx}",
+      throw new SyntaxException(s"unrecognized string_part ${ctx}",
                                 getSourceLocation(grammar.docSource, ctx))
     }
   }
@@ -239,23 +242,20 @@ string
 	; */
   override def visitPrimitive_literal(ctx: WdlV2Parser.Primitive_literalContext): Expr = {
     if (ctx.NONELITERAL() != null) {
-      return ExprNone()(getSourceLocation(grammar.docSource, ctx))
-    }
-    if (ctx.BoolLiteral() != null) {
+      ExprNone()(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.BoolLiteral() != null) {
       val value = ctx.getText.toLowerCase() == "true"
-      return ExprBoolean(value)(getSourceLocation(grammar.docSource, ctx))
+      ExprBoolean(value)(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.number() != null) {
+      visitNumber(ctx.number())
+    } else if (ctx.string() != null) {
+      visitString(ctx.string())
+    } else if (ctx.Identifier() != null) {
+      ExprIdentifier(ctx.getText)(getSourceLocation(grammar.docSource, ctx))
+    } else {
+      throw new SyntaxException("unrecognized primitive_literal",
+                                getSourceLocation(grammar.docSource, ctx))
     }
-    if (ctx.number() != null) {
-      return visitNumber(ctx.number())
-    }
-    if (ctx.string() != null) {
-      return visitString(ctx.string())
-    }
-    if (ctx.Identifier() != null) {
-      return ExprIdentifier(ctx.getText)(getSourceLocation(grammar.docSource, ctx))
-    }
-    throw new SyntaxException("Not one of four supported variants of primitive_literal",
-                              getSourceLocation(grammar.docSource, ctx))
   }
 
   override def visitLor(ctx: WdlV2Parser.LorContext): Expr = {
@@ -275,6 +275,7 @@ string
     val arg1 = visitExpr_infix3(ctx.expr_infix3())
     ExprEqeq(arg0, arg1)(getSourceLocation(grammar.docSource, ctx))
   }
+
   override def visitLt(ctx: WdlV2Parser.LtContext): Expr = {
     val arg0 = visitExpr_infix2(ctx.expr_infix2())
     val arg1 = visitExpr_infix3(ctx.expr_infix3())
@@ -366,9 +367,10 @@ string
       .toVector
 
     val n = elements.size
-    if (n % 2 != 0)
+    if (n % 2 != 0) {
       throw new SyntaxException("the expressions in a map must come in pairs",
                                 getSourceLocation(grammar.docSource, ctx))
+    }
 
     val m: Vector[ExprMember] = Vector.tabulate(n / 2) { i =>
       val key = elements(2 * i)
@@ -425,13 +427,14 @@ string
   // | (PLUS | MINUS) expr #unarysigned
   override def visitUnarysigned(ctx: WdlV2Parser.UnarysignedContext): Expr = {
     val expr = visitExpr(ctx.expr())
-
-    if (ctx.PLUS() != null)
+    if (ctx.PLUS() != null) {
       ExprUnaryPlus(expr)(getSourceLocation(grammar.docSource, ctx))
-    else if (ctx.MINUS() != null)
+    } else if (ctx.MINUS() != null) {
       ExprUnaryMinus(expr)(getSourceLocation(grammar.docSource, ctx))
-    else
-      throw new SyntaxException("bad unary expression")(getSourceLocation(grammar.docSource, ctx))
+    } else {
+      throw new SyntaxException("unrecognized unary expression",
+                                getSourceLocation(grammar.docSource, ctx))
+    }
   }
 
   // | expr_core LBRACK expr RBRACK #at
@@ -566,7 +569,8 @@ string
       visitChildren(ctx).asInstanceOf[Expr]
     } catch {
       case _: NullPointerException =>
-        throw new SyntaxException("bad expression")(getSourceLocation(grammar.docSource, ctx))
+        throw new SyntaxException("unrecognized expression",
+                                  getSourceLocation(grammar.docSource, ctx))
     }
   }
 
@@ -603,7 +607,7 @@ string
       case left_name: WdlV2Parser.Left_nameContext           => visitLeft_name(left_name)
       case get_name: WdlV2Parser.Get_nameContext             => visitGet_name(get_name)
       case _ =>
-        throw new SyntaxException("bad expression")(getSourceLocation(grammar.docSource, ctx))
+        throw new SyntaxException("bad expression", getSourceLocation(grammar.docSource, ctx))
     }
   }
 
@@ -613,9 +617,10 @@ unbound_decls
 	;
    */
   override def visitUnbound_decls(ctx: WdlV2Parser.Unbound_declsContext): Declaration = {
-    if (ctx.wdl_type() == null)
-      throw new SyntaxException("type missing in declaration",
+    if (ctx.wdl_type() == null) {
+      throw new SyntaxException("unrecognized declaration",
                                 getSourceLocation(grammar.docSource, ctx))
+    }
     val wdlType: Type = visitWdl_type(ctx.wdl_type())
     val name: String = getIdentifierText(ctx.Identifier(), ctx)
     Declaration(name, wdlType, None)(getSourceLocation(grammar.docSource, ctx))
@@ -627,9 +632,10 @@ bound_decls
 	;
    */
   override def visitBound_decls(ctx: WdlV2Parser.Bound_declsContext): Declaration = {
-    if (ctx.wdl_type() == null)
-      throw new SyntaxException("type missing in declaration",
+    if (ctx.wdl_type() == null) {
+      throw new SyntaxException("unrecognized declaration",
                                 getSourceLocation(grammar.docSource, ctx))
+    }
     val wdlType = visitWdl_type(ctx.wdl_type())
     val name: String = getIdentifierText(ctx.Identifier(), ctx)
     if (ctx.expr() == null) {
@@ -647,11 +653,13 @@ any_decls
 	;
    */
   override def visitAny_decls(ctx: WdlV2Parser.Any_declsContext): Declaration = {
-    if (ctx.unbound_decls() != null)
-      return visitUnbound_decls(ctx.unbound_decls())
-    if (ctx.bound_decls() != null)
-      return visitBound_decls(ctx.bound_decls())
-    throw new SyntaxException("bad declaration format")(getSourceLocation(grammar.docSource, ctx))
+    if (ctx.unbound_decls() != null) {
+      visitUnbound_decls(ctx.unbound_decls())
+    } else if (ctx.bound_decls() != null) {
+      visitBound_decls(ctx.bound_decls())
+    } else {
+      throw new SyntaxException("unrecognized format", getSourceLocation(grammar.docSource, ctx))
+    }
   }
 
   /* meta_value
@@ -664,31 +672,26 @@ any_decls
     ; */
   override def visitMeta_value(ctx: WdlV2Parser.Meta_valueContext): MetaValue = {
     if (ctx.MetaNull() != null) {
-      return MetaValueNull()(getSourceLocation(grammar.docSource, ctx))
-    }
-    if (ctx.MetaBool() != null) {
+      MetaValueNull()(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.MetaBool() != null) {
       val value = ctx.getText.toLowerCase() == "true"
-      return MetaValueBoolean(value)(getSourceLocation(grammar.docSource, ctx))
-    }
-    if (ctx.MetaInt() != null) {
-      return MetaValueInt(ctx.MetaInt().getText.toLong)(getSourceLocation(grammar.docSource, ctx))
-    }
-    if (ctx.MetaFloat() != null) {
-      return MetaValueFloat(ctx.MetaFloat().getText.toDouble)(
+      MetaValueBoolean(value)(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.MetaInt() != null) {
+      MetaValueInt(ctx.MetaInt().getText.toLong)(getSourceLocation(grammar.docSource, ctx))
+    } else if (ctx.MetaFloat() != null) {
+      MetaValueFloat(ctx.MetaFloat().getText.toDouble)(
           getSourceLocation(grammar.docSource, ctx)
       )
+    } else if (ctx.meta_string() != null) {
+      visitMeta_string(ctx.meta_string())
+    } else if (ctx.meta_array() != null) {
+      visitMeta_array(ctx.meta_array())
+    } else if (ctx.meta_object() != null) {
+      visitMeta_object(ctx.meta_object())
+    } else {
+      throw new SyntaxException("unrecognized meta_value",
+                                getSourceLocation(grammar.docSource, ctx))
     }
-    if (ctx.meta_string() != null) {
-      return visitMeta_string(ctx.meta_string())
-    }
-    if (ctx.meta_array() != null) {
-      return visitMeta_array(ctx.meta_array())
-    }
-    if (ctx.meta_object() != null) {
-      return visitMeta_object(ctx.meta_object())
-    }
-    throw new SyntaxException("Not one of four supported variants of meta_value",
-                              getSourceLocation(grammar.docSource, ctx))
   }
 
   override def visitMeta_string_part(ctx: WdlV2Parser.Meta_string_partContext): MetaValueString = {
@@ -697,7 +700,7 @@ any_decls
     } else if (ctx.MetaEscStringPart() != null) {
       visitEscapse_sequence(ctx.MetaEscStringPart())
     } else {
-      throw new SyntaxException(s"invalid meta_string_part ${ctx}",
+      throw new SyntaxException(s"unrecognized meta_string_part ${ctx}",
                                 getSourceLocation(grammar.docSource, ctx))
     }
     MetaValueString(text)(getSourceLocation(grammar.docSource, ctx))
@@ -1109,10 +1112,11 @@ task_input
 	: LBRACE call_inputs? RBRACE
 	; */
   override def visitCall_body(ctx: WdlV2Parser.Call_bodyContext): CallInputs = {
-    if (ctx.call_inputs() == null)
+    if (ctx.call_inputs() == null) {
       CallInputs(Vector.empty)(getSourceLocation(grammar.docSource, ctx))
-    else
+    } else {
       visitCall_inputs(ctx.call_inputs())
+    }
   }
 
   /* call
@@ -1205,15 +1209,17 @@ scatter
   override def visitInner_workflow_element(
       ctx: WdlV2Parser.Inner_workflow_elementContext
   ): WorkflowElement = {
-    if (ctx.bound_decls() != null)
+    if (ctx.bound_decls() != null) {
       return visitBound_decls(ctx.bound_decls())
-    if (ctx.call() != null)
+    } else if (ctx.call() != null) {
       return visitCall(ctx.call())
-    if (ctx.scatter() != null)
+    } else if (ctx.scatter() != null) {
       return visitScatter(ctx.scatter())
-    if (ctx.conditional() != null)
+    } else if (ctx.conditional() != null) {
       return visitConditional(ctx.conditional())
-    throw new Exception("sanity")
+    } else {
+      throw new Exception("unrecognized workflow element")
+    }
   }
 
   /*
@@ -1278,7 +1284,7 @@ document_element
 	; */
   override def visitVersion(ctx: WdlV2Parser.VersionContext): Version = {
     if (ctx.ReleaseVersion() == null) {
-      throw new Exception("version not specified")
+      throw new Exception("unrecognized version")
     }
     val value = ctx.ReleaseVersion().getText
     Version(WdlVersion.withName(value))(getSourceLocation(grammar.docSource, ctx))

--- a/src/main/scala/wdlTools/types/TypeContext.scala
+++ b/src/main/scala/wdlTools/types/TypeContext.scala
@@ -139,7 +139,7 @@ case class TypeContext(
         val fqn = namespace + "." + name
         fqn -> wfSig.copy(name = fqn)
       case other =>
-        throw new RuntimeException(s"sanity: ${other.getClass}")
+        throw new RuntimeException(s"unrecognized callable: ${other.getClass}")
     }
 
     // rename the imported structs according to the aliases
@@ -150,7 +150,7 @@ case class TypeContext(
     //     alias GrandChild as GrandChild2
     //
     val aliasMapping: Map[String, String] = typeAliases.map {
-      case AST.ImportAlias(src, dest, _) => src -> dest
+      case AST.ImportAlias(src, dest) => src -> dest
     }.toMap
     val importAliases: Map[String, T_Struct] = importContext.aliases.toMap.map {
       case (name, importedStruct: T_Struct) =>

--- a/src/main/scala/wdlTools/types/TypeInfer.scala
+++ b/src/main/scala/wdlTools/types/TypeInfer.scala
@@ -1289,7 +1289,7 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
     }
 
     val tVersion = TAT.Version(doc.version.value)(doc.version.loc)
-    val tDoc = TAT.Document(doc.source, tVersion, elements, workflow, doc.loc)(doc.comments)
+    val tDoc = TAT.Document(doc.source, tVersion, elements, workflow, doc.comments)(doc.loc)
     (tDoc, finalContext)
   }
 

--- a/src/main/scala/wdlTools/types/TypeInfer.scala
+++ b/src/main/scala/wdlTools/types/TypeInfer.scala
@@ -170,8 +170,7 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
                   loc: SourceLocation): AST.Expr = {
         if (oper.isDefined) {
           AST.ExprApply(oper.get.name,
-                        Vector(AST.ExprArray(exprs, SourceLocation.merge(exprs.map(_.loc)))),
-                        loc)
+                        Vector(AST.ExprArray(exprs)(SourceLocation.merge(exprs.map(_.loc)))))(loc)
         } else if (exprs.size == 1) {
           exprs.head
         } else {
@@ -180,10 +179,10 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
       }
       def inner(expr: AST.Expr): (Vector[AST.Expr], Option[Operator], SourceLocation) = {
         val (outerOper, lhs, rhs, loc) = expr match {
-          case AST.ExprApply(funcName, Vector(lhs, rhs), loc) =>
+          case AST.ExprApply(funcName, Vector(lhs, rhs)) =>
             Operator.Vectorizable.get(funcName) match {
-              case Some(oper) => (oper, lhs, rhs, loc)
-              case _          => return (Vector(expr), None, loc)
+              case Some(oper) => (oper, lhs, rhs, expr.loc)
+              case _          => return (Vector(expr), None, expr.loc)
             }
           case _ => return (Vector(expr), None, expr.loc)
         }
@@ -236,7 +235,7 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
     def nested(nestedExpr: AST.Expr, nestedState: ExprState): TAT.Expr = {
       nestedExpr match {
         // interpolation
-        case AST.ExprCompoundString(vec, loc) =>
+        case e: AST.ExprCompoundString =>
           // if we're not already in a string, being in a ExprCompoundString
           // guarantees that we are
           val nextState = if (nestedState >= ExprState.InString) {
@@ -246,12 +245,12 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
           }
           // All the sub-exressions have to be strings, or coercible to strings
           val initialType: T = T_String
-          val (vec2, wdlType) = vec.foldLeft((Vector.empty[TAT.Expr], initialType)) {
+          val (vec2, wdlType) = e.value.foldLeft((Vector.empty[TAT.Expr], initialType)) {
             case ((v, t), subExpr) =>
               val (e2, t2) = nestedStringExpr(subExpr, nextState, t, initialType)
               (v :+ e2, t2)
           }
-          TAT.ExprCompoundString(vec2, wdlType, loc)
+          TAT.ExprCompoundString(vec2, wdlType)(e.loc)
         case _ =>
           // the next state for any other nested expression - if we're already in a String,
           // then any nested expression must occur within a placeholder
@@ -262,23 +261,23 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
           }
           nestedExpr match {
             // None can be any type optional
-            case AST.ValueNone(loc)           => TAT.ValueNone(T_Optional(T_Any), loc)
-            case AST.ValueBoolean(value, loc) => TAT.ValueBoolean(value, T_Boolean, loc)
-            case AST.ValueInt(value, loc)     => TAT.ValueInt(value, T_Int, loc)
-            case AST.ValueFloat(value, loc)   => TAT.ValueFloat(value, T_Float, loc)
-            case AST.ValueString(value, loc)  => TAT.ValueString(value, T_String, loc)
+            case e: AST.ValueNone    => TAT.ValueNone(T_Optional(T_Any))(e.loc)
+            case e: AST.ValueBoolean => TAT.ValueBoolean(e.value, T_Boolean)(e.loc)
+            case e: AST.ValueInt     => TAT.ValueInt(e.value, T_Int)(e.loc)
+            case e: AST.ValueFloat   => TAT.ValueFloat(e.value, T_Float)(e.loc)
+            case e: AST.ValueString  => TAT.ValueString(e.value, T_String)(e.loc)
 
             // complex types
-            case AST.ExprPair(l, r, loc) =>
-              val l2 = nested(l, nextState)
-              val r2 = nested(r, nextState)
+            case e: AST.ExprPair =>
+              val l2 = nested(e.l, nextState)
+              val r2 = nested(e.r, nextState)
               val t = T_Pair(l2.wdlType, r2.wdlType)
-              TAT.ExprPair(l2, r2, t, loc)
-            case AST.ExprArray(items, loc) if items.isEmpty =>
+              TAT.ExprPair(l2, r2, t)(e.loc)
+            case e: AST.ExprArray if e.value.isEmpty =>
               // The array is empty, we can't tell what the array type is.
-              TAT.ExprArray(Vector.empty, T_Array(T_Any), loc)
-            case AST.ExprArray(items, loc) =>
-              val tItems = items.map(e => nested(e, nextState))
+              TAT.ExprArray(Vector.empty, T_Array(T_Any))(e.loc)
+            case e: AST.ExprArray =>
+              val tItems = e.value.map(e => nested(e, nextState))
               val unifyCtx =
                 UnificationContext(section, inPlaceholder = nextState >= ExprState.InPlaceholder)
               val wdlTypes = tItems.map(_.wdlType)
@@ -289,45 +288,45 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
                 } catch {
                   case _: TypeUnificationException =>
                     handleError(
-                        s"""array ${items} contains multiple incompatible data types 
+                        s"""array ${e.value} contains multiple incompatible data types
                            |${wdlTypes.toSet.mkString(",")}""".stripMargin
                           .replaceAll("\n", " "),
                         nestedExpr.loc
                     )
                     tItems.head.wdlType
                 }
-              TAT.ExprArray(tItems, itemType, loc)
-            case AST.ExprObject(members, loc) =>
-              val tMembers = members
+              TAT.ExprArray(tItems, itemType)(e.loc)
+            case e: AST.ExprObject =>
+              val tMembers = e.value
                 .map {
-                  case AST.ExprMember(key, value, _) =>
+                  case AST.ExprMember(key, value) =>
                     val k = nested(key, nextState)
                     val v = nested(value, nextState)
                     (k, v)
                 }
                 .to(TreeSeqMap)
-              TAT.ExprObject(tMembers, T_Object, loc)
-            case AST.ExprStruct(name, members, loc) =>
-              val tMembers = members
+              TAT.ExprObject(tMembers, T_Object)(e.loc)
+            case e: AST.ExprStruct =>
+              val tMembers = e.members
                 .map {
-                  case AST.ExprMember(key, value, _) =>
+                  case AST.ExprMember(key, value) =>
                     val k = nested(key, nextState)
                     val v = nested(value, nextState)
                     (k, v)
                 }
                 .to(TreeSeqMap)
-              val wdlType = ctx.aliases.get(name) match {
+              val wdlType = ctx.aliases.get(e.name) match {
                 case Some(structType: T_Struct) => structType
                 case _ =>
-                  handleError(s"Struct type ${name} is not defined", nestedExpr.loc)
+                  handleError(s"Struct type ${e.name} is not defined", nestedExpr.loc)
                   T_Object
               }
-              TAT.ExprObject(tMembers, wdlType, loc)
-            case AST.ExprMap(members, loc) if members.isEmpty =>
+              TAT.ExprObject(tMembers, wdlType)(e.loc)
+            case e: AST.ExprMap if e.value.isEmpty =>
               // The key and value types are unknown.
-              TAT.ExprMap(SeqMap.empty, T_Map(T_Any, T_Any), loc)
-            case AST.ExprMap(members, loc) =>
-              val tMembers = members
+              TAT.ExprMap(SeqMap.empty, T_Map(T_Any, T_Any))(e.loc)
+            case e: AST.ExprMap =>
+              val tMembers = e.value
                 .map { item: AST.ExprMember =>
                   val k = nested(item.key, nextState)
                   val v = nested(item.value, nextState)
@@ -337,31 +336,31 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
               // unify the key/value types
               val unifyCtx = UnificationContext(section, nextState >= ExprState.InPlaceholder)
               val (keys, values) = tMembers.unzip
-              val keyType = unifyTypes(keys.map(_.wdlType), "map keys", loc, unifyCtx) match {
+              val keyType = unifyTypes(keys.map(_.wdlType), "map keys", e.loc, unifyCtx) match {
                 case t: T_Primitive => t
                 case t =>
                   handleError(s"Map key type ${t} is not primitive", nestedExpr.loc)
                   t
               }
-              val valueType = unifyTypes(values.map(_.wdlType), "map values", loc, unifyCtx)
-              TAT.ExprMap(tMembers, T_Map(keyType, valueType), loc)
+              val valueType = unifyTypes(values.map(_.wdlType), "map values", e.loc, unifyCtx)
+              TAT.ExprMap(tMembers, T_Map(keyType, valueType))(e.loc)
 
-            case AST.ExprIdentifier(id, loc) =>
+            case e: AST.ExprIdentifier =>
               // an identifier has to be bound to a known type. Lookup the the type,
               // and add it to the expression.
-              val t = ctx.lookup(id, bindings) match {
+              val t = ctx.lookup(e.id, bindings) match {
                 case Some(t) => t
                 case None =>
-                  handleError(s"Identifier ${id} is not defined", nestedExpr.loc)
+                  handleError(s"Identifier ${e.id} is not defined", nestedExpr.loc)
                   T_Any
               }
-              TAT.ExprIdentifier(id, t, loc)
+              TAT.ExprIdentifier(e.id, t)(e.loc)
 
-            case AST.ExprPlaceholder(t, f, sep, default, expr, loc) =>
+            case e: AST.ExprPlaceholder =>
               val unifyCtx = UnificationContext(section, nextState >= ExprState.InPlaceholder)
               val valueExpr = nested(expr, ExprState.InPlaceholder)
 
-              val (defaultExpr, defaultValueType) = default
+              val (defaultExpr, defaultValueType) = e.default
                 .map { d =>
                   val (defaultExpr, defaultType) = nestedStringExpr(d, ExprState.InPlaceholder)
                   val t = TypeUtils.unwrapOptional(valueExpr.wdlType) match {
@@ -372,7 +371,7 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
                       // the value is supposed to be optional but is not - we allow it anyway
                       T_String
                     case T_Array(vt, _)
-                        if sep.isDefined && unify.isCoercibleTo(T_String, vt, unifyCtx) =>
+                        if e.sep.isDefined && unify.isCoercibleTo(T_String, vt, unifyCtx) =>
                       // mixing default and sep - not technically allowed but we support it
                       // since it is used in some "industry standard" workflows
                       T_String
@@ -390,9 +389,9 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
                 }
                 .getOrElse((None, None))
 
-              val tOption = t.map(nestedStringExpr(_, ExprState.InPlaceholder))
-              val fOption = f.map(nestedStringExpr(_, ExprState.InPlaceholder))
-              val sepOption = sep.map(nestedStringExpr(_, ExprState.InPlaceholder))
+              val tOption = e.t.map(nestedStringExpr(_, ExprState.InPlaceholder))
+              val fOption = e.f.map(nestedStringExpr(_, ExprState.InPlaceholder))
+              val sepOption = e.sep.map(nestedStringExpr(_, ExprState.InPlaceholder))
 
               (tOption, fOption, sepOption) match {
                 case (Some((trueExpr, trueType)), Some((falseExpr, falseType)), None) =>
@@ -418,8 +417,7 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
                                       None,
                                       defaultExpr,
                                       valueExpr,
-                                      wdlType,
-                                      loc)
+                                      wdlType)(e.loc)
                 case (None, None, Some((sepExpr, _))) =>
                   val valueType = if (defaultValueType.isDefined) {
                     TypeUtils.unwrapOptional(valueExpr.wdlType)
@@ -443,33 +441,25 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
                     case (t, Some(d)) if t == d => t
                     case _                      => T_String
                   }
-                  TAT.ExprPlaceholder(None,
-                                      None,
-                                      Some(sepExpr),
-                                      defaultExpr,
-                                      valueExpr,
-                                      wdlType,
-                                      loc)
+                  TAT.ExprPlaceholder(None, None, Some(sepExpr), defaultExpr, valueExpr, wdlType)(
+                      e.loc
+                  )
                 case (None, None, None) =>
                   TAT.ExprPlaceholder(None,
                                       None,
                                       None,
                                       defaultExpr,
                                       valueExpr,
-                                      defaultValueType.get,
-                                      loc)
+                                      defaultValueType.get)(e.loc)
                 case _ =>
                   throw new Exception(s"invalid combination of placeholder options: ${nestedExpr}")
               }
 
-            case AST.ExprIfThenElse(cond: AST.Expr,
-                                    trueBranch: AST.Expr,
-                                    falseBranch: AST.Expr,
-                                    loc) =>
+            case e: AST.ExprIfThenElse =>
               // if (x == 1) then "Sunday" else "Weekday"
-              val eCond = nested(cond, nextState)
-              val eTrueBranch = nested(trueBranch, nextState)
-              val eFalseBranch = nested(falseBranch, nextState)
+              val eCond = nested(e.cond, nextState)
+              val eTrueBranch = nested(e.tBranch, nextState)
+              val eFalseBranch = nested(e.fBranch, nextState)
               val t = {
                 if (eCond.wdlType != T_Boolean) {
                   handleError(
@@ -493,12 +483,12 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
                   }
                 }
               }
-              TAT.ExprIfThenElse(eCond, eTrueBranch, eFalseBranch, t, loc)
+              TAT.ExprIfThenElse(eCond, eTrueBranch, eFalseBranch, t)(e.loc)
 
-            case AST.ExprAt(collection: AST.Expr, index: AST.Expr, loc) =>
+            case e: AST.ExprAt =>
               // Access an array element at [index: Int] or a map value at [key: K]
-              val eIndex = nested(index, nextState)
-              val eCollection = nested(collection, nextState)
+              val eIndex = nested(e.index, nextState)
+              val eCollection = nested(e.array, nextState)
               val t = (eIndex.wdlType, eCollection.wdlType) match {
                 case (T_Int, T_Array(elementType, _)) =>
                   elementType
@@ -518,34 +508,34 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
                   handleError(
                       s"""${prettyFormatExpr(eIndex)} is not a valid index for collection 
                          |${prettyFormatExpr(eCollection)}""".stripMargin.replaceAll("\n", " "),
-                      loc
+                      e.loc
                   )
                   eCollection.wdlType
               }
-              TAT.ExprAt(eCollection, eIndex, t, loc)
+              TAT.ExprAt(eCollection, eIndex, t)(e.loc)
 
-            case AST.ExprGetName(expr: AST.Expr, id: String, loc) =>
+            case e: AST.ExprGetName =>
               // Access a field in a struct or an object. For example "x.a" in:
               //   Int z = x.a
-              val e = nested(expr, nextState)
-              val t = typeEvalExprGetName(e, id, ctx)
-              TAT.ExprGetName(e, id, t, loc)
+              val expr = nested(e.e, nextState)
+              val wdlType = typeEvalExprGetName(expr, e.id, ctx)
+              TAT.ExprGetName(expr, e.id, wdlType)(e.loc)
 
             // vectorize any mathematical operations
             case applyExpr: AST.ExprApply if canVectorize(applyExpr) =>
               nested(vectorize(applyExpr), nestedState)
-            case AST.ExprApply(funcName, elements, loc) =>
+            case e: AST.ExprApply =>
               // Apply a standard library function to arguments. For example:
               //   read_int("4")
-              val tElements = elements.map(e => nested(e, nextState))
+              val tElements = e.elements.map(e => nested(e, nextState))
               try {
                 val (outputType, funcSig) =
-                  ctx.stdlib.apply(funcName, tElements.map(_.wdlType), nextState)
-                TAT.ExprApply(funcName, funcSig, tElements, outputType, loc)
+                  ctx.stdlib.apply(e.funcName, tElements.map(_.wdlType), nextState)
+                TAT.ExprApply(e.funcName, funcSig, tElements, outputType)(e.loc)
               } catch {
                 case e: StdlibFunctionException =>
                   handleError(e.getMessage, nestedExpr.loc)
-                  TAT.ValueNone(T_Any, nestedExpr.loc)
+                  TAT.ValueNone(T_Any)(nestedExpr.loc)
               }
           }
       }
@@ -555,17 +545,17 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
 
   private def typeFromAst(t: AST.Type, loc: SourceLocation, ctx: TypeContext): T = {
     t match {
-      case _: AST.TypeBoolean            => T_Boolean
-      case _: AST.TypeInt                => T_Int
-      case _: AST.TypeFloat              => T_Float
-      case _: AST.TypeString             => T_String
-      case _: AST.TypeFile               => T_File
-      case _: AST.TypeDirectory          => T_Directory
-      case AST.TypeOptional(t, _)        => T_Optional(typeFromAst(t, loc, ctx))
-      case AST.TypeArray(t, nonEmpty, _) => T_Array(typeFromAst(t, loc, ctx), nonEmpty = nonEmpty)
-      case AST.TypeMap(k, v, _)          => T_Map(typeFromAst(k, loc, ctx), typeFromAst(v, loc, ctx))
-      case AST.TypePair(l, r, _)         => T_Pair(typeFromAst(l, loc, ctx), typeFromAst(r, loc, ctx))
-      case AST.TypeIdentifier(id, _) =>
+      case _: AST.TypeBoolean         => T_Boolean
+      case _: AST.TypeInt             => T_Int
+      case _: AST.TypeFloat           => T_Float
+      case _: AST.TypeString          => T_String
+      case _: AST.TypeFile            => T_File
+      case _: AST.TypeDirectory       => T_Directory
+      case AST.TypeOptional(t)        => T_Optional(typeFromAst(t, loc, ctx))
+      case AST.TypeArray(t, nonEmpty) => T_Array(typeFromAst(t, loc, ctx), nonEmpty = nonEmpty)
+      case AST.TypeMap(k, v)          => T_Map(typeFromAst(k, loc, ctx), typeFromAst(v, loc, ctx))
+      case AST.TypePair(l, r)         => T_Pair(typeFromAst(l, loc, ctx), typeFromAst(r, loc, ctx))
+      case AST.TypeIdentifier(id) =>
         ctx.aliases.get(id) match {
           case None =>
             handleError(s"struct ${id} has not been defined", loc)
@@ -573,11 +563,11 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
           case Some(struct) => struct
         }
       case _: AST.TypeObject => T_Object
-      case AST.TypeStruct(name, members, _) =>
+      case AST.TypeStruct(name, members) =>
         T_Struct(name,
                  members
                    .map {
-                     case AST.StructMember(name, t2, _) => name -> typeFromAst(t2, loc, ctx)
+                     case AST.StructMember(name, t2) => name -> typeFromAst(t2, loc, ctx)
                    }
                    .to(TreeSeqMap))
     }
@@ -636,10 +626,10 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
   ): (TAT.PrivateVariable, Bindings[String, T]) = {
     translateDeclaration(decl, section, ctx, bindings, canShadow) match {
       case (wdlType, Some(tExpr), newBindings) =>
-        (TAT.PrivateVariable(decl.name, wdlType, tExpr, decl.loc), newBindings)
+        (TAT.PrivateVariable(decl.name, wdlType, tExpr)(decl.loc), newBindings)
       case (wdlType, None, newBindings) =>
         handleError(s"Private variable ${decl.name} must have an expression", decl.loc)
-        (TAT.PrivateVariable(decl.name, wdlType, TAT.ValueNull(wdlType, decl.loc), decl.loc),
+        (TAT.PrivateVariable(decl.name, wdlType, TAT.ValueNull(wdlType)(decl.loc))(decl.loc),
          newBindings)
     }
   }
@@ -661,15 +651,14 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
               translateDeclaration(decl, Section.Input, ctx, bindings)
             val tParam = (wdlType, tExpr) match {
               case (t: WdlTypes.T_Optional, None) =>
-                TAT.OptionalInputParameter(decl.name, t, decl.loc)
+                TAT.OptionalInputParameter(decl.name, t)(decl.loc)
               case (_, None) =>
-                TAT.RequiredInputParameter(decl.name, wdlType, decl.loc)
+                TAT.RequiredInputParameter(decl.name, wdlType)(decl.loc)
               case (t, Some(expr)) =>
                 // drop any optional type wrapper if this is an input with a default value
                 TAT.OverridableInputParameterWithDefault(decl.name,
                                                          TypeUtils.unwrapOptional(t),
-                                                         expr,
-                                                         decl.loc)
+                                                         expr)(decl.loc)
             }
             (tInputParams :+ tParam, names + decl.name, afterBindings)
         }
@@ -700,7 +689,7 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
               translateDeclaration(decl, Section.Output, ctx, bindings, canShadow = true)
             val tOutputParam = tExpr match {
               case Some(tExpr) =>
-                TAT.OutputParameter(decl.name, wdlType, tExpr, decl.loc)
+                TAT.OutputParameter(decl.name, wdlType, tExpr)(decl.loc)
               case _ =>
                 throw new TypeException("Outputs must have expressions", decl.loc)
             }
@@ -714,58 +703,61 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
   private def applyRuntime(rtSection: AST.RuntimeSection, ctx: TypeContext): TAT.RuntimeSection = {
     val restrictions = getRuntimeTypeRestrictions(ctx.version)
     val m = rtSection.kvs
-      .map {
-        case AST.RuntimeKV(id, expr, loc) =>
-          val tExpr = applyExpr(expr, ctx)
-          // if there are type restrictions, check that the type of the expression is coercible to
-          // one of the allowed types
-          if (!restrictions.get(id).forall(_.exists(t => unify.isCoercibleTo(t, tExpr.wdlType)))) {
-            throw new TypeException(
-                s"runtime id ${id} is not coercible to one of the allowed types ${restrictions(id)}",
-                loc
-            )
-          }
-          id -> tExpr
+      .map { kv: AST.RuntimeKV =>
+        val tExpr = applyExpr(kv.expr, ctx)
+        // if there are type restrictions, check that the type of the expression is coercible to
+        // one of the allowed types
+        if (!restrictions
+              .get(kv.id)
+              .forall(_.exists(t => unify.isCoercibleTo(t, tExpr.wdlType)))) {
+          throw new TypeException(
+              s"runtime id ${kv.id} is not coercible to one of the allowed types ${restrictions(kv.id)}",
+              kv.loc
+          )
+        }
+        kv.id -> tExpr
       }
       .to(TreeSeqMap)
-    TAT.RuntimeSection(m, rtSection.loc)
+    TAT.RuntimeSection(m)(rtSection.loc)
   }
 
   // convert the generic expression syntax into a specialized JSON object
   // language for meta values only.
   private def applyMetaValue(expr: AST.MetaValue, ctx: TypeContext): TAT.MetaValue = {
     expr match {
-      case AST.MetaValueNull(loc)           => TAT.MetaValueNull(loc)
-      case AST.MetaValueBoolean(value, loc) => TAT.MetaValueBoolean(value, loc)
-      case AST.MetaValueInt(value, loc)     => TAT.MetaValueInt(value, loc)
-      case AST.MetaValueFloat(value, loc)   => TAT.MetaValueFloat(value, loc)
-      case AST.MetaValueString(value, loc)  => TAT.MetaValueString(value, loc)
-      case AST.MetaValueArray(vec, loc) =>
-        TAT.MetaValueArray(vec.map(applyMetaValue(_, ctx)), loc)
-      case AST.MetaValueObject(members, loc) =>
+      case v: AST.MetaValueNull    => TAT.MetaValueNull()(v.loc)
+      case v: AST.MetaValueBoolean => TAT.MetaValueBoolean(v.value)(v.loc)
+      case v: AST.MetaValueInt     => TAT.MetaValueInt(v.value)(v.loc)
+      case v: AST.MetaValueFloat   => TAT.MetaValueFloat(v.value)(v.loc)
+      case v: AST.MetaValueString  => TAT.MetaValueString(v.value)(v.loc)
+      case v: AST.MetaValueArray =>
+        TAT.MetaValueArray(v.value.map(applyMetaValue(_, ctx)))(v.loc)
+      case v: AST.MetaValueObject =>
         TAT.MetaValueObject(
-            members
+            v.value
               .map {
-                case AST.MetaKV(key, value, _) =>
+                case AST.MetaKV(key, value) =>
                   key -> applyMetaValue(value, ctx)
               }
-              .to(TreeSeqMap),
-            loc
+              .to(TreeSeqMap)
+        )(
+            v.loc
         )
       case other =>
         handleError(s"${SUtil.prettyFormatMetaValue(other)} is an invalid meta value", expr.loc)
-        TAT.MetaValueNull(other.loc)
+        TAT.MetaValueNull()(other.loc)
     }
   }
 
   private def applyMeta(metaSection: AST.MetaSection, ctx: TypeContext): TAT.MetaSection = {
-    TAT.MetaSection(metaSection.kvs
-                      .map {
-                        case AST.MetaKV(k, v, _) =>
-                          k -> applyMetaValue(v, ctx)
-                      }
-                      .to(TreeSeqMap),
-                    metaSection.loc)
+    TAT.MetaSection(
+        metaSection.kvs
+          .map {
+            case AST.MetaKV(k, v) =>
+              k -> applyMetaValue(v, ctx)
+          }
+          .to(TreeSeqMap)
+    )(metaSection.loc)
   }
 
   private def applyParamMeta(paramMetaSection: AST.ParameterMetaSection,
@@ -780,11 +772,12 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
                   s"parameter_meta key ${kv.id} does not refer to an input or output declaration",
                   kv.loc
               )
-              TAT.MetaValueNull(kv.value.loc)
+              TAT.MetaValueNull()(kv.value.loc)
             }
             kv.id -> metaValue
           }
-          .to(TreeSeqMap),
+          .to(TreeSeqMap)
+    )(
         paramMetaSection.loc
     )
   }
@@ -793,10 +786,11 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
     TAT.MetaSection(
         hintsSection.kvs
           .map {
-            case AST.MetaKV(k, v, _) =>
+            case AST.MetaKV(k, v) =>
               k -> applyMetaValue(v, ctx)
           }
-          .to(TreeSeqMap),
+          .to(TreeSeqMap)
+    )(
         hintsSection.loc
     )
   }
@@ -877,10 +871,10 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
                  |which is not coercible to a string""".stripMargin.replaceAll("\n", " "),
               expr.loc
           )
-          TAT.ValueString(prettyFormatExpr(e), T_String, e.loc)
+          TAT.ValueString(prettyFormatExpr(e), T_String)(e.loc)
       }
     }
-    val tCommand = TAT.CommandSection(tCommandParts, task.command.loc)
+    val tCommand = TAT.CommandSection(tCommandParts)(task.command.loc)
 
     val (outputDefs, outputCtx) = task.output match {
       case None             => (Vector.empty, declCtx)
@@ -903,19 +897,16 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
       None
     }
     val taskType = T_Task(taskName, inputType, outputType, function)
-    TAT.Task(
-        name = taskName,
-        wdlType = taskType,
-        inputs = inputDefs,
-        outputs = outputDefs,
-        command = tCommand,
-        privateVariables = tDeclarations,
-        meta = tMeta,
-        parameterMeta = tParamMeta,
-        runtime = tRuntime,
-        hints = tHints,
-        loc = task.loc
-    )
+    TAT.Task(taskName,
+             taskType,
+             inputDefs,
+             outputDefs,
+             tCommand,
+             tDeclarations,
+             tMeta,
+             tParamMeta,
+             tRuntime,
+             tHints)(task.loc)
   }
 
   // 1. all the caller arguments have to exist with the correct types
@@ -973,7 +964,7 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
 
     // convert inputs
     val callerInputs: SeqMap[String, TAT.Expr] = call.inputs match {
-      case Some(AST.CallInputs(value, _)) =>
+      case Some(AST.CallInputs(value)) =>
         value
           .map { inp =>
             val argName = inp.name
@@ -1013,13 +1004,13 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
             logger.warning(
                 s"compulsory argument '${argName}' to task/workflow ${call.name} is missing"
             )
-            Some(argName -> TAT.ValueNone(wdlType, call.loc))
+            Some(argName -> TAT.ValueNone(wdlType)(call.loc))
           case None =>
             handleError(
                 s"compulsory argument '${argName}' to task/workflow ${call.name} is missing",
                 call.loc
             )
-            Some(argName -> TAT.ValueNone(wdlType, call.loc))
+            Some(argName -> TAT.ValueNone(wdlType)(call.loc))
           case Some(_) =>
             // argument is provided
             None
@@ -1031,19 +1022,18 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
 
     // convert the alias to a simpler string option
     val alias = call.alias match {
-      case None                         => None
-      case Some(AST.CallAlias(name, _)) => Some(name)
+      case None                      => None
+      case Some(AST.CallAlias(name)) => Some(name)
     }
 
-    TAT.Call(
-        unqualifiedName,
-        call.name,
-        wdlType,
-        callee,
-        alias,
-        afters,
-        actualName,
-        callerInputs ++ missingInputs,
+    TAT.Call(unqualifiedName,
+             call.name,
+             wdlType,
+             callee,
+             alias,
+             afters,
+             actualName,
+             callerInputs ++ missingInputs)(
         call.loc
     )
   }
@@ -1082,7 +1072,7 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
     val (tBody, bindings) = applyWorkflowElements(scatter.body, bodyCtx)
     assert(!bindings.contains(scatter.identifier))
 
-    val tScatter = TAT.Scatter(scatter.identifier, collection, tBody, scatter.loc)
+    val tScatter = TAT.Scatter(scatter.identifier, collection, tBody)(scatter.loc)
 
     // Add an array type to all variables defined in the scatter body
     // if the scatter collection is non-empty, then we know the output
@@ -1111,7 +1101,7 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
       case e if e.wdlType == T_Boolean => e
       case e =>
         handleError(s"Expression ${prettyFormatExpr(e)} must have boolean type", cond.loc)
-        TAT.ValueBoolean(value = false, T_Boolean, e.loc)
+        TAT.ValueBoolean(value = false, T_Boolean)(e.loc)
     }
 
     // keep track of the inner/outer bindings. Within the block we need [inner],
@@ -1130,7 +1120,7 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
           varName -> TypeUtils.ensureOptional(typ)
       }
 
-    (TAT.Conditional(condExpr, wfElements, cond.loc), WdlTypeBindings(optionalBindings))
+    (TAT.Conditional(condExpr, wfElements)(cond.loc), WdlTypeBindings(optionalBindings))
   }
 
   // Add types to a block of workflow-elements:
@@ -1198,16 +1188,7 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
     // calculate the type signature of the workflow
     val (inputType, outputType) = calcSignature(inputDefs, outputDefs)
     val wfType = T_Workflow(wf.name, inputType, outputType)
-    TAT.Workflow(
-        name = wf.name,
-        wdlType = wfType,
-        inputs = inputDefs,
-        outputs = outputDefs,
-        meta = tMeta,
-        parameterMeta = tParamMeta,
-        body = wfElements,
-        loc = wf.loc
-    )
+    TAT.Workflow(wf.name, wfType, inputDefs, outputDefs, tMeta, tParamMeta, wfElements)(wf.loc)
   }
 
   // Convert from AST to TAT and maintain context
@@ -1251,17 +1232,19 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
             case Some(x) => x
           }
 
-          val tAliases = importDoc.aliases.map {
-            case AST.ImportAlias(id1, id2, loc) =>
-              importCtx.aliases.get(id1) match {
-                case Some(referee) => TAT.ImportAlias(id1, id2, referee, loc)
-                case None =>
-                  handleError(s"missing struct ${id1}", loc)
-                  TAT.ImportAlias(id1, id2, T_Struct(id1, SeqMap.empty), loc)
-              }
+          val tAliases = importDoc.aliases.map { impAlias: AST.ImportAlias =>
+            importCtx.aliases.get(impAlias.id1) match {
+              case Some(referee) =>
+                TAT.ImportAlias(impAlias.id1, impAlias.id2, referee)(impAlias.loc)
+              case None =>
+                handleError(s"missing struct ${impAlias.id1}", impAlias.loc)
+                TAT.ImportAlias(impAlias.id1, impAlias.id2, T_Struct(impAlias.id1, SeqMap.empty))(
+                    impAlias.loc
+                )
+            }
           }
 
-          val tImportDoc = TAT.ImportDoc(namespace, tAliases, addr, tDoc, importDoc.loc)
+          val tImportDoc = TAT.ImportDoc(namespace, tAliases, addr, tDoc)(importDoc.loc)
 
           // add the externally visible definitions to the context
           val afterCtx =
@@ -1277,7 +1260,7 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
         case ((tElements, beforeCtx), struct: AST.TypeStruct) =>
           // Add the struct to the context
           val tStruct = typeFromAst(struct, struct.loc, beforeCtx).asInstanceOf[T_Struct]
-          val tStructDef = TAT.StructDefinition(struct.name, tStruct, tStruct.members, struct.loc)
+          val tStructDef = TAT.StructDefinition(struct.name, tStruct, tStruct.members)(struct.loc)
           val afterCtx =
             try {
               beforeCtx.bindStruct(tStruct)
@@ -1305,8 +1288,8 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
         (Some(tWorkflow), afterCtx)
     }
 
-    val tVersion = TAT.Version(doc.version.value, doc.version.loc)
-    val tDoc = TAT.Document(doc.source, tVersion, elements, workflow, doc.loc, doc.comments)
+    val tVersion = TAT.Version(doc.version.value)(doc.version.loc)
+    val tDoc = TAT.Document(doc.source, tVersion, elements, workflow, doc.loc)(doc.comments)
     (tDoc, finalContext)
   }
 

--- a/src/main/scala/wdlTools/types/TypeUtils.scala
+++ b/src/main/scala/wdlTools/types/TypeUtils.scala
@@ -357,37 +357,37 @@ object TypeUtils {
         return callbackValue.get
       }
       innerExpr match {
-        case TAT.ValueNull(_, _)                    => "null"
-        case TAT.ValueNone(_, _)                    => "None"
-        case TAT.ValueBoolean(value: Boolean, _, _) => value.toString
-        case TAT.ValueInt(value, _, _)              => value.toString
-        case TAT.ValueFloat(value, _, _)            => value.toString
+        case TAT.ValueNull(_)                    => "null"
+        case TAT.ValueNone(_)                    => "None"
+        case TAT.ValueBoolean(value: Boolean, _) => value.toString
+        case TAT.ValueInt(value, _)              => value.toString
+        case TAT.ValueFloat(value, _)            => value.toString
 
         // add double quotes around string-like value unless disableQuoting = true
-        case TAT.ValueString(value, _, _) =>
+        case TAT.ValueString(value, _) =>
           if (disableQuoting) value else s""""$value""""
-        case TAT.ValueFile(value, _, _) =>
+        case TAT.ValueFile(value, _) =>
           if (disableQuoting) value else s""""$value""""
-        case TAT.ValueDirectory(value, _, _) =>
+        case TAT.ValueDirectory(value, _) =>
           if (disableQuoting) value else s""""$value""""
 
-        case TAT.ExprIdentifier(id: String, _, _) => id
+        case TAT.ExprIdentifier(id: String, _) => id
 
-        case TAT.ExprCompoundString(value, _, _) =>
+        case TAT.ExprCompoundString(value, _) =>
           val vec = value.map(x => inner(x, disableQuoting)).mkString(", ")
           s"ExprCompoundString(${vec})"
-        case TAT.ExprPair(l, r, _, _) =>
+        case TAT.ExprPair(l, r, _) =>
           s"(${inner(l, disableQuoting)}, ${inner(r, disableQuoting)})"
-        case TAT.ExprArray(value, _, _) =>
+        case TAT.ExprArray(value, _) =>
           "[" + value.map(x => inner(x, disableQuoting)).mkString(", ") + "]"
-        case TAT.ExprMap(value, _, _) =>
+        case TAT.ExprMap(value, _) =>
           val m2 = value
             .map {
               case (k, v) => s"${inner(k, disableQuoting)} : ${inner(v, disableQuoting)}"
             }
             .mkString(", ")
           s"{$m2}"
-        case TAT.ExprObject(value, _, _) =>
+        case TAT.ExprObject(value, _) =>
           val m2 = value
             .map {
               case (k, v) =>
@@ -397,7 +397,7 @@ object TypeUtils {
           s"object {$m2}"
 
         // ~{true="--yes" false="--no" boolean_value}
-        case TAT.ExprPlaceholder(t, f, sep, default, value, _, _) =>
+        case TAT.ExprPlaceholder(t, f, sep, default, value, _) =>
           val optStr = Vector(
               t.map(e => s"true=${inner(e, disableQuoting)}"),
               f.map(e => s"false=${inner(e, disableQuoting)}"),
@@ -407,31 +407,29 @@ object TypeUtils {
           s"{${optStr} ${inner(value, disableQuoting)}}"
 
         // Access an array element at [index]
-        case TAT.ExprAt(array, index, _, _) =>
+        case TAT.ExprAt(array, index, _) =>
           s"${inner(array, disableQuoting)}[${inner(index, disableQuoting)}]"
 
         // conditional:
         // if (x == 1) then "Sunday" else "Weekday"
-        case TAT.ExprIfThenElse(cond, tBranch, fBranch, _, _) =>
+        case TAT.ExprIfThenElse(cond, tBranch, fBranch, _) =>
           s"if (${inner(cond, disableQuoting)}) then ${inner(tBranch, disableQuoting)} else ${inner(fBranch, disableQuoting)}"
 
         // Apply a builtin unary operator
-        case TAT.ExprApply(oper: String, _, Vector(unaryValue), _, _)
-            if Operator.All.contains(oper) =>
+        case TAT.ExprApply(oper: String, _, Vector(unaryValue), _) if Operator.All.contains(oper) =>
           val symbol = Operator.All(oper).symbol
           s"${symbol}${inner(unaryValue, disableQuoting)}"
         // Apply a buildin binary operator
-        case TAT.ExprApply(oper: String, _, Vector(lhs, rhs), _, _)
-            if Operator.All.contains(oper) =>
+        case TAT.ExprApply(oper: String, _, Vector(lhs, rhs), _) if Operator.All.contains(oper) =>
           val symbol = Operator.All(oper).symbol
           s"${inner(lhs, disableQuoting)} ${symbol} ${inner(rhs, disableQuoting)}"
         // Apply a standard library function to arguments. For example:
         //   read_int("4")
-        case TAT.ExprApply(funcName, _, elements, _, _) =>
+        case TAT.ExprApply(funcName, _, elements, _) =>
           val args = elements.map(x => inner(x, disableQuoting)).mkString(", ")
           s"${funcName}(${args})"
 
-        case TAT.ExprGetName(e, id: String, _, _) =>
+        case TAT.ExprGetName(e, id: String, _) =>
           s"${inner(e, disableQuoting)}.${id}"
       }
     }
@@ -440,11 +438,11 @@ object TypeUtils {
 
   def prettyFormatInput(input: TAT.InputParameter, indent: String = ""): String = {
     input match {
-      case TAT.RequiredInputParameter(name, wdlType, _) =>
+      case TAT.RequiredInputParameter(name, wdlType) =>
         s"${indent}${prettyFormatType(wdlType)} ${name}"
-      case TAT.OverridableInputParameterWithDefault(name, wdlType, defaultExpr, _) =>
+      case TAT.OverridableInputParameterWithDefault(name, wdlType, defaultExpr) =>
         s"${indent}${prettyFormatType(wdlType)} ${name} = ${prettyFormatExpr(defaultExpr)}"
-      case TAT.OptionalInputParameter(name, wdlType, _) =>
+      case TAT.OptionalInputParameter(name, wdlType) =>
         s"${indent}${prettyFormatType(wdlType)} ${name}"
     }
   }
@@ -474,41 +472,41 @@ object TypeUtils {
         Map.empty
       case _: TAT.ValueNone =>
         Map.empty
-      case TAT.ExprIdentifier(id, wdlType, _) =>
+      case TAT.ExprIdentifier(id, wdlType) =>
         Map(id -> wdlType)
-      case TAT.ExprCompoundString(valArr, _, _) =>
+      case TAT.ExprCompoundString(valArr, _) =>
         valArr.flatMap(elem => exprDependencies(elem)).toMap
-      case TAT.ExprPair(l, r, _, _) =>
+      case TAT.ExprPair(l, r, _) =>
         exprDependencies(l) ++ exprDependencies(r)
-      case TAT.ExprArray(arrVal, _, _) =>
+      case TAT.ExprArray(arrVal, _) =>
         arrVal.flatMap(elem => exprDependencies(elem)).toMap
-      case TAT.ExprMap(valMap, _, _) =>
+      case TAT.ExprMap(valMap, _) =>
         valMap.flatMap { case (k, v) => exprDependencies(k) ++ exprDependencies(v) }
-      case TAT.ExprObject(fields, _, _) =>
+      case TAT.ExprObject(fields, _) =>
         fields.flatMap { case (_, v) => exprDependencies(v) }
-      case TAT.ExprPlaceholder(t, f, sep, default, value: TAT.Expr, _, _) =>
+      case TAT.ExprPlaceholder(t, f, sep, default, value: TAT.Expr, _) =>
         Vector(t.map(exprDependencies),
                f.map(exprDependencies),
                sep.map(exprDependencies),
                default.map(exprDependencies)).flatten.flatten.toMap ++ exprDependencies(value)
       // Access an array element at [index]
-      case TAT.ExprAt(value, index, _, _) =>
+      case TAT.ExprAt(value, index, _) =>
         exprDependencies(value) ++ exprDependencies(index)
       // conditional:
-      case TAT.ExprIfThenElse(cond, tBranch, fBranch, _, _) =>
+      case TAT.ExprIfThenElse(cond, tBranch, fBranch, _) =>
         exprDependencies(cond) ++ exprDependencies(tBranch) ++ exprDependencies(fBranch)
       // Apply a standard library function to arguments.
       //
       // TODO: some arguments may be _optional_ we need to take that
       // into account. We need to look into the function type
       // and figure out which arguments are optional.
-      case TAT.ExprApply(_, _, elements, _, _) =>
+      case TAT.ExprApply(_, _, elements, _) =>
         elements.flatMap(exprDependencies).toMap
       // Access a field in a call
       //   Int z = eliminateDuplicate.fields
-      case TAT.ExprGetName(TAT.ExprIdentifier(id, wdlType, _), _, _, _) =>
+      case TAT.ExprGetName(TAT.ExprIdentifier(id, wdlType), _, _) =>
         Map(id -> wdlType)
-      case TAT.ExprGetName(expr, _, _, _) =>
+      case TAT.ExprGetName(expr, _, _) =>
         exprDependencies(expr)
     }
   }

--- a/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
+++ b/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
@@ -41,7 +41,8 @@ object TypedAbstractSyntax {
   case class ExprCompoundString(value: Vector[Expr], wdlType: WdlTypes.T)(val loc: SourceLocation)
       extends Expr
 
-  case class ExprPair(l: Expr, r: Expr, wdlType: WdlTypes.T)(val loc: SourceLocation) extends Expr
+  case class ExprPair(left: Expr, right: Expr, wdlType: WdlTypes.T)(val loc: SourceLocation)
+      extends Expr
   case class ExprArray(value: Vector[Expr], wdlType: WdlTypes.T)(val loc: SourceLocation)
       extends Expr
   case class ExprMap(value: SeqMap[Expr, Expr], wdlType: WdlTypes.T)(val loc: SourceLocation)
@@ -55,10 +56,10 @@ object TypedAbstractSyntax {
   // ~{default="foo" optional_value}
   // ~{sep=", " array_value}
   //
-  case class ExprPlaceholder(t: Option[Expr],
-                             f: Option[Expr],
-                             sep: Option[Expr],
-                             default: Option[Expr],
+  case class ExprPlaceholder(trueOpt: Option[Expr],
+                             falseOpt: Option[Expr],
+                             sepOpt: Option[Expr],
+                             defaultOpt: Option[Expr],
                              value: Expr,
                              wdlType: WdlTypes.T)(val loc: SourceLocation)
       extends Expr
@@ -69,7 +70,7 @@ object TypedAbstractSyntax {
 
   // conditional:
   // if (x == 1) then "Sunday" else "Weekday"
-  case class ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr, wdlType: WdlTypes.T)(
+  case class ExprIfThenElse(cond: Expr, trueExpr: Expr, falseExpr: Expr, wdlType: WdlTypes.T)(
       val loc: SourceLocation
   ) extends Expr
 
@@ -83,7 +84,7 @@ object TypedAbstractSyntax {
 
   // Access a field in a struct or an object. For example:
   //   Int z = x.a
-  case class ExprGetName(e: Expr, id: String, wdlType: WdlTypes.T)(val loc: SourceLocation)
+  case class ExprGetName(expr: Expr, id: String, wdlType: WdlTypes.T)(val loc: SourceLocation)
       extends Expr
 
   sealed trait Variable extends Element {

--- a/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
+++ b/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
@@ -253,6 +253,7 @@ object TypedAbstractSyntax {
   case class Document(source: FileNode,
                       version: Version,
                       elements: Vector[DocumentElement],
-                      workflow: Option[Workflow])(val loc: SourceLocation)(val comments: CommentMap)
+                      workflow: Option[Workflow],
+                      comments: CommentMap)(val loc: SourceLocation)
       extends Element
 }

--- a/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
+++ b/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
@@ -24,27 +24,29 @@ object TypedAbstractSyntax {
   }
 
   // values
-  case class ValueNull(wdlType: WdlTypes.T, loc: SourceLocation) extends Expr
-  case class ValueNone(wdlType: WdlTypes.T, loc: SourceLocation) extends Expr
-  case class ValueBoolean(value: Boolean, wdlType: WdlTypes.T, loc: SourceLocation) extends Expr
-  case class ValueInt(value: Long, wdlType: WdlTypes.T, loc: SourceLocation) extends Expr
-  case class ValueFloat(value: Double, wdlType: WdlTypes.T, loc: SourceLocation) extends Expr
-  case class ValueString(value: String, wdlType: WdlTypes.T, loc: SourceLocation) extends Expr
-  case class ValueFile(value: String, wdlType: WdlTypes.T, loc: SourceLocation) extends Expr
-  case class ValueDirectory(value: String, wdlType: WdlTypes.T, loc: SourceLocation) extends Expr
-  case class ExprIdentifier(id: String, wdlType: WdlTypes.T, loc: SourceLocation) extends Expr
+  case class ValueNull(wdlType: WdlTypes.T)(val loc: SourceLocation) extends Expr
+  case class ValueNone(wdlType: WdlTypes.T)(val loc: SourceLocation) extends Expr
+  case class ValueBoolean(value: Boolean, wdlType: WdlTypes.T)(val loc: SourceLocation) extends Expr
+  case class ValueInt(value: Long, wdlType: WdlTypes.T)(val loc: SourceLocation) extends Expr
+  case class ValueFloat(value: Double, wdlType: WdlTypes.T)(val loc: SourceLocation) extends Expr
+  case class ValueString(value: String, wdlType: WdlTypes.T)(val loc: SourceLocation) extends Expr
+  case class ValueFile(value: String, wdlType: WdlTypes.T)(val loc: SourceLocation) extends Expr
+  case class ValueDirectory(value: String, wdlType: WdlTypes.T)(val loc: SourceLocation)
+      extends Expr
+  case class ExprIdentifier(id: String, wdlType: WdlTypes.T)(val loc: SourceLocation) extends Expr
 
   // represents strings with interpolation. These occur only in command blocks.
   // For example:
   //  "some string part ~{ident + ident} some string part after"
-  case class ExprCompoundString(value: Vector[Expr], wdlType: WdlTypes.T, loc: SourceLocation)
+  case class ExprCompoundString(value: Vector[Expr], wdlType: WdlTypes.T)(val loc: SourceLocation)
       extends Expr
 
-  case class ExprPair(l: Expr, r: Expr, wdlType: WdlTypes.T, loc: SourceLocation) extends Expr
-  case class ExprArray(value: Vector[Expr], wdlType: WdlTypes.T, loc: SourceLocation) extends Expr
-  case class ExprMap(value: SeqMap[Expr, Expr], wdlType: WdlTypes.T, loc: SourceLocation)
+  case class ExprPair(l: Expr, r: Expr, wdlType: WdlTypes.T)(val loc: SourceLocation) extends Expr
+  case class ExprArray(value: Vector[Expr], wdlType: WdlTypes.T)(val loc: SourceLocation)
       extends Expr
-  case class ExprObject(value: SeqMap[Expr, Expr], wdlType: WdlTypes.T, loc: SourceLocation)
+  case class ExprMap(value: SeqMap[Expr, Expr], wdlType: WdlTypes.T)(val loc: SourceLocation)
+      extends Expr
+  case class ExprObject(value: SeqMap[Expr, Expr], wdlType: WdlTypes.T)(val loc: SourceLocation)
       extends Expr
 
   // These are expressions of kind:
@@ -58,34 +60,31 @@ object TypedAbstractSyntax {
                              sep: Option[Expr],
                              default: Option[Expr],
                              value: Expr,
-                             wdlType: WdlTypes.T,
-                             loc: SourceLocation)
+                             wdlType: WdlTypes.T)(val loc: SourceLocation)
       extends Expr
 
   // Access an array element at [index]
-  case class ExprAt(array: Expr, index: Expr, wdlType: WdlTypes.T, loc: SourceLocation) extends Expr
+  case class ExprAt(array: Expr, index: Expr, wdlType: WdlTypes.T)(val loc: SourceLocation)
+      extends Expr
 
   // conditional:
   // if (x == 1) then "Sunday" else "Weekday"
-  case class ExprIfThenElse(cond: Expr,
-                            tBranch: Expr,
-                            fBranch: Expr,
-                            wdlType: WdlTypes.T,
-                            loc: SourceLocation)
-      extends Expr
+  case class ExprIfThenElse(cond: Expr, tBranch: Expr, fBranch: Expr, wdlType: WdlTypes.T)(
+      val loc: SourceLocation
+  ) extends Expr
 
   // Apply a standard library function to arguments. For example:
   //   read_int("4")
   case class ExprApply(funcName: String,
                        funcWdlType: T_Function,
                        elements: Vector[Expr],
-                       wdlType: WdlTypes.T,
-                       loc: SourceLocation)
+                       wdlType: WdlTypes.T)(val loc: SourceLocation)
       extends Expr
 
   // Access a field in a struct or an object. For example:
   //   Int z = x.a
-  case class ExprGetName(e: Expr, id: String, wdlType: WdlTypes.T, loc: SourceLocation) extends Expr
+  case class ExprGetName(e: Expr, id: String, wdlType: WdlTypes.T)(val loc: SourceLocation)
+      extends Expr
 
   sealed trait Variable extends Element {
     val name: String
@@ -104,7 +103,7 @@ object TypedAbstractSyntax {
   sealed trait InputParameter extends Variable
 
   // A compulsory input that has no default, and must be provided by the caller
-  case class RequiredInputParameter(name: String, wdlType: WdlTypes.T, loc: SourceLocation)
+  case class RequiredInputParameter(name: String, wdlType: WdlTypes.T)(val loc: SourceLocation)
       extends InputParameter
 
   /**
@@ -112,25 +111,25 @@ object TypedAbstractSyntax {
     */
   case class OverridableInputParameterWithDefault(name: String,
                                                   wdlType: WdlTypes.T,
-                                                  defaultExpr: Expr,
-                                                  loc: SourceLocation)
+                                                  defaultExpr: Expr)(val loc: SourceLocation)
       extends InputParameter
 
   /**
     * An input that may be omitted by the caller. In that case the value will
     * be null (or None).
     */
-  case class OptionalInputParameter(name: String, wdlType: WdlTypes.T_Optional, loc: SourceLocation)
-      extends InputParameter
+  case class OptionalInputParameter(name: String, wdlType: WdlTypes.T_Optional)(
+      val loc: SourceLocation
+  ) extends InputParameter
 
-  case class OutputParameter(name: String, wdlType: WdlTypes.T, expr: Expr, loc: SourceLocation)
+  case class OutputParameter(name: String, wdlType: WdlTypes.T, expr: Expr)(val loc: SourceLocation)
       extends Variable
 
   /**
     * A variable definition and assignment that does not appear in the input or output section,
     * i.e. it is private to the task/workflow.
     */
-  case class PrivateVariable(name: String, wdlType: WdlTypes.T, expr: Expr, loc: SourceLocation)
+  case class PrivateVariable(name: String, wdlType: WdlTypes.T, expr: Expr)(val loc: SourceLocation)
       extends WorkflowElement
       with Variable
 
@@ -155,40 +154,37 @@ object TypedAbstractSyntax {
   //     ls ~{input_file}
   //     echo ~{input_string}
   // >>>
-  case class CommandSection(parts: Vector[Expr], loc: SourceLocation) extends Element
-  case class RuntimeSection(kvs: SeqMap[String, Expr], loc: SourceLocation) extends Element
+  case class CommandSection(parts: Vector[Expr])(val loc: SourceLocation) extends Element
+  case class RuntimeSection(kvs: SeqMap[String, Expr])(val loc: SourceLocation) extends Element
 
   // A specialized JSON-like object language for meta values only.
   sealed trait MetaValue extends Element
-  case class MetaValueNull(loc: SourceLocation) extends MetaValue
-  case class MetaValueBoolean(value: Boolean, loc: SourceLocation) extends MetaValue
-  case class MetaValueInt(value: Long, loc: SourceLocation) extends MetaValue
-  case class MetaValueFloat(value: Double, loc: SourceLocation) extends MetaValue
-  case class MetaValueString(value: String, loc: SourceLocation) extends MetaValue
-  case class MetaValueObject(value: SeqMap[String, MetaValue], loc: SourceLocation)
+  case class MetaValueNull()(val loc: SourceLocation) extends MetaValue
+  case class MetaValueBoolean(value: Boolean)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueInt(value: Long)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueFloat(value: Double)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueString(value: String)(val loc: SourceLocation) extends MetaValue
+  case class MetaValueObject(value: SeqMap[String, MetaValue])(val loc: SourceLocation)
       extends MetaValue
-  case class MetaValueArray(value: Vector[MetaValue], loc: SourceLocation) extends MetaValue
+  case class MetaValueArray(value: Vector[MetaValue])(val loc: SourceLocation) extends MetaValue
 
   // the parameter sections have mappings from keys to json-like objects
-  case class MetaSection(kvs: SeqMap[String, MetaValue], loc: SourceLocation) extends Element
+  case class MetaSection(kvs: SeqMap[String, MetaValue])(val loc: SourceLocation) extends Element
 
-  case class Version(value: WdlVersion, loc: SourceLocation) extends Element
+  case class Version(value: WdlVersion)(val loc: SourceLocation) extends Element
 
   // import statement with the typed-AST for the referenced document
-  case class ImportAlias(id1: String, id2: String, referee: WdlTypes.T_Struct, loc: SourceLocation)
-      extends Element
-  case class ImportDoc(namespace: String,
-                       aliases: Vector[ImportAlias],
-                       addr: String,
-                       doc: Document,
-                       loc: SourceLocation)
-      extends DocumentElement
+  case class ImportAlias(id1: String, id2: String, referee: WdlTypes.T_Struct)(
+      val loc: SourceLocation
+  ) extends Element
+  case class ImportDoc(namespace: String, aliases: Vector[ImportAlias], addr: String, doc: Document)(
+      val loc: SourceLocation
+  ) extends DocumentElement
 
   // a definition of a struct
   case class StructDefinition(name: String,
                               wdlType: WdlTypes.T_Struct,
-                              members: SeqMap[String, WdlTypes.T],
-                              loc: SourceLocation)
+                              members: SeqMap[String, WdlTypes.T])(val loc: SourceLocation)
       extends DocumentElement
 
   // A task
@@ -201,12 +197,11 @@ object TypedAbstractSyntax {
                   meta: Option[MetaSection],
                   parameterMeta: Option[MetaSection],
                   runtime: Option[RuntimeSection],
-                  hints: Option[MetaSection],
-                  loc: SourceLocation)
+                  hints: Option[MetaSection])(val loc: SourceLocation)
       extends DocumentElement
       with Callable
 
-  case class CallAfter(name: String, loc: SourceLocation) extends Element
+  case class CallAfter(name: String)(val loc: SourceLocation) extends Element
 
   // A call has three names - a fully-qualified name (FQN), an unqualified name
   // (UQN), and an "actual" name. The UQN is the callee name without any namespace.
@@ -227,8 +222,7 @@ object TypedAbstractSyntax {
                   alias: Option[String],
                   afters: Vector[WdlTypes.T_Call],
                   actualName: String,
-                  inputs: SeqMap[String, Expr],
-                  loc: SourceLocation)
+                  inputs: SeqMap[String, Expr])(val loc: SourceLocation)
       extends WorkflowElement
 
   sealed trait BlockElement extends WorkflowElement {
@@ -236,13 +230,11 @@ object TypedAbstractSyntax {
     val body: Vector[WorkflowElement]
   }
 
-  case class Scatter(identifier: String,
-                     expr: Expr,
-                     body: Vector[WorkflowElement],
-                     loc: SourceLocation)
-      extends BlockElement
+  case class Scatter(identifier: String, expr: Expr, body: Vector[WorkflowElement])(
+      val loc: SourceLocation
+  ) extends BlockElement
 
-  case class Conditional(expr: Expr, body: Vector[WorkflowElement], loc: SourceLocation)
+  case class Conditional(expr: Expr, body: Vector[WorkflowElement])(val loc: SourceLocation)
       extends BlockElement
 
   // A workflow
@@ -253,8 +245,7 @@ object TypedAbstractSyntax {
                       outputs: Vector[OutputParameter],
                       meta: Option[MetaSection],
                       parameterMeta: Option[MetaSection],
-                      body: Vector[WorkflowElement],
-                      loc: SourceLocation)
+                      body: Vector[WorkflowElement])(val loc: SourceLocation)
       extends Element
       with Callable
 
@@ -262,7 +253,6 @@ object TypedAbstractSyntax {
                       version: Version,
                       elements: Vector[DocumentElement],
                       workflow: Option[Workflow],
-                      loc: SourceLocation,
-                      comments: CommentMap)
+                      loc: SourceLocation)(val comments: CommentMap)
       extends Element
 }

--- a/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
+++ b/src/main/scala/wdlTools/types/TypedAbstractSyntax.scala
@@ -253,7 +253,6 @@ object TypedAbstractSyntax {
   case class Document(source: FileNode,
                       version: Version,
                       elements: Vector[DocumentElement],
-                      workflow: Option[Workflow],
-                      loc: SourceLocation)(val comments: CommentMap)
+                      workflow: Option[Workflow])(val loc: SourceLocation)(val comments: CommentMap)
       extends Element
 }

--- a/src/main/scala/wdlTools/types/TypedAbstractSyntaxTreeWalker.scala
+++ b/src/main/scala/wdlTools/types/TypedAbstractSyntaxTreeWalker.scala
@@ -129,18 +129,18 @@ class TypedAbstractSyntaxTreeVisitor {
     */
   def traverseExpression(ctx: VisitorContext[Expr]): Unit = {
     val exprs: Vector[Expr] = ctx.element match {
-      case ExprCompoundString(value, _, _) => value
-      case ExprPair(l, r, _, _)            => Vector(l, r)
-      case ExprArray(value, _, _)          => value
-      case ExprMap(value, _, _)            => value.keys.toVector ++ value.values.toVector
-      case ExprObject(value, _, _)         => value.keys.toVector ++ value.values.toVector
-      case ExprPlaceholder(t, f, sep, default, value, _, _) =>
+      case ExprCompoundString(value, _) => value
+      case ExprPair(l, r, _)            => Vector(l, r)
+      case ExprArray(value, _)          => value
+      case ExprMap(value, _)            => value.keys.toVector ++ value.values.toVector
+      case ExprObject(value, _)         => value.keys.toVector ++ value.values.toVector
+      case ExprPlaceholder(t, f, sep, default, value, _) =>
         Vector(t, f, sep, default).flatten :+ value
-      case ExprAt(array, index, _, _)                   => Vector(array, index)
-      case ExprIfThenElse(cond, tBranch, fBranch, _, _) => Vector(cond, tBranch, fBranch)
-      case ExprApply(_, _, elements, _, _)              => elements
-      case ExprGetName(e, _, _, _)                      => Vector(e)
-      case _                                            => Vector.empty
+      case ExprAt(array, index, _)                   => Vector(array, index)
+      case ExprIfThenElse(cond, tBranch, fBranch, _) => Vector(cond, tBranch, fBranch)
+      case ExprApply(_, _, elements, _)              => elements
+      case ExprGetName(e, _, _)                      => Vector(e)
+      case _                                         => Vector.empty
     }
     exprs.foreach { e =>
       traverseExpression(ctx.createChildContext[Expr](e))
@@ -256,9 +256,9 @@ class TypedAbstractSyntaxTreeWalker(followImports: Boolean = false)
 
   override def visitInputDefinition(ctx: VisitorContext[InputParameter]): Unit = {
     ctx.element match {
-      case RequiredInputParameter(name, wdlType, _) => visitVariable(name, wdlType, None, ctx)
-      case OptionalInputParameter(name, wdlType, _) => visitVariable(name, wdlType, None, ctx)
-      case OverridableInputParameterWithDefault(name, wdlType, defaultExpr, _) =>
+      case RequiredInputParameter(name, wdlType) => visitVariable(name, wdlType, None, ctx)
+      case OptionalInputParameter(name, wdlType) => visitVariable(name, wdlType, None, ctx)
+      case OverridableInputParameterWithDefault(name, wdlType, defaultExpr) =>
         visitVariable(name, wdlType, Some(defaultExpr), ctx)
     }
   }

--- a/src/test/scala/wdlTools/eval/EvalTest.scala
+++ b/src/test/scala/wdlTools/eval/EvalTest.scala
@@ -425,7 +425,7 @@ class EvalTest extends AnyFlatSpec with Matchers with Inside {
     val (evaluator, decls) = parseAndTypeCheckAndGetDeclarations(v1Dir.resolve("constants.wdl"))
 
     decls.foreach {
-      case TAT.PrivateVariable(id, wdlType, expr, _) =>
+      case TAT.PrivateVariable(id, wdlType, expr) =>
         val expected: Option[WdlValues.V] = allExpectedResults(id)
         expected match {
           case None =>
@@ -444,7 +444,7 @@ class EvalTest extends AnyFlatSpec with Matchers with Inside {
   it should "not be able to access unsupported file protocols" in {
     val (evaluator, decls) = parseAndTypeCheckAndGetDeclarations(v1Dir.resolve("bad_protocol.wdl"))
     decls match {
-      case Vector(TAT.PrivateVariable(_, wdlType, expr, _)) =>
+      case Vector(TAT.PrivateVariable(_, wdlType, expr)) =>
         assertThrows[EvalException] {
           evaluator.applyConstAndCoerce(expr, wdlType)
         }
@@ -481,13 +481,15 @@ class EvalTest extends AnyFlatSpec with Matchers with Inside {
         T_Function1("select_first", T_Array(T_Int, nonEmpty = true), T_Int),
         Vector(
             TAT.ExprArray(
-                Vector(TAT.ExprIdentifier("x", T_Optional(T_Int), SourceLocation.empty),
-                       TAT.ValueInt(5, T_Int, SourceLocation.empty)),
-                T_Array(T_Optional(T_Int), nonEmpty = true),
+                Vector(TAT.ExprIdentifier("x", T_Optional(T_Int))(SourceLocation.empty),
+                       TAT.ValueInt(5, T_Int)(SourceLocation.empty)),
+                T_Array(T_Optional(T_Int), nonEmpty = true)
+            )(
                 SourceLocation.empty
             )
         ),
-        T_Int,
+        T_Int
+    )(
         SourceLocation.empty
     )
     val evaluator = createEvaluator()
@@ -518,7 +520,7 @@ class EvalTest extends AnyFlatSpec with Matchers with Inside {
     )
     val env: Map[String, V] =
       task.privateVariables.foldLeft(inputs) {
-        case (env, TAT.PrivateVariable(name, wdlType, expr, _)) =>
+        case (env, TAT.PrivateVariable(name, wdlType, expr)) =>
           val wdlValue =
             evaluator.applyExprAndCoerce(expr, wdlType, WdlValueBindings(env))
           env + (name -> wdlValue)

--- a/src/test/scala/wdlTools/syntax/AbstractSyntaxTest.scala
+++ b/src/test/scala/wdlTools/syntax/AbstractSyntaxTest.scala
@@ -92,7 +92,7 @@ class AbstractSyntaxTest extends AnyFlatSpec with Matchers {
     task.parameterMeta.get.kvs.size shouldBe 1
     val mpkv = task.parameterMeta.get.kvs.head
     mpkv should matchPattern {
-      case MetaKV("i", MetaValueNull(_), _) =>
+      case MetaKV("i", MetaValueNull()) =>
     }
   }
 
@@ -135,7 +135,7 @@ class AbstractSyntaxTest extends AnyFlatSpec with Matchers {
     val parser = parsers.getParser(src)
     val doc = parser.parseDocument(src)
     doc.version should matchPattern {
-      case Version(WdlVersion.V1, _) =>
+      case Version(WdlVersion.V1) =>
     }
     doc.elements.size shouldBe 1
     doc.elements.head.asInstanceOf[Task].name shouldBe "foo"

--- a/src/test/scala/wdlTools/syntax/draft_2/ConcreteSyntaxDraft2Test.scala
+++ b/src/test/scala/wdlTools/syntax/draft_2/ConcreteSyntaxDraft2Test.scala
@@ -36,44 +36,44 @@ class ConcreteSyntaxDraft2Test extends AnyFlatSpec with Matchers {
     elem shouldBe a[Task]
     val task = elem.asInstanceOf[Task]
 
-    val InputSection(decls, _) = task.input.get
-    decls(0) should matchPattern { case Declaration("i", TypeInt(_), None, _)     => }
-    decls(1) should matchPattern { case Declaration("s", TypeString(_), None, _)  => }
-    decls(2) should matchPattern { case Declaration("x", TypeFloat(_), None, _)   => }
-    decls(3) should matchPattern { case Declaration("b", TypeBoolean(_), None, _) => }
-    decls(4) should matchPattern { case Declaration("f", TypeFile(_), None, _)    => }
+    val InputSection(decls) = task.input.get
+    decls(0) should matchPattern { case Declaration("i", TypeInt(), None)     => }
+    decls(1) should matchPattern { case Declaration("s", TypeString(), None)  => }
+    decls(2) should matchPattern { case Declaration("x", TypeFloat(), None)   => }
+    decls(3) should matchPattern { case Declaration("b", TypeBoolean(), None) => }
+    decls(4) should matchPattern { case Declaration("f", TypeFile(), None)    => }
     decls(5) should matchPattern {
-      case Declaration("p1", TypePair(_: TypeInt, _: TypeString, _), None, _) =>
+      case Declaration("p1", TypePair(_: TypeInt, _: TypeString), None) =>
     }
     decls(6) should matchPattern {
-      case Declaration("p2", TypePair(_: TypeFloat, _: TypeFile, _), None, _) =>
+      case Declaration("p2", TypePair(_: TypeFloat, _: TypeFile), None) =>
     }
     decls(7) should matchPattern {
-      case Declaration("p3", TypePair(_: TypeBoolean, _: TypeBoolean, _), None, _) =>
+      case Declaration("p3", TypePair(_: TypeBoolean, _: TypeBoolean), None) =>
     }
     decls(8) should matchPattern {
-      case Declaration("ia", TypeArray(_: TypeInt, false, _), None, _) =>
+      case Declaration("ia", TypeArray(_: TypeInt, false), None) =>
     }
     decls(9) should matchPattern {
-      case Declaration("sa", TypeArray(_: TypeString, false, _), None, _) =>
+      case Declaration("sa", TypeArray(_: TypeString, false), None) =>
     }
     decls(10) should matchPattern {
-      case Declaration("xa", TypeArray(_: TypeFloat, false, _), None, _) =>
+      case Declaration("xa", TypeArray(_: TypeFloat, false), None) =>
     }
     decls(11) should matchPattern {
-      case Declaration("ba", TypeArray(_: TypeBoolean, false, _), None, _) =>
+      case Declaration("ba", TypeArray(_: TypeBoolean, false), None) =>
     }
     decls(12) should matchPattern {
-      case Declaration("fa", TypeArray(_: TypeFile, false, _), None, _) =>
+      case Declaration("fa", TypeArray(_: TypeFile, false), None) =>
     }
     decls(13) should matchPattern {
-      case Declaration("m_si", TypeMap(_: TypeInt, _: TypeString, _), None, _) =>
+      case Declaration("m_si", TypeMap(_: TypeInt, _: TypeString), None) =>
     }
     decls(14) should matchPattern {
-      case Declaration("m_ff", TypeMap(_: TypeFile, _: TypeFile, _), None, _) =>
+      case Declaration("m_ff", TypeMap(_: TypeFile, _: TypeFile), None) =>
     }
     decls(15) should matchPattern {
-      case Declaration("m_bf", TypeMap(_: TypeBoolean, _: TypeFloat, _), None, _) =>
+      case Declaration("m_bf", TypeMap(_: TypeBoolean, _: TypeFloat), None) =>
     }
   }
 
@@ -86,135 +86,122 @@ class ConcreteSyntaxDraft2Test extends AnyFlatSpec with Matchers {
     val task = elem.asInstanceOf[Task]
 
     task.input.get.declarations(0) should matchPattern {
-      case Declaration("i", _: TypeInt, Some(ExprInt(3, _)), _) =>
+      case Declaration("i", _: TypeInt, Some(ExprInt(3))) =>
     }
     task.input.get.declarations(1) should matchPattern {
-      case Declaration("s", _: TypeString, Some(ExprString("hello world", _)), _) =>
+      case Declaration("s", _: TypeString, Some(ExprString("hello world"))) =>
     }
     task.input.get.declarations(2) should matchPattern {
-      case Declaration("x", _: TypeFloat, Some(ExprFloat(4.3, _)), _) =>
+      case Declaration("x", _: TypeFloat, Some(ExprFloat(4.3))) =>
     }
     task.input.get.declarations(3) should matchPattern {
-      case Declaration("f", _: TypeFile, Some(ExprString("/dummy/x.txt", _)), _) =>
+      case Declaration("f", _: TypeFile, Some(ExprString("/dummy/x.txt"))) =>
     }
     task.input.get.declarations(4) should matchPattern {
-      case Declaration("b", _: TypeBoolean, Some(ExprBoolean(false, _)), _) =>
+      case Declaration("b", _: TypeBoolean, Some(ExprBoolean(false))) =>
     }
     task.input.get.declarations(5) should matchPattern {
       case Declaration(
           "ia",
-          TypeArray(_: TypeInt, false, _),
-          Some(ExprArrayLiteral(Vector(ExprInt(1, _), ExprInt(2, _), ExprInt(3, _)), _)),
-          _
+          TypeArray(_: TypeInt, false),
+          Some(ExprArrayLiteral(Vector(ExprInt(1), ExprInt(2), ExprInt(3))))
           ) =>
     }
     task.input.get.declarations(6) should matchPattern {
       case Declaration("ia",
-                       TypeArray(_: TypeInt, true, _),
-                       Some(ExprArrayLiteral(Vector(ExprInt(10, _)), _)),
-                       _) =>
+                       TypeArray(_: TypeInt, true),
+                       Some(ExprArrayLiteral(Vector(ExprInt(10))))) =>
     }
     task.input.get.declarations(7) should matchPattern {
-      case Declaration("m", TypeMap(TypeInt(_), TypeString(_), _), Some(ExprMapLiteral(_, _)), _) =>
+      case Declaration("m", TypeMap(TypeInt(), TypeString()), Some(ExprMapLiteral(_))) =>
     }
     task.input.get.declarations(8) should matchPattern {
-      case Declaration("o", _: TypeObject, Some(ExprObjectLiteral(_, _)), _) =>
+      case Declaration("o", _: TypeObject, Some(ExprObjectLiteral(_))) =>
     }
-    /*(Map("A" -> ExprInt(1, _),
+    /*(Map("A" -> ExprInt(1),
      "B" -> ExprInt(2, _,
-     _))), _)) */
+     _))))) */
 
     task.input.get.declarations(9) should matchPattern {
       case Declaration("twenty_threes",
-                       TypePair(TypeInt(_), TypeString(_), _),
-                       Some(ExprPair(ExprInt(23, _), ExprString("twenty-three", _), _)),
-                       _) =>
+                       TypePair(TypeInt(), TypeString()),
+                       Some(ExprPair(ExprInt(23), ExprString("twenty-three")))) =>
     }
 
     // Logical expressions
     task.declarations(0) should matchPattern {
       case Declaration("b2",
                        _: TypeBoolean,
-                       Some(ExprLor(ExprBoolean(true, _), ExprBoolean(false, _), _)),
-                       _) =>
+                       Some(ExprLor(ExprBoolean(true), ExprBoolean(false)))) =>
     }
     task.declarations(1) should matchPattern {
       case Declaration("b3",
                        _: TypeBoolean,
-                       Some(ExprLand(ExprBoolean(true, _), ExprBoolean(false, _), _)),
-                       _) =>
+                       Some(ExprLand(ExprBoolean(true), ExprBoolean(false)))) =>
     }
     task.declarations(2) should matchPattern {
-      case Declaration("b4", _: TypeBoolean, Some(ExprEqeq(ExprInt(3, _), ExprInt(5, _), _)), _) =>
+      case Declaration("b4", _: TypeBoolean, Some(ExprEqeq(ExprInt(3), ExprInt(5)))) =>
     }
     task.declarations(3) should matchPattern {
-      case Declaration("b5", _: TypeBoolean, Some(ExprLt(ExprInt(4, _), ExprInt(5, _), _)), _) =>
+      case Declaration("b5", _: TypeBoolean, Some(ExprLt(ExprInt(4), ExprInt(5)))) =>
     }
     task.declarations(4) should matchPattern {
-      case Declaration("b6", _: TypeBoolean, Some(ExprGte(ExprInt(4, _), ExprInt(5, _), _)), _) =>
+      case Declaration("b6", _: TypeBoolean, Some(ExprGte(ExprInt(4), ExprInt(5)))) =>
     }
     task.declarations(5) should matchPattern {
-      case Declaration("b7", _: TypeBoolean, Some(ExprNeq(ExprInt(6, _), ExprInt(7, _), _)), _) =>
+      case Declaration("b7", _: TypeBoolean, Some(ExprNeq(ExprInt(6), ExprInt(7)))) =>
     }
     task.declarations(6) should matchPattern {
-      case Declaration("b8", _: TypeBoolean, Some(ExprLte(ExprInt(6, _), ExprInt(7, _), _)), _) =>
+      case Declaration("b8", _: TypeBoolean, Some(ExprLte(ExprInt(6), ExprInt(7)))) =>
     }
     task.declarations(7) should matchPattern {
-      case Declaration("b9", _: TypeBoolean, Some(ExprGt(ExprInt(6, _), ExprInt(7, _), _)), _) =>
+      case Declaration("b9", _: TypeBoolean, Some(ExprGt(ExprInt(6), ExprInt(7)))) =>
     }
     task.declarations(8) should matchPattern {
-      case Declaration("b10", _: TypeBoolean, Some(ExprNegate(ExprIdentifier("b2", _), _)), _) =>
+      case Declaration("b10", _: TypeBoolean, Some(ExprNegate(ExprIdentifier("b2")))) =>
     }
 
     // Arithmetic
     task.declarations(9) should matchPattern {
-      case Declaration("j", _: TypeInt, Some(ExprAdd(ExprInt(4, _), ExprInt(5, _), _)), _) =>
+      case Declaration("j", _: TypeInt, Some(ExprAdd(ExprInt(4), ExprInt(5)))) =>
     }
     task.declarations(10) should matchPattern {
-      case Declaration("j1", _: TypeInt, Some(ExprMod(ExprInt(4, _), ExprInt(10, _), _)), _) =>
+      case Declaration("j1", _: TypeInt, Some(ExprMod(ExprInt(4), ExprInt(10)))) =>
     }
     task.declarations(11) should matchPattern {
-      case Declaration("j2", _: TypeInt, Some(ExprDivide(ExprInt(10, _), ExprInt(7, _), _)), _) =>
+      case Declaration("j2", _: TypeInt, Some(ExprDivide(ExprInt(10), ExprInt(7)))) =>
     }
     task.declarations(12) should matchPattern {
-      case Declaration("j3", _: TypeInt, Some(ExprIdentifier("j", _)), _) =>
+      case Declaration("j3", _: TypeInt, Some(ExprIdentifier("j"))) =>
     }
     task.declarations(13) should matchPattern {
-      case Declaration("j4",
-                       _: TypeInt,
-                       Some(ExprAdd(ExprIdentifier("j", _), ExprInt(19, _), _)),
-                       _) =>
+      case Declaration("j4", _: TypeInt, Some(ExprAdd(ExprIdentifier("j"), ExprInt(19)))) =>
     }
 
     task.declarations(14) should matchPattern {
-      case Declaration("k",
-                       _: TypeInt,
-                       Some(ExprAt(ExprIdentifier("ia", _), ExprInt(3, _), _)),
-                       _) =>
+      case Declaration("k", _: TypeInt, Some(ExprAt(ExprIdentifier("ia"), ExprInt(3)))) =>
     }
     task.declarations(15) should matchPattern {
       case Declaration(
           "k2",
           _: TypeInt,
-          Some(ExprApply("f", Vector(ExprInt(1, _), ExprInt(2, _), ExprInt(3, _)), _)),
-          _
+          Some(ExprApply("f", Vector(ExprInt(1), ExprInt(2), ExprInt(3))))
           ) =>
     }
 
     /*    val m = task.declarations(23).expr
     m should matchPattern {
-      case Map(ExprInt(1, _) -> ExprString("a", _),
-                                      ExprInt(2, _) -> ExprString("b", _)),
+      case Map(ExprInt(1) -> ExprString("a"),
+                                      ExprInt(2) -> ExprString("b")),
     _)),*/
 
     task.declarations(16) should matchPattern {
       case Declaration("k3",
                        _: TypeInt,
-                       Some(ExprIfThenElse(ExprBoolean(true, _), ExprInt(1, _), ExprInt(2, _), _)),
-                       _) =>
+                       Some(ExprIfThenElse(ExprBoolean(true), ExprInt(1), ExprInt(2)))) =>
     }
     task.declarations(17) should matchPattern {
-      case Declaration("k4", _: TypeInt, Some(ExprGetName(ExprIdentifier("x", _), "a", _)), _) =>
+      case Declaration("k4", _: TypeInt, Some(ExprGetName(ExprIdentifier("x"), "a"))) =>
     }
   }
 
@@ -228,11 +215,11 @@ class ConcreteSyntaxDraft2Test extends AnyFlatSpec with Matchers {
 
     task.name shouldBe "district"
     task.declarations(0) should matchPattern {
-      case Declaration("k", TypeInt(_), Some(ExprGetName(ExprIdentifier("x", _), "a", _)), _) =>
+      case Declaration("k", TypeInt(), Some(ExprGetName(ExprIdentifier("x"), "a"))) =>
     }
     task.output shouldBe None
     task.command should matchPattern {
-      case CommandSection(Vector(), _) =>
+      case CommandSection(Vector()) =>
     }
     task.meta shouldBe None
     task.parameterMeta shouldBe None
@@ -254,7 +241,7 @@ class ConcreteSyntaxDraft2Test extends AnyFlatSpec with Matchers {
 
     task.name shouldBe "wc"
     task.output.get should matchPattern {
-      case OutputSection(Vector(Declaration("num_lines", TypeInt(_), Some(ExprInt(3, _)), _)), _) =>
+      case OutputSection(Vector(Declaration("num_lines", TypeInt(), Some(ExprInt(3))))) =>
     }
   }
 
@@ -291,38 +278,37 @@ class ConcreteSyntaxDraft2Test extends AnyFlatSpec with Matchers {
 
     task.name shouldBe "wc"
     task.input.get should matchPattern {
-      case InputSection(Vector(Declaration("inp_file", _: TypeFile, None, _)), _) =>
+      case InputSection(Vector(Declaration("inp_file", _: TypeFile, None))) =>
     }
     task.declarations should matchPattern {
       case Vector(
-          Declaration("i", TypeInt(_), Some(ExprAdd(ExprInt(4, _), ExprInt(5, _), _)), _)
+          Declaration("i", TypeInt(), Some(ExprAdd(ExprInt(4), ExprInt(5))))
           ) =>
     }
     task.output.get should matchPattern {
-      case OutputSection(Vector(Declaration("num_lines", _: TypeInt, Some(ExprInt(3, _)), _)), _) =>
+      case OutputSection(Vector(Declaration("num_lines", _: TypeInt, Some(ExprInt(3))))) =>
     }
     task.command shouldBe a[CommandSection]
     task.command.parts.size shouldBe 3
     task.command.parts(0) should matchPattern {
-      case ExprString("\n    # this is inside the command and so not a WDL comment\n    wc -l ",
-                      _) =>
+      case ExprString("\n    # this is inside the command and so not a WDL comment\n    wc -l ") =>
     }
     task.command.parts(1) should matchPattern {
-      case ExprIdentifier("inp_file", _) =>
+      case ExprIdentifier("inp_file") =>
     }
 
     task.meta.get shouldBe a[MetaSection]
     task.meta.get.kvs.size shouldBe 1
     val mkv = task.meta.get.kvs.head
     mkv should matchPattern {
-      case MetaKV("author", "Robin Hood", _) =>
+      case MetaKV("author", "Robin Hood") =>
     }
 
     task.parameterMeta.get shouldBe a[ParameterMetaSection]
     task.parameterMeta.get.kvs.size shouldBe 1
     val mpkv = task.parameterMeta.get.kvs.head
     mpkv should matchPattern {
-      case MetaKV("inp_file", "just because", _) =>
+      case MetaKV("inp_file", "just because") =>
     }
   }
 
@@ -344,23 +330,22 @@ class ConcreteSyntaxDraft2Test extends AnyFlatSpec with Matchers {
     task.input.get shouldBe a[InputSection]
     task.input.get.declarations.size shouldBe 2
     task.input.get.declarations(0) should matchPattern {
-      case Declaration("min_std_max_min", TypeInt(_), None, _) =>
+      case Declaration("min_std_max_min", TypeInt(), None) =>
     }
     task.input.get.declarations(1) should matchPattern {
-      case Declaration("prefix", TypeString(_), None, _) =>
+      case Declaration("prefix", TypeString(), None) =>
     }
 
     task.command shouldBe a[CommandSection]
     task.command.parts(0) should matchPattern {
-      case ExprString("\n    echo ", _) =>
+      case ExprString("\n    echo ") =>
     }
     task.command.parts(1) should matchPattern {
       case ExprPlaceholder(None,
                            None,
-                           Some(ExprString(",", _)),
+                           Some(ExprString(",")),
                            None,
-                           ExprIdentifier("min_std_max_min", _),
-                           _) =>
+                           ExprIdentifier("min_std_max_min")) =>
     }
   }
 
@@ -379,10 +364,10 @@ class ConcreteSyntaxDraft2Test extends AnyFlatSpec with Matchers {
     }
     calls.size shouldBe 1
     calls(0) should matchPattern {
-      case Call("bar", Some(CallAlias("boz", _)), _, _) =>
+      case Call("bar", Some(CallAlias("boz")), _) =>
     }
     calls(0).inputs.get.value should matchPattern {
-      case Vector(CallInput("i", ExprIdentifier("s", _), _)) =>
+      case Vector(CallInput("i", ExprIdentifier("s"))) =>
     }
 
     val scatters = wf.body.collect {
@@ -391,15 +376,15 @@ class ConcreteSyntaxDraft2Test extends AnyFlatSpec with Matchers {
     scatters.size shouldBe 1
     scatters(0).identifier shouldBe "i"
     scatters(0).expr should matchPattern {
-      case ExprArrayLiteral(Vector(ExprInt(1, _), ExprInt(2, _), ExprInt(3, _)), _) =>
+      case ExprArrayLiteral(Vector(ExprInt(1), ExprInt(2), ExprInt(3))) =>
     }
     scatters(0).body.size shouldBe 1
     scatters(0).body(0) should matchPattern {
-      case Call("add", None, _, _) =>
+      case Call("add", None, _) =>
     }
     val call = scatters(0).body(0).asInstanceOf[Call]
     call.inputs.get.value should matchPattern {
-      case Vector(CallInput("x", ExprIdentifier("i", _), _)) =>
+      case Vector(CallInput("x", ExprIdentifier("i"))) =>
     }
 
     val conditionals = wf.body.collect {
@@ -407,10 +392,10 @@ class ConcreteSyntaxDraft2Test extends AnyFlatSpec with Matchers {
     }
     conditionals.size shouldBe 1
     conditionals(0).expr should matchPattern {
-      case ExprEqeq(ExprBoolean(true, _), ExprBoolean(false, _), _) =>
+      case ExprEqeq(ExprBoolean(true), ExprBoolean(false)) =>
     }
     conditionals(0).body should matchPattern {
-      case Vector(Call("sub", None, _, _)) =>
+      case Vector(Call("sub", None, _)) =>
     }
     conditionals(0).body(0).asInstanceOf[Call].inputs.size shouldBe 0
 
@@ -418,7 +403,7 @@ class ConcreteSyntaxDraft2Test extends AnyFlatSpec with Matchers {
     wf.meta.get.kvs.size shouldEqual 1
     wf.meta.get.kvs.head.value shouldEqual "Robert Heinlein"
     wf.meta.get.kvs should matchPattern {
-      case Vector(MetaKV("author", "Robert Heinlein", _)) =>
+      case Vector(MetaKV("author", "Robert Heinlein")) =>
     }
   }
 
@@ -456,9 +441,7 @@ class ConcreteSyntaxDraft2Test extends AnyFlatSpec with Matchers {
     val decl = task.declarations.head
     decl.name shouldBe "j"
     decl.expr.get should matchPattern {
-      case ExprAdd(ExprAdd(ExprIdentifier("i", _), ExprIdentifier("i", _), _),
-                   ExprIdentifier("i", _),
-                   _) =>
+      case ExprAdd(ExprAdd(ExprIdentifier("i"), ExprIdentifier("i")), ExprIdentifier("i")) =>
     }
   }
 
@@ -473,7 +456,7 @@ class ConcreteSyntaxDraft2Test extends AnyFlatSpec with Matchers {
     val decl = wf.body.head.asInstanceOf[Declaration]
     decl.name shouldBe "b"
     decl.expr.get should matchPattern {
-      case ExprAdd(ExprAdd(ExprInt(1, _), ExprInt(2, _), _), ExprInt(3, _), _) =>
+      case ExprAdd(ExprAdd(ExprInt(1), ExprInt(2)), ExprInt(3)) =>
     }
   }
 
@@ -488,13 +471,12 @@ class ConcreteSyntaxDraft2Test extends AnyFlatSpec with Matchers {
     val decl = wf.body.head.asInstanceOf[Declaration]
     decl.name shouldBe "a"
     decl.expr.get should matchPattern {
-      case ExprApply("select_first",
-                     Vector(
-                         ExprArrayLiteral(Vector(ExprInt(3, _),
-                                                 ExprApply("round", Vector(ExprInt(100, _)), _)),
-                                          _)
-                     ),
-                     _) =>
+      case ExprApply(
+          "select_first",
+          Vector(
+              ExprArrayLiteral(Vector(ExprInt(3), ExprApply("round", Vector(ExprInt(100)))))
+          )
+          ) =>
         ()
     }
   }

--- a/src/test/scala/wdlTools/syntax/v1/ConcreteSyntaxV1Test.scala
+++ b/src/test/scala/wdlTools/syntax/v1/ConcreteSyntaxV1Test.scala
@@ -42,44 +42,44 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
     elem shouldBe a[Task]
     val task = elem.asInstanceOf[Task]
 
-    val InputSection(decls, _) = task.input.get
-    decls(0) should matchPattern { case Declaration("i", TypeInt(_), None, _)     => }
-    decls(1) should matchPattern { case Declaration("s", TypeString(_), None, _)  => }
-    decls(2) should matchPattern { case Declaration("x", TypeFloat(_), None, _)   => }
-    decls(3) should matchPattern { case Declaration("b", TypeBoolean(_), None, _) => }
-    decls(4) should matchPattern { case Declaration("f", TypeFile(_), None, _)    => }
+    val InputSection(decls) = task.input.get
+    decls(0) should matchPattern { case Declaration("i", TypeInt(_), None)     => }
+    decls(1) should matchPattern { case Declaration("s", TypeString(_), None)  => }
+    decls(2) should matchPattern { case Declaration("x", TypeFloat(_), None)   => }
+    decls(3) should matchPattern { case Declaration("b", TypeBoolean(_), None) => }
+    decls(4) should matchPattern { case Declaration("f", TypeFile(_), None)    => }
     decls(5) should matchPattern {
-      case Declaration("p1", TypePair(_: TypeInt, _: TypeString, _), None, _) =>
+      case Declaration("p1", TypePair(_: TypeInt, _: TypeString), None) =>
     }
     decls(6) should matchPattern {
-      case Declaration("p2", TypePair(_: TypeFloat, _: TypeFile, _), None, _) =>
+      case Declaration("p2", TypePair(_: TypeFloat, _: TypeFile), None) =>
     }
     decls(7) should matchPattern {
-      case Declaration("p3", TypePair(_: TypeBoolean, _: TypeBoolean, _), None, _) =>
+      case Declaration("p3", TypePair(_: TypeBoolean, _: TypeBoolean), None) =>
     }
     decls(8) should matchPattern {
-      case Declaration("ia", TypeArray(_: TypeInt, false, _), None, _) =>
+      case Declaration("ia", TypeArray(_: TypeInt, false), None) =>
     }
     decls(9) should matchPattern {
-      case Declaration("sa", TypeArray(_: TypeString, false, _), None, _) =>
+      case Declaration("sa", TypeArray(_: TypeString, false), None) =>
     }
     decls(10) should matchPattern {
-      case Declaration("xa", TypeArray(_: TypeFloat, false, _), None, _) =>
+      case Declaration("xa", TypeArray(_: TypeFloat, false), None) =>
     }
     decls(11) should matchPattern {
-      case Declaration("ba", TypeArray(_: TypeBoolean, false, _), None, _) =>
+      case Declaration("ba", TypeArray(_: TypeBoolean, false), None) =>
     }
     decls(12) should matchPattern {
-      case Declaration("fa", TypeArray(_: TypeFile, false, _), None, _) =>
+      case Declaration("fa", TypeArray(_: TypeFile, false), None) =>
     }
     decls(13) should matchPattern {
-      case Declaration("m_si", TypeMap(_: TypeInt, _: TypeString, _), None, _) =>
+      case Declaration("m_si", TypeMap(_: TypeInt, _: TypeString), None) =>
     }
     decls(14) should matchPattern {
-      case Declaration("m_ff", TypeMap(_: TypeFile, _: TypeFile, _), None, _) =>
+      case Declaration("m_ff", TypeMap(_: TypeFile, _: TypeFile), None) =>
     }
     decls(15) should matchPattern {
-      case Declaration("m_bf", TypeMap(_: TypeBoolean, _: TypeFloat, _), None, _) =>
+      case Declaration("m_bf", TypeMap(_: TypeBoolean, _: TypeFloat), None) =>
     }
   }
 
@@ -93,136 +93,121 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
     val task = elem.asInstanceOf[Task]
 
     task.declarations(0) should matchPattern {
-      case Declaration("i", _: TypeInt, Some(ExprInt(3, _)), _) =>
+      case Declaration("i", _: TypeInt, Some(ExprInt(3))) =>
     }
     task.declarations(1) should matchPattern {
-      case Declaration("s", _: TypeString, Some(ExprString("hello world", _)), _) =>
+      case Declaration("s", _: TypeString, Some(ExprString("hello world"))) =>
     }
     task.declarations(2) should matchPattern {
-      case Declaration("x", _: TypeFloat, Some(ExprFloat(4.3, _)), _) =>
+      case Declaration("x", _: TypeFloat, Some(ExprFloat(4.3))) =>
     }
     task.declarations(3) should matchPattern {
-      case Declaration("f", _: TypeFile, Some(ExprString("/dummy/x.txt", _)), _) =>
+      case Declaration("f", _: TypeFile, Some(ExprString("/dummy/x.txt"))) =>
     }
     task.declarations(4) should matchPattern {
-      case Declaration("b", _: TypeBoolean, Some(ExprBoolean(false, _)), _) =>
+      case Declaration("b", _: TypeBoolean, Some(ExprBoolean(false))) =>
     }
 
     // Logical expressions
     task.declarations(5) should matchPattern {
       case Declaration("b2",
                        _: TypeBoolean,
-                       Some(ExprLor(ExprBoolean(true, _), ExprBoolean(false, _), _)),
-                       _) =>
+                       Some(ExprLor(ExprBoolean(true), ExprBoolean(false)))) =>
     }
     task.declarations(6) should matchPattern {
       case Declaration("b3",
                        _: TypeBoolean,
-                       Some(ExprLand(ExprBoolean(true, _), ExprBoolean(false, _), _)),
-                       _) =>
+                       Some(ExprLand(ExprBoolean(true), ExprBoolean(false)))) =>
     }
     task.declarations(7) should matchPattern {
-      case Declaration("b4", _: TypeBoolean, Some(ExprEqeq(ExprInt(3, _), ExprInt(5, _), _)), _) =>
+      case Declaration("b4", _: TypeBoolean, Some(ExprEqeq(ExprInt(3), ExprInt(5)))) =>
     }
     task.declarations(8) should matchPattern {
-      case Declaration("b5", _: TypeBoolean, Some(ExprLt(ExprInt(4, _), ExprInt(5, _), _)), _) =>
+      case Declaration("b5", _: TypeBoolean, Some(ExprLt(ExprInt(4), ExprInt(5)))) =>
     }
     task.declarations(9) should matchPattern {
-      case Declaration("b6", _: TypeBoolean, Some(ExprGte(ExprInt(4, _), ExprInt(5, _), _)), _) =>
+      case Declaration("b6", _: TypeBoolean, Some(ExprGte(ExprInt(4), ExprInt(5)))) =>
     }
     task.declarations(10) should matchPattern {
-      case Declaration("b7", _: TypeBoolean, Some(ExprNeq(ExprInt(6, _), ExprInt(7, _), _)), _) =>
+      case Declaration("b7", _: TypeBoolean, Some(ExprNeq(ExprInt(6), ExprInt(7)))) =>
     }
     task.declarations(11) should matchPattern {
-      case Declaration("b8", _: TypeBoolean, Some(ExprLte(ExprInt(6, _), ExprInt(7, _), _)), _) =>
+      case Declaration("b8", _: TypeBoolean, Some(ExprLte(ExprInt(6), ExprInt(7)))) =>
     }
     task.declarations(12) should matchPattern {
-      case Declaration("b9", _: TypeBoolean, Some(ExprGt(ExprInt(6, _), ExprInt(7, _), _)), _) =>
+      case Declaration("b9", _: TypeBoolean, Some(ExprGt(ExprInt(6), ExprInt(7)))) =>
     }
     task.declarations(13) should matchPattern {
-      case Declaration("b10", _: TypeBoolean, Some(ExprNegate(ExprIdentifier("b2", _), _)), _) =>
+      case Declaration("b10", _: TypeBoolean, Some(ExprNegate(ExprIdentifier("b2")))) =>
     }
 
     // Arithmetic
     task.declarations(14) should matchPattern {
-      case Declaration("j", _: TypeInt, Some(ExprAdd(ExprInt(4, _), ExprInt(5, _), _)), _) =>
+      case Declaration("j", _: TypeInt, Some(ExprAdd(ExprInt(4), ExprInt(5)))) =>
     }
     task.declarations(15) should matchPattern {
-      case Declaration("j1", _: TypeInt, Some(ExprMod(ExprInt(4, _), ExprInt(10, _), _)), _) =>
+      case Declaration("j1", _: TypeInt, Some(ExprMod(ExprInt(4), ExprInt(10)))) =>
     }
     task.declarations(16) should matchPattern {
-      case Declaration("j2", _: TypeInt, Some(ExprDivide(ExprInt(10, _), ExprInt(7, _), _)), _) =>
+      case Declaration("j2", _: TypeInt, Some(ExprDivide(ExprInt(10), ExprInt(7)))) =>
     }
     task.declarations(17) should matchPattern {
-      case Declaration("j3", _: TypeInt, Some(ExprIdentifier("j", _)), _) =>
+      case Declaration("j3", _: TypeInt, Some(ExprIdentifier("j"))) =>
     }
     task.declarations(18) should matchPattern {
-      case Declaration("j4",
-                       _: TypeInt,
-                       Some(ExprAdd(ExprIdentifier("j", _), ExprInt(19, _), _)),
-                       _) =>
+      case Declaration("j4", _: TypeInt, Some(ExprAdd(ExprIdentifier("j"), ExprInt(19)))) =>
     }
 
     task.declarations(19) should matchPattern {
       case Declaration(
           "ia",
-          TypeArray(_: TypeInt, false, _),
-          Some(ExprArrayLiteral(Vector(ExprInt(1, _), ExprInt(2, _), ExprInt(3, _)), _)),
-          _
+          TypeArray(_: TypeInt, false),
+          Some(ExprArrayLiteral(Vector(ExprInt(1), ExprInt(2), ExprInt(3))))
           ) =>
     }
     task.declarations(20) should matchPattern {
       case Declaration("ia",
-                       TypeArray(_: TypeInt, true, _),
-                       Some(ExprArrayLiteral(Vector(ExprInt(10, _)), _)),
-                       _) =>
+                       TypeArray(_: TypeInt, true),
+                       Some(ExprArrayLiteral(Vector(ExprInt(10))))) =>
     }
     task.declarations(21) should matchPattern {
-      case Declaration("k",
-                       _: TypeInt,
-                       Some(ExprAt(ExprIdentifier("ia", _), ExprInt(3, _), _)),
-                       _) =>
+      case Declaration("k", _: TypeInt, Some(ExprAt(ExprIdentifier("ia"), ExprInt(3)))) =>
     }
     task.declarations(22) should matchPattern {
-      case Declaration(
-          "k2",
-          _: TypeInt,
-          Some(ExprApply("f", Vector(ExprInt(1, _), ExprInt(2, _), ExprInt(3, _)), _)),
-          _
-          ) =>
+      case Declaration("k2",
+                       _: TypeInt,
+                       Some(ExprApply("f", Vector(ExprInt(1), ExprInt(2), ExprInt(3))))) =>
     }
 
     task.declarations(23) should matchPattern {
-      case Declaration("m", TypeMap(TypeInt(_), TypeString(_), _), Some(ExprMapLiteral(_, _)), _) =>
+      case Declaration("m", TypeMap(TypeInt(_), TypeString(_)), Some(ExprMapLiteral(_))) =>
     }
     /*    val m = task.declarations(23).expr
     m should matchPattern {
-      case Map(ExprInt(1, _) -> ExprString("a", _),
-                                      ExprInt(2, _) -> ExprString("b", _)),
+      case Map(ExprInt(1) -> ExprString("a"),
+                                      ExprInt(2) -> ExprString("b")),
     _)),*/
 
     task.declarations(24) should matchPattern {
       case Declaration("k3",
                        _: TypeInt,
-                       Some(ExprIfThenElse(ExprBoolean(true, _), ExprInt(1, _), ExprInt(2, _), _)),
-                       _) =>
+                       Some(ExprIfThenElse(ExprBoolean(true), ExprInt(1), ExprInt(2)))) =>
     }
     task.declarations(25) should matchPattern {
-      case Declaration("k4", _: TypeInt, Some(ExprGetName(ExprIdentifier("x", _), "a", _)), _) =>
+      case Declaration("k4", _: TypeInt, Some(ExprGetName(ExprIdentifier("x"), "a"))) =>
     }
 
     task.declarations(26) should matchPattern {
-      case Declaration("o", _: TypeObject, Some(ExprObjectLiteral(_, _)), _) =>
+      case Declaration("o", _: TypeObject, Some(ExprObjectLiteral(_))) =>
     }
-    /*(Map("A" -> ExprInt(1, _),
+    /*(Map("A" -> ExprInt(1),
      "B" -> ExprInt(2, _,
-     _))), _)) */
+     _))))) */
 
     task.declarations(27) should matchPattern {
       case Declaration("twenty_threes",
-                       TypePair(TypeInt(_), TypeString(_), _),
-                       Some(ExprPair(ExprInt(23, _), ExprString("twenty-three", _), _)),
-                       _) =>
+                       TypePair(TypeInt(_), TypeString(_)),
+                       Some(ExprPair(ExprInt(23), ExprString("twenty-three")))) =>
     }
   }
 
@@ -239,13 +224,13 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
     task.input shouldBe None
     task.output shouldBe None
     task.command should matchPattern {
-      case CommandSection(Vector(), _) =>
+      case CommandSection(Vector()) =>
     }
     task.meta shouldBe None
     task.parameterMeta shouldBe None
 
     task.declarations(0) should matchPattern {
-      case Declaration("k", TypeInt(_), Some(ExprGetName(ExprIdentifier("x", _), "a", _)), _) =>
+      case Declaration("k", TypeInt(_), Some(ExprGetName(ExprIdentifier("x"), "a"))) =>
     }
   }
 
@@ -266,7 +251,7 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
 
     task.name shouldBe "wc"
     task.output.get should matchPattern {
-      case OutputSection(Vector(Declaration("num_lines", TypeInt(_), Some(ExprInt(3, _)), _)), _) =>
+      case OutputSection(Vector(Declaration("num_lines", TypeInt(_), Some(ExprInt(3))))) =>
     }
   }
 
@@ -304,37 +289,36 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
 
     task.name shouldBe "wc"
     task.input.get should matchPattern {
-      case InputSection(Vector(Declaration("inp_file", _: TypeFile, None, _)), _) =>
+      case InputSection(Vector(Declaration("inp_file", _: TypeFile, None))) =>
     }
     task.output.get should matchPattern {
-      case OutputSection(Vector(Declaration("num_lines", _: TypeInt, Some(ExprInt(3, _)), _)), _) =>
+      case OutputSection(Vector(Declaration("num_lines", _: TypeInt, Some(ExprInt(3))))) =>
     }
     task.command shouldBe a[CommandSection]
     task.command.parts.size shouldBe 3
     task.command.parts(0) should matchPattern {
-      case ExprString("\n    # this is inside the command and so not a WDL comment\n    wc -l ",
-                      _) =>
+      case ExprString("\n    # this is inside the command and so not a WDL comment\n    wc -l ") =>
     }
     task.command.parts(1) should matchPattern {
-      case ExprIdentifier("inp_file", _) =>
+      case ExprIdentifier("inp_file") =>
     }
 
     task.meta.get shouldBe a[MetaSection]
     task.meta.get.kvs.size shouldBe 1
     val mkv = task.meta.get.kvs.head
     mkv should matchPattern {
-      case MetaKV("author", MetaValueString("Robin Hood", _), _) =>
+      case MetaKV("author", MetaValueString("Robin Hood")) =>
     }
 
     task.parameterMeta.get shouldBe a[ParameterMetaSection]
     task.parameterMeta.get.kvs.size shouldBe 1
     val mpkv = task.parameterMeta.get.kvs.head
     mpkv should matchPattern {
-      case MetaKV("inp_file", MetaValueString("just because", _), _) =>
+      case MetaKV("inp_file", MetaValueString("just because")) =>
     }
 
     task.declarations(0) should matchPattern {
-      case Declaration("i", TypeInt(_), Some(ExprAdd(ExprInt(4, _), ExprInt(5, _), _)), _) =>
+      case Declaration("i", TypeInt(_), Some(ExprAdd(ExprInt(4), ExprInt(5)))) =>
     }
   }
 
@@ -357,23 +341,22 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
     task.input.get shouldBe a[InputSection]
     task.input.get.declarations.size shouldBe 2
     task.input.get.declarations(0) should matchPattern {
-      case Declaration("min_std_max_min", TypeInt(_), None, _) =>
+      case Declaration("min_std_max_min", TypeInt(_), None) =>
     }
     task.input.get.declarations(1) should matchPattern {
-      case Declaration("prefix", TypeString(_), None, _) =>
+      case Declaration("prefix", TypeString(_), None) =>
     }
 
     task.command shouldBe a[CommandSection]
     task.command.parts(0) should matchPattern {
-      case ExprString("\n    echo ", _) =>
+      case ExprString("\n    echo ") =>
     }
     task.command.parts(1) should matchPattern {
       case ExprPlaceholder(None,
                            None,
-                           Some(ExprString(",", _)),
+                           Some(ExprString(",")),
                            None,
-                           ExprIdentifier("min_std_max_min", _),
-                           _) =>
+                           ExprIdentifier("min_std_max_min")) =>
     }
   }
 
@@ -388,16 +371,16 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
     structs(0).name shouldBe "Address"
     structs(0).members.size shouldBe 3
     structs(0).members should matchPattern {
-      case Vector(StructMember("street", TypeString(_), _),
-                  StructMember("city", TypeString(_), _),
-                  StructMember("zipcode", TypeInt(_), _)) =>
+      case Vector(StructMember("street", TypeString(_)),
+                  StructMember("city", TypeString(_)),
+                  StructMember("zipcode", TypeInt(_))) =>
     }
 
     structs(1).name shouldBe "Data"
     structs(1).members should matchPattern {
-      case Vector(StructMember("history", TypeFile(_), _),
-                  StructMember("date", TypeInt(_), _),
-                  StructMember("month", TypeString(_), _)) =>
+      case Vector(StructMember("history", TypeFile(_)),
+                  StructMember("date", TypeInt(_)),
+                  StructMember("month", TypeString(_))) =>
     }
   }
 
@@ -417,10 +400,10 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
     }
     calls.size shouldBe 1
     calls(0) should matchPattern {
-      case Call("bar", Some(CallAlias("boz", _)), _, _) =>
+      case Call("bar", Some(CallAlias("boz")), _) =>
     }
     calls(0).inputs.get.value should matchPattern {
-      case Vector(CallInput("i", ExprIdentifier("s", _), _)) =>
+      case Vector(CallInput("i", ExprIdentifier("s"))) =>
     }
 
     val scatters = wf.body.collect {
@@ -429,15 +412,15 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
     scatters.size shouldBe 1
     scatters(0).identifier shouldBe "i"
     scatters(0).expr should matchPattern {
-      case ExprArrayLiteral(Vector(ExprInt(1, _), ExprInt(2, _), ExprInt(3, _)), _) =>
+      case ExprArrayLiteral(Vector(ExprInt(1), ExprInt(2), ExprInt(3))) =>
     }
     scatters(0).body.size shouldBe 1
     scatters(0).body(0) should matchPattern {
-      case Call("add", None, _, _) =>
+      case Call("add", None, _) =>
     }
     val call = scatters(0).body(0).asInstanceOf[Call]
     call.inputs.get.value should matchPattern {
-      case Vector(CallInput("x", ExprIdentifier("i", _), _)) =>
+      case Vector(CallInput("x", ExprIdentifier("i"))) =>
     }
 
     val conditionals = wf.body.collect {
@@ -445,16 +428,16 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
     }
     conditionals.size shouldBe 1
     conditionals(0).expr should matchPattern {
-      case ExprEqeq(ExprBoolean(true, _), ExprBoolean(false, _), _) =>
+      case ExprEqeq(ExprBoolean(true), ExprBoolean(false)) =>
     }
     conditionals(0).body should matchPattern {
-      case Vector(Call("sub", None, _, _)) =>
+      case Vector(Call("sub", None, _)) =>
     }
     conditionals(0).body(0).asInstanceOf[Call].inputs.size shouldBe 0
 
     wf.meta.get shouldBe a[MetaSection]
     wf.meta.get.kvs should matchPattern {
-      case Vector(MetaKV("author", MetaValueString("Robert Heinlein", _), _)) =>
+      case Vector(MetaKV("author", MetaValueString("Robert Heinlein"))) =>
     }
   }
 
@@ -496,9 +479,7 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
     val decl = task.declarations.head
     decl.name shouldBe "j"
     decl.expr.get should matchPattern {
-      case ExprAdd(ExprAdd(ExprIdentifier("i", _), ExprIdentifier("i", _), _),
-                   ExprIdentifier("i", _),
-                   _) =>
+      case ExprAdd(ExprAdd(ExprIdentifier("i"), ExprIdentifier("i")), ExprIdentifier("i")) =>
     }
   }
 
@@ -514,7 +495,7 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
     val decl = wf.body.head.asInstanceOf[Declaration]
     decl.name shouldBe "b"
     decl.expr.get should matchPattern {
-      case ExprAdd(ExprAdd(ExprInt(1, _), ExprInt(2, _), _), ExprInt(3, _), _) =>
+      case ExprAdd(ExprAdd(ExprInt(1), ExprInt(2)), ExprInt(3)) =>
     }
   }
 
@@ -549,13 +530,12 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
     val decl = wf.body.head.asInstanceOf[Declaration]
     decl.name shouldBe "a"
     decl.expr.get should matchPattern {
-      case ExprApply("select_first",
-                     Vector(
-                         ExprArrayLiteral(Vector(ExprInt(3, _),
-                                                 ExprApply("round", Vector(ExprInt(100, _)), _)),
-                                          _)
-                     ),
-                     _) =>
+      case ExprApply(
+          "select_first",
+          Vector(
+              ExprArrayLiteral(Vector(ExprInt(3), ExprApply("round", Vector(ExprInt(100)))))
+          )
+          ) =>
         ()
     }
   }
@@ -613,7 +593,7 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
     val metaKvs = task.meta.get.kvs
     metaKvs.size shouldBe 1
     metaKvs.head should matchPattern {
-      case MetaKV("version", MetaValueString("1.1", _), _) =>
+      case MetaKV("version", MetaValueString("1.1")) =>
     }
     task.parameterMeta shouldBe defined
     val paramMetaKvs = task.parameterMeta.get.kvs
@@ -621,26 +601,23 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
     paramMetaKvs(0) should matchPattern {
       case MetaKV(
           "i",
-          MetaValueObject(Vector(
-                              MetaKV("description", MetaValueString("An int", _), _),
-                              MetaKV("default", MetaValueInt(3, _), _),
-                              MetaKV("array_of_objs",
-                                     MetaValueArray(
-                                         Vector(
-                                             MetaValueObject(
-                                                 Vector(
-                                                     MetaKV("foo", MetaValueBoolean(false, _), _),
-                                                     MetaKV("bar", MetaValueFloat(1.0, _), _)
-                                                 ),
-                                                 _
-                                             )
-                                         ),
-                                         _
-                                     ),
-                                     _)
-                          ),
-                          _),
-          _
+          MetaValueObject(
+              Vector(
+                  MetaKV("description", MetaValueString("An int")),
+                  MetaKV("default", MetaValueInt(3)),
+                  MetaKV("array_of_objs",
+                         MetaValueArray(
+                             Vector(
+                                 MetaValueObject(
+                                     Vector(
+                                         MetaKV("foo", MetaValueBoolean(false)),
+                                         MetaKV("bar", MetaValueFloat(1.0))
+                                     )
+                                 )
+                             )
+                         ))
+              )
+          )
           ) =>
     }
   }
@@ -665,22 +642,19 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
     wf.body(0) should matchPattern {
       case Declaration(
           "a",
-          TypeArray(TypeInt(_), false, _),
-          Some(ExprArrayLiteral(Vector(ExprInt(1, _), ExprInt(2, _), ExprInt(3, _)), _)),
-          _
+          TypeArray(TypeInt(_), false),
+          Some(ExprArrayLiteral(Vector(ExprInt(1), ExprInt(2), ExprInt(3))))
           ) =>
     }
     wf.body(1) should matchPattern {
       case Declaration(
           "m",
-          TypeMap(TypeString(_), TypeInt(_), _),
+          TypeMap(TypeString(_), TypeInt(_)),
           Some(
               ExprMapLiteral(
-                  Vector(ExprMember(ExprString("hello", _), ExprInt(1, _), _)),
-                  _
+                  Vector(ExprMember(ExprString("hello"), ExprInt(1)))
               )
-          ),
-          _
+          )
           ) =>
     }
     wf.body(2) should matchPattern {
@@ -689,18 +663,13 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
           TypeObject(_),
           Some(
               ExprObjectLiteral(
-                  Vector(ExprMember(ExprString("foo", _), ExprInt(2, _), _)),
-                  _
+                  Vector(ExprMember(ExprString("foo"), ExprInt(2)))
               )
-          ),
-          _
+          )
           ) =>
     }
     wf.body(3) should matchPattern {
-      case Call("baz",
-                None,
-                Some(CallInputs(Vector(CallInput("s", ExprString("hi", _), _)), _)),
-                _) =>
+      case Call("baz", None, Some(CallInputs(Vector(CallInput("s", ExprString("hi")))))) =>
     }
 
     wf.meta shouldBe defined
@@ -708,14 +677,11 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
     meta.size shouldBe 5
     meta should matchPattern {
       case Vector(
-          MetaKV("x", MetaValueString("'", _), _),
-          MetaKV("y", MetaValueString("\"", _), _),
-          MetaKV("foo", MetaValueObject(Vector(MetaKV("bar", MetaValueInt(1, _), _)), _), _),
-          MetaKV("baz",
-                 MetaValueArray(Vector(MetaValueInt(1, _), MetaValueInt(2, _), MetaValueInt(3, _)),
-                                _),
-                 _),
-          MetaKV("blorf", MetaValueArray(Vector(), _), _)
+          MetaKV("x", MetaValueString("'")),
+          MetaKV("y", MetaValueString("\"")),
+          MetaKV("foo", MetaValueObject(Vector(MetaKV("bar", MetaValueInt(1))))),
+          MetaKV("baz", MetaValueArray(Vector(MetaValueInt(1), MetaValueInt(2), MetaValueInt(3)))),
+          MetaKV("blorf", MetaValueArray(Vector()))
           ) =>
     }
   }
@@ -734,13 +700,13 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
 
   private def getString(expr: Expr): String = {
     expr match {
-      case ExprString(value, _) => value
-      case ExprCompoundString(parts, _) =>
+      case ExprString(value) => value
+      case ExprCompoundString(parts) =>
         parts
           .flatMap {
-            case ExprString(s, _)        => Vector(s)
-            case cs: ExprCompoundString  => getString(cs)
-            case ExprIdentifier(name, _) => Vector(s"$${${name}}")
+            case ExprString(s)          => Vector(s)
+            case cs: ExprCompoundString => getString(cs)
+            case ExprIdentifier(name)   => Vector(s"$${${name}}")
             case other =>
               throw new Exception(s"unexpected expression ${other}")
           }
@@ -762,7 +728,7 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
       .getOrElse(throw new Exception("missing declaration actual_read_group"))
     val s = decl.expr match {
       case Some(
-          ExprApply("select_first", Vector(ExprArrayLiteral(Vector(_, cs), _)), _)
+          ExprApply("select_first", Vector(ExprArrayLiteral(Vector(_, cs))))
           ) =>
         getString(cs)
       case _ =>
@@ -784,7 +750,7 @@ class ConcreteSyntaxV1Test extends AnyFlatSpec with Matchers {
       .getOrElse(throw new Exception("missing declaration actual_read_group"))
     val strings = decl.expr match {
       case Some(
-          ExprArrayLiteral(strings, _)
+          ExprArrayLiteral(strings)
           ) =>
         strings.map(getString)
       case _ =>

--- a/src/test/scala/wdlTools/syntax/v2/ConcreteSyntaxV2Test.scala
+++ b/src/test/scala/wdlTools/syntax/v2/ConcreteSyntaxV2Test.scala
@@ -29,13 +29,13 @@ class ConcreteSyntaxV2Test extends AnyFlatSpec with Matchers {
     elem shouldBe a[Task]
     val task = elem.asInstanceOf[Task]
 
-    val InputSection(decls, _) = task.input.get
-    decls(0) should matchPattern { case Declaration("i", TypeInt(_), None, _)       => }
-    decls(1) should matchPattern { case Declaration("s", TypeString(_), None, _)    => }
-    decls(2) should matchPattern { case Declaration("x", TypeFloat(_), None, _)     => }
-    decls(3) should matchPattern { case Declaration("b", TypeBoolean(_), None, _)   => }
-    decls(4) should matchPattern { case Declaration("f", TypeFile(_), None, _)      => }
-    decls(5) should matchPattern { case Declaration("d", TypeDirectory(_), None, _) => }
+    val InputSection(decls) = task.input.get
+    decls(0) should matchPattern { case Declaration("i", TypeInt(), None)       => }
+    decls(1) should matchPattern { case Declaration("s", TypeString(), None)    => }
+    decls(2) should matchPattern { case Declaration("x", TypeFloat(), None)     => }
+    decls(3) should matchPattern { case Declaration("b", TypeBoolean(), None)   => }
+    decls(4) should matchPattern { case Declaration("f", TypeFile(), None)      => }
+    decls(5) should matchPattern { case Declaration("d", TypeDirectory(), None) => }
   }
 
   it should "parse a complex workflow with imports" in {
@@ -54,10 +54,10 @@ class ConcreteSyntaxV2Test extends AnyFlatSpec with Matchers {
   it should "handle passthrough syntax for call inputs" in {
     val doc = getDocument(getSource("passthrough.wdl"))
     doc.workflow.get.body match {
-      case Vector(Call(_, _, _, Some(inputs), _)) =>
+      case Vector(Call(_, _, _, Some(inputs))) =>
         inputs.value.size shouldBe 1
         inputs.value.head.expr should matchPattern {
-          case ExprIdentifier("s", _) =>
+          case ExprIdentifier("s") =>
         }
       case _ => throw new Exception("unexpected inputs")
     }

--- a/src/test/scala/wdlTools/types/TypeInferTest.scala
+++ b/src/test/scala/wdlTools/types/TypeInferTest.scala
@@ -72,26 +72,26 @@ class TypeInferTest extends AnyFlatSpec with Matchers {
     }.head
     task.outputs.size shouldBe 1
     task.outputs.head match {
-      case TAT.OutputParameter("name", WdlTypes.T_Struct("Name", types), expr, _) =>
+      case TAT.OutputParameter("name", WdlTypes.T_Struct("Name", types), expr) =>
         val typesMap = Map(
             "first" -> WdlTypes.T_String,
             "last" -> WdlTypes.T_String
         )
         types shouldBe typesMap
         expr match {
-          case TAT.ExprObject(members, WdlTypes.T_Struct("Name", types), _) =>
+          case TAT.ExprObject(members, WdlTypes.T_Struct("Name", types)) =>
             types shouldBe typesMap
             val objMembers = members.map {
-              case (TAT.ValueString(key, WdlTypes.T_String, _), value) => key -> value
+              case (TAT.ValueString(key, WdlTypes.T_String), value) => key -> value
               case other =>
                 throw new Exception(s"invalid object key ${other}")
             }
             objMembers.keySet shouldBe Set("first", "last")
             objMembers("first") should matchPattern {
-              case TAT.ExprIdentifier("first", WdlTypes.T_String, _) =>
+              case TAT.ExprIdentifier("first", WdlTypes.T_String) =>
             }
             objMembers("last") should matchPattern {
-              case TAT.ExprIdentifier("last", WdlTypes.T_String, _) =>
+              case TAT.ExprIdentifier("last", WdlTypes.T_String) =>
             }
           case _ =>
             throw new Exception("invalid expression for output 'name'")
@@ -104,11 +104,11 @@ class TypeInferTest extends AnyFlatSpec with Matchers {
   it should "compare identical callables as equal" in {
     val tDoc = check(v1Dir, "top_level.wdl")
     val topImports = tDoc.elements.collect {
-      case TAT.ImportDoc(namespace, _, _, doc, _) => namespace -> doc
+      case TAT.ImportDoc(namespace, _, _, doc) => namespace -> doc
     }.toMap
     topImports.size shouldBe 2
     val subImports = topImports("sub").elements.collect {
-      case TAT.ImportDoc(namespace, _, _, doc, _) => namespace -> doc
+      case TAT.ImportDoc(namespace, _, _, doc) => namespace -> doc
     }.toMap
     subImports.size shouldBe 1
     val topTasks = topImports("tasks").elements.collect {


### PR DESCRIPTION
Previously, the `loc: SourceLocation` field was included in the first parameter section of all AST case classes, which caused it to be included in the automatically generated `equals` and `hashCode` methods. This breaks when the same file is imported in two different places, causing the path of the source file to be different, or when code is generated with slightly different syntax and then reparsed and compared with the original code. This PR moves `loc` to the second parameter section.

In the process, some of the AST field names were changed for greater clarity, which constitute breaking changes (hence the 0.13.0 version). There are also cleanups to the parser code and improvements of error messages.