### PR TITLE
Disable line wrapping in placeholders

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,8 +3,9 @@
 ## in develop
 
 * Fixes quoting and escaping of import URIs by code formatter/generator
+* Disables wrapping of expressions within placeholders
 
-## 0.13.0
+## 0.13.0 (2021-05-20)
 
 * **Breaking changes**:
     * `loc` is moved from the first to second parameter section in all AST case classes to prevent it from being included in the `equals` and `hashCode` implementations

--- a/src/main/scala/wdlTools/generators/code/WdlGenerator.scala
+++ b/src/main/scala/wdlTools/generators/code/WdlGenerator.scala
@@ -476,12 +476,13 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
   }
 
   private case class Placeholder(value: Sized,
-                                 ctx: ExpressionContext,
+                                 open: String,
+                                 inString: Boolean,
                                  options: Option[Vector[Sized]] = None)
       extends Group(
-          ends = Some(Literal(ctx.placeholderOpen), Literal(Symbols.PlaceholderClose)),
-          wrapping = if (ctx.inString(quoted = true)) Wrapping.Never else Wrapping.AsNeeded,
-          spacing = if (ctx.inString()) Spacing.Off else Spacing.On
+          ends = Some(Literal(open), Literal(Symbols.PlaceholderClose)),
+          wrapping = if (inString) Wrapping.Never else Wrapping.AsNeeded,
+          spacing = if (inString) Spacing.Off else Spacing.On
       )
       with Composite {
 
@@ -554,13 +555,14 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
             value.map(buildExpression(_, ctx)),
             Some(Symbols.ArrayDelimiter),
             Some(Literal(Symbols.ArrayLiteralOpen), Literal(Symbols.ArrayLiteralClose)),
-            wrapping = Wrapping.AllOrNone
+            wrapping = if (ctx.inString()) Wrapping.Never else Wrapping.AllOrNone
         )
       case ExprPair(left, right, _) =>
         Container(
             Vector(buildExpression(left, ctx), buildExpression(right, ctx)),
             Some(Symbols.ArrayDelimiter),
-            Some(Literal(Symbols.GroupOpen), Literal(Symbols.GroupClose))
+            Some(Literal(Symbols.GroupOpen), Literal(Symbols.GroupClose)),
+            wrapping = if (ctx.inString()) Wrapping.Never else Wrapping.AsNeeded
         )
       case ExprMap(value, _) =>
         Container(
@@ -569,7 +571,7 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
             }.toVector,
             Some(Symbols.ArrayDelimiter),
             Some(Literal(Symbols.MapOpen), Literal(Symbols.MapClose)),
-            Wrapping.Always,
+            wrapping = if (ctx.inString()) Wrapping.Never else Wrapping.Always,
             continue = false
         )
       case ExprObject(value, wdlType) =>
@@ -591,14 +593,15 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
             Some(Symbols.ArrayDelimiter),
             Some(Sequence(Vector(Literal(name), Literal(Symbols.ObjectOpen)), spacing = Spacing.On),
                  Literal(Symbols.ObjectClose)),
-            Wrapping.Always,
+            wrapping = if (ctx.inString()) Wrapping.Never else Wrapping.Always,
             continue = false
         )
       // placeholders
       case ExprPlaceholder(t, f, sep, default, value, _) =>
         Placeholder(
             buildExpression(value, ctx.advanceTo(InPlaceholderState)),
-            ctx,
+            ctx.placeholderOpen,
+            ctx.inString(),
             Some(
                 Vector(
                     t.map(e => placeholderOption(Symbols.TrueOption, e)),
@@ -634,7 +637,8 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
             Container(
                 Vector(buildExpression(index, nextCtx)),
                 Some(Symbols.ArrayDelimiter),
-                Some(prefix, suffix)
+                Some(prefix, suffix),
+                wrapping = if (ctx.inString()) Wrapping.Never else Wrapping.AsNeeded
             )
           case ExprIfThenElse(cond, tBranch, fBranch, _) =>
             val condSized = buildExpression(cond, nextCtx)
@@ -648,7 +652,8 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
                     tSized,
                     Literal(Symbols.Else),
                     fSized
-                )
+                ),
+                wrapping = if (ctx.inString()) Wrapping.Never else Wrapping.AsNeeded
             )
           case ExprApply(oper, _, Vector(ExprArray(args, _)), _)
               if Operator.Vectorizable.contains(oper) =>
@@ -673,7 +678,8 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
             Container(
                 elements.map(buildExpression(_, nextCtx)),
                 Some(Symbols.ArrayDelimiter),
-                Some(prefix, suffix)
+                Some(prefix, suffix),
+                wrapping = if (ctx.inString()) Wrapping.Never else Wrapping.AsNeeded
             )
           case ExprGetName(e, id, _) =>
             val exprSized = buildExpression(e, nextCtx)
@@ -684,7 +690,7 @@ case class WdlGenerator(targetVersion: Option[WdlVersion] = None, omitNullInputs
           case other => throw new Exception(s"Unrecognized expression $other")
         }
         if (ctx.inString(resetInPlaceholder = true)) {
-          Placeholder(sized, ctx)
+          Placeholder(sized, ctx.placeholderOpen, ctx.inString())
         } else {
           sized
         }


### PR DESCRIPTION
A regression was introduced by #147. Expressions in placeholders are not meant to be line-wrapped. This PR again disables line wrapping in placeholders.