### PR TITLE
Fix some issues with the `fix` command

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 * Adds `fix` tool to automatically fix some non-compliant WDL syntax
 * Improve error messages in expression evaluator
 
+
 ## 0.13.1 (2021-05-27)
 
 * Fixes handling of relative imports for WDL specified using non-file URIs (e.g. http(s))

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,14 @@
 # Change log
 
+## in develop
+
+* Allows automatic coersion of `read_*` return values from `String` to other primitive types
+* Fixes handling of relative imports that are not in a subdirectory of the main WDL's parent directory
+
 ## 0.14.0 (2021-05-27)
 
 * Adds `fix` tool to automatically fix some non-compliant WDL syntax
 * Improve error messages in expression evaluator
-
 
 ## 0.13.1 (2021-05-27)
 

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val wdlTools = root.settings(
 )
 
 lazy val dependencies = {
-  val dxCommonVersion = "0.4.0"
+  val dxCommonVersion = "0.4.1-SNAPSHOT"
   val antlr4Version = "4.9"
   val scallopVersion = "3.4.0"
   val typesafeVersion = "1.3.3"

--- a/doc/Commands/Fix.md
+++ b/doc/Commands/Fix.md
@@ -25,6 +25,49 @@ The `fix` command attempts to automatically fix WDL files with the following spe
 
 Additional fixes will be added as needed. Please request them by opening an [issue](https://github.com/dnanexus-rnd/wdlTools/issues).
 
+## Issues that cannot be fixed (partial list)
+
+* Re-usage of variable names within the same scope, e.g.
+    ```wdl
+    task bad_juju {
+      input {
+        String foo
+      }
+      ...
+      output {
+        Int foo
+      }
+    }
+    ```
+* Coercions from `String` to non-`String` values are allowed within the context of `read_*` return values, but not otherwise. For example, this is legal:
+    ```wdl
+    task ok {
+      command <<<
+      echo "1\n2\n3" > ints.txt
+      >>>
+      output {
+        Array[Int] ints = read_lines("ints.txt")
+      }
+    }
+    ```
+    but this is illegal:
+    ```wdl
+    workflow not_ok {
+      call ints_to_strings
+      output {
+        Array[Int] ints = ints_to_strings.strings
+      }
+    }
+    task ints_to_strings {
+      command <<<
+      echo "1\n2\n3" > ints.txt
+      >>>
+      output {
+        Array[String] strings = read_lines("ints.txt")
+      }
+    }
+    ```
+
 ## Example
 
 ```bash

--- a/src/main/scala/wdlTools/cli/Fix.scala
+++ b/src/main/scala/wdlTools/cli/Fix.scala
@@ -1,13 +1,12 @@
 package wdlTools.cli
 
-import java.nio.file.{Path, Paths}
+import java.nio.file.Paths
 import wdlTools.generators.code.WdlGenerator
-import dx.util.{AddressableFileSource, FileNode, FileSourceResolver, FileUtils, LinesFileNode}
+import dx.util.{AddressableFileSource, FileNode, FileSourceResolver, LinesFileNode}
 import wdlTools.syntax.{Parsers, SyntaxException}
 import wdlTools.types.TypedAbstractSyntax.{Document, ImportDoc}
-import wdlTools.types.{TypeCheckingRegime, TypeException, TypeInfer}
+import wdlTools.types.TypeCheckingRegime
 
-import java.io.{ByteArrayOutputStream, PrintStream}
 import scala.collection.immutable.SeqMap
 import scala.language.reflectiveCalls
 
@@ -15,50 +14,12 @@ case class Fix(conf: WdlToolsConf) extends Command {
   override def apply(): Unit = {
     val fileResolver = FileSourceResolver.get
     val docSource = fileResolver.resolve(conf.fix.uri())
-    val baseFileSource =
-      conf.fix.baseUri.toOption
-        .map(fileResolver.resolveDirectory(_))
-        .orElse(docSource.getParent)
-        .getOrElse(
-            throw new Exception(s"cannot determine the base FileSource for main WDL ${docSource}")
-        )
     val srcVersion = conf.fix.srcVersion.toOption
-    val outputDir = conf.fix.outputDir.toOption.getOrElse(Paths.get("."))
-    val overwrite = conf.fix.overwrite()
     val wdlVersion = srcVersion.getOrElse(Parsers.default.getWdlVersion(docSource))
 
-    def parseAndCheck(
-        source: FileNode,
-        message: String,
-        regime: TypeCheckingRegime.TypeCheckingRegime,
-        fileResolver: FileSourceResolver
-    ): Document = {
-      val errorHandler = new ErrorHandler()
-      val parsers = Parsers(conf.fix.followImports(), fileResolver = fileResolver)
-      val parser = parsers.getParser(wdlVersion)
-      val checker =
-        TypeInfer(regime, fileResolver = fileResolver, errorHandler = Some(errorHandler.apply))
-      val document =
-        try {
-          val (document, _) = checker.apply(parser.parseDocument(source))
-          document
-        } catch {
-          case e: SyntaxException =>
-            throw new Exception(s"Failed to parse ${source}; ${message}", e)
-          case e: TypeException =>
-            throw new Exception(s"Failed to type-check ${source}; ${message}", e)
-        }
-      if (errorHandler.hasErrors) {
-        val msgStream = new ByteArrayOutputStream()
-        errorHandler.printErrors(new PrintStream(msgStream), effects = true)
-        throw new Exception(
-            s"Failed to type-check ${source}; ${message}:\n${msgStream.toString()}"
-        )
-      }
-      document
-    }
-
     val document = parseAndCheck(docSource,
+                                 wdlVersion,
+                                 conf.fix.followImports(),
                                  "this error cannot be fixed automatically",
                                  TypeCheckingRegime.Lenient,
                                  fileResolver)
@@ -66,16 +27,13 @@ case class Fix(conf: WdlToolsConf) extends Command {
     // use a SeqMap so that the first entry will be the file generated from the source document
     val generator =
       WdlGenerator(Some(wdlVersion), omitNullCallInputs = false, rewriteNonstandardUsages = true)
-    var results: SeqMap[Path, Iterable[String]] = SeqMap.empty
-    var visited: Set[String] = Set.empty
+    var results: SeqMap[AddressableFileSource, Iterable[String]] = SeqMap.empty
 
     def generateDocument(fileSource: FileNode, doc: Document): Unit = {
       fileSource match {
-        case fs: AddressableFileSource if !visited.contains(fileSource.toString) =>
-          visited += fileSource.toString
-          val outputPath = outputDir.resolve(baseFileSource.relativize(fs))
+        case fs: AddressableFileSource if !results.contains(fs) =>
           val lines = generator.generateDocument(doc)
-          results += outputPath -> lines
+          results += fs -> lines
           doc.elements.foreach {
             case ImportDoc(_, _, addr, doc) =>
               generateDocument(fileResolver.resolve(addr, Some(fs)), doc)
@@ -91,9 +49,9 @@ case class Fix(conf: WdlToolsConf) extends Command {
     // validate that the generated files parse
     val validationParser = Parsers.default.getParser(wdlVersion)
     results.foreach {
-      case (path, lines) =>
+      case (fs, lines) =>
         try {
-          validationParser.parseDocument(LinesFileNode(lines.toVector, path.toString))
+          validationParser.parseDocument(LinesFileNode(lines.toVector, fs.toString))
         } catch {
           case e: SyntaxException =>
             throw new Exception(
@@ -103,20 +61,19 @@ case class Fix(conf: WdlToolsConf) extends Command {
         }
     }
 
-    // write out fixed versions
-    results.foreach {
-      case (path, lines) =>
-        FileUtils.writeFileContent(path, lines.mkString(System.lineSeparator()), overwrite)
-    }
-
     // Validate that the fixed versions type-check correctly - we can't do this until
     // after we write out the documents because otherwise import resolution won't work -
-    // this should only fail if there is a bug in the code generator. Prepend the output
-    // dir to the search path.
+    // this should only fail if there is a bug in the code generator.
+    val outputDir = conf.fix.outputDir.toOption.getOrElse(Paths.get("."))
+    val overwrite = conf.fix.overwrite()
+    val outputPaths = writeDocuments(results, Some(outputDir), overwrite)
+    // Prepend the output dir to the search path.
     val rewrittenFileResolver = fileResolver.addToLocalSearchPath(Vector(outputDir), append = false)
     parseAndCheck(
-        rewrittenFileResolver.fromPath(results.head._1),
-        "this is likely due to a bug in the WDL code generator - please report this issue",
+        rewrittenFileResolver.fromPath(outputPaths(results.head._1)),
+        wdlVersion,
+        conf.fix.followImports(),
+        "this may be an unsupported fix, or it may be due to a bug in the WDL code generator - please report this issue",
         TypeCheckingRegime.Moderate,
         rewrittenFileResolver
     )

--- a/src/main/scala/wdlTools/cli/Format.scala
+++ b/src/main/scala/wdlTools/cli/Format.scala
@@ -1,7 +1,7 @@
 package wdlTools.cli
 
 import wdlTools.generators.code.WdlFormatter
-import dx.util.{FileSourceResolver, FileUtils, LocalFileSource}
+import dx.util.FileSourceResolver
 
 import scala.language.reflectiveCalls
 
@@ -10,19 +10,9 @@ case class Format(conf: WdlToolsConf) extends Command {
     val docSource = FileSourceResolver.get.resolve(conf.format.uri())
     val outputDir = conf.format.outputDir.toOption
     val overwrite = conf.format.overwrite()
-    val formatter = WdlFormatter(followImports = conf.format.followImports())
+    val followImports = conf.format.followImports()
+    val formatter = WdlFormatter(followImports = followImports)
     val documents = formatter.formatDocuments(docSource)
-    documents.foreach {
-      case (source, lines) if outputDir.isDefined =>
-        FileUtils.writeFileContent(outputDir.get.resolve(source.name),
-                                   lines.mkString(System.lineSeparator()),
-                                   overwrite = overwrite)
-      case (localSource: LocalFileSource, lines) if overwrite =>
-        FileUtils.writeFileContent(localSource.canonicalPath,
-                                   lines.mkString(System.lineSeparator()),
-                                   overwrite = true)
-      case (_, lines) =>
-        println(lines.mkString(System.lineSeparator()))
-    }
+    writeDocuments(documents, outputDir, overwrite)
   }
 }

--- a/src/main/scala/wdlTools/cli/Main.scala
+++ b/src/main/scala/wdlTools/cli/Main.scala
@@ -2,6 +2,13 @@ package wdlTools.cli
 
 import dx.util.Logger
 
+/**
+  * Base class for wdlTools CLI commands.
+  */
+trait Command {
+  def apply(): Unit
+}
+
 object Main extends App {
   val conf = new WdlToolsConf(args.toVector)
 

--- a/src/main/scala/wdlTools/cli/WdlToolsConf.scala
+++ b/src/main/scala/wdlTools/cli/WdlToolsConf.scala
@@ -1,0 +1,451 @@
+package wdlTools.cli
+
+import java.net.URI
+import java.nio.file.{Path, Paths}
+
+import org.rogach.scallop.{
+  ArgType,
+  ScallopConf,
+  ScallopOption,
+  Subcommand,
+  ValueConverter,
+  singleArgConverter
+}
+import wdlTools.syntax.{Antlr4Util, WdlVersion}
+import wdlTools.types.TypeCheckingRegime
+import wdlTools.types.TypeCheckingRegime.TypeCheckingRegime
+import dx.util.FileUtils.{FileScheme, getUriScheme}
+import dx.util.{FileSourceResolver, Logger}
+
+import scala.util.Try
+
+abstract class InitializableSubcommand(name: String) extends Subcommand(name) {
+  def init(): Unit
+}
+
+class WdlToolsConf(args: Seq[String]) extends ScallopConf(args) {
+  def exceptionHandler[T]: PartialFunction[Throwable, Either[String, Option[T]]] = {
+    case t: Throwable => Left(s"${t.getMessage}")
+  }
+  def listArgConverter[A](
+      conv: String => A,
+      handler: PartialFunction[Throwable, Either[String, Option[List[A]]]] = PartialFunction.empty
+  ): ValueConverter[List[A]] = new ValueConverter[List[A]] {
+    def parse(s: List[(String, List[String])]): Either[String, Option[List[A]]] = {
+      Try({
+        val l = s.flatMap(_._2).map(i => conv(i))
+        if (l.isEmpty) {
+          Right(None)
+        } else {
+          Right(Some(l))
+        }
+      }).recover(handler)
+        .recover({
+          case _: Exception => Left("wrong arguments format")
+        })
+        .get
+    }
+    val argType = ArgType.LIST
+  }
+  implicit val fileListConverter: ValueConverter[List[Path]] =
+    listArgConverter[Path](Paths.get(_), exceptionHandler[List[Path]])
+  implicit val versionConverter: ValueConverter[WdlVersion] =
+    singleArgConverter[WdlVersion](WdlVersion.withNameIgnoreCase, exceptionHandler[WdlVersion])
+  implicit val tcRegimeConverter: ValueConverter[TypeCheckingRegime] =
+    singleArgConverter[TypeCheckingRegime](TypeCheckingRegime.withNameIgnoreCase,
+                                           exceptionHandler[TypeCheckingRegime])
+
+  abstract class WdlToolsSubcommand(name: String, description: String)
+      extends InitializableSubcommand(name) {
+    // there is a compiler bug that prevents accessing name directly
+    banner(s"""Usage: wdlTools ${commandNameAndAliases.head} [OPTIONS] <path|uri>
+              |${description}
+              |
+              |Options:
+              |""".stripMargin)
+
+    val verbose: ScallopOption[Int] = tally(descr = "use more verbose output")
+    val quiet: ScallopOption[Boolean] = opt(descr = "use less verbose output")
+
+    /**
+      * The verbosity level
+      * @return
+      */
+    def init(): Unit = {
+      val quiet = this.quiet.getOrElse(default = false)
+      val traceLevel = this.verbose.getOrElse(default = 0)
+      Logger.set(quiet, traceLevel)
+    }
+  }
+
+  private def getParent(pathOrUri: String): Option[Path] = {
+    getUriScheme(pathOrUri) match {
+      case Some(FileScheme) => Some(Paths.get(URI.create(pathOrUri)).getParent)
+      case None             => Some(Paths.get(pathOrUri).getParent)
+      case _                => None
+    }
+  }
+
+  /**
+    * The local directories to search for WDL imports.
+    * @param pathOrUri a file path or URI, from which to get the parent directory to add to the paths
+    * @return
+    */
+  private def localDirectories(pathOrUri: String,
+                               localDirs: ScallopOption[List[Path]]): Vector[Path] = {
+    localDirs.toOption match {
+      case None        => getParent(pathOrUri).toVector
+      case Some(paths) => (paths.toSet ++ getParent(pathOrUri).toSet).toVector
+    }
+  }
+
+  class ParserSubcommand(name: String, description: String)
+      extends WdlToolsSubcommand(name: String, description: String) {
+    val antlr4Trace: ScallopOption[Boolean] = opt(
+        descr = "enable trace logging of the ANTLR4 parser"
+    )
+    val localDir: ScallopOption[List[Path]] =
+      opt[List[Path]](
+          descr =
+            "directory in which to search for imports; ignored if --nofollow-imports is specified"
+      )
+    val uri: ScallopOption[String] =
+      trailArg[String](descr = "path or String (file:// or http(s)://) to the main WDL file")
+
+    override def init(): Unit = {
+      super.init()
+      FileSourceResolver.set(localDirectories(uri(), localDir))
+      Antlr4Util.setParserTrace(antlr4Trace())
+    }
+  }
+
+  version(s"wdlTools ${wdlTools.getVersion}")
+  banner("""Usage: wdlTools <COMMAND> [OPTIONS]
+           |Options:
+           |""".stripMargin)
+
+  class ParserCheckerSubcommand(name: String, description: String)
+      extends ParserSubcommand(name, description) {
+    val regime: ScallopOption[TypeCheckingRegime] = opt[TypeCheckingRegime](
+        descr = "Strictness of type checking",
+        default = Some(TypeCheckingRegime.Moderate)
+    )
+  }
+
+  val check = new ParserCheckerSubcommand(
+      name = "check",
+      description = "Type check WDL file."
+  ) {
+    val json: ScallopOption[Boolean] = toggle(
+        descrYes = "Output type-check errors as JSON",
+        descrNo = "Output type-check errors as plain text",
+        default = Some(false)
+    )
+    val outputFile: ScallopOption[Path] = opt[Path](
+        descr =
+          "File in which to write type-check errors; if not specified, errors are written to stdout"
+    )
+    val overwrite: ScallopOption[Boolean] = toggle(
+        descrYes = "Overwrite existing files",
+        descrNo = "(Default) Do not overwrite existing files",
+        default = Some(false)
+    )
+  }
+  addSubcommand(check)
+
+  class FollowOptionalParserSubcommand(name: String, description: String)
+      extends ParserSubcommand(name, description) {
+    val followImports: ScallopOption[Boolean] = toggle(
+        descrYes = "(Default) format imported files in addition to the main file",
+        descrNo = "only format the main file",
+        default = Some(true)
+    )
+  }
+
+  val docgen = new FollowOptionalParserSubcommand(
+      name = "docgen",
+      description = "Generate documentation from a WDL file and all its dependencies"
+  ) {
+    val title: ScallopOption[String] = opt[String](
+        descr = "Title for generated documentation"
+    )
+    val outputDir: ScallopOption[Path] = opt[Path](
+        descr = "Directory in which to output documentation",
+        short = 'O',
+        default = Some(Paths.get("docs"))
+    )
+    val overwrite: ScallopOption[Boolean] = toggle(
+        descrYes = "Overwrite existing files",
+        descrNo = "(Default) Do not overwrite existing files",
+        default = Some(false)
+    )
+  }
+  addSubcommand(docgen)
+
+  val format = new FollowOptionalParserSubcommand(
+      name = "format",
+      description = "Reformat WDL file and all its dependencies according to style rules."
+  ) {
+    val wdlVersion: ScallopOption[WdlVersion] = opt[WdlVersion](
+        descr = "WDL version to generate; currently only v1.0 is supported",
+        default = Some(WdlVersion.V1)
+    )
+    val supportedVersions: Set[WdlVersion] = Set(WdlVersion.V1, WdlVersion.V1_1)
+    validateOpt(wdlVersion) {
+      case Some(version) if !supportedVersions.contains(version) =>
+        Left("Only WDL v1.0 is supported currently")
+      case _ => Right(())
+    }
+    val outputDir: ScallopOption[Path] = opt[Path](
+        descr = "Directory in which to output formatted WDL files",
+        short = 'O'
+    )
+    val overwrite: ScallopOption[Boolean] = toggle(
+        descrYes = "Overwrite existing files",
+        descrNo = "(Default) Do not overwrite existing files",
+        default = Some(false)
+    )
+  }
+  addSubcommand(format)
+
+  val lint = new ParserCheckerSubcommand(
+      name = "lint",
+      description = "Check WDL file for common mistakes and bad code smells"
+  ) {
+    val config: ScallopOption[Path] = opt[Path](descr = "Path to lint config file")
+    val includeRules: ScallopOption[List[String]] = opt[List[String]](
+        descr =
+          "Lint rules to include; may be of the form '<rule>=<level>' to change the default level"
+    )
+    val excludeRules: ScallopOption[List[String]] =
+      opt[List[String]](descr = "Lint rules to exclude")
+    validateOpt(config, includeRules, excludeRules) {
+      case _ if config.isDefined && (includeRules.isDefined || excludeRules.isDefined) =>
+        Left("--config and --include-rules/--exclude-rules are mutually exclusive")
+      case _ => Right(())
+    }
+    val json: ScallopOption[Boolean] = toggle(
+        descrYes = "Output lint errors as JSON",
+        descrNo = "Output lint errors as plain text",
+        default = Some(false)
+    )
+    val outputFile: ScallopOption[Path] = opt[Path](
+        descr = "File in which to write lint errors; if not specified, errors are written to stdout"
+    )
+    val overwrite: ScallopOption[Boolean] = toggle(
+        descrYes = "Overwrite existing files",
+        descrNo = "(Default) Do not overwrite existing files",
+        default = Some(false)
+    )
+  }
+  addSubcommand(lint)
+
+  val upgrade = new FollowOptionalParserSubcommand(
+      name = "upgrade",
+      description = "Upgrade a WDL file to a more recent version"
+  ) {
+    val srcVersion: ScallopOption[WdlVersion] = opt[WdlVersion](
+        descr = "WDL version of the document being upgraded",
+        default = None
+    )
+    val destVersion: ScallopOption[WdlVersion] = opt[WdlVersion](
+        descr = "WDL version of the document being upgraded",
+        default = Some(WdlVersion.V1)
+    )
+    val supportedVersions: Set[WdlVersion] = Set(WdlVersion.V1, WdlVersion.V1_1)
+    validateOpt(destVersion) {
+      case Some(version) if !supportedVersions.contains(version) =>
+        Left(
+            s"Only WDL versions ${supportedVersions.map(_.name).mkString(",")} are supported currently"
+        )
+      case _ => Right(())
+    }
+    validateOpt(srcVersion, destVersion) {
+      case (Some(src), Some(dst)) if src < dst => Right(())
+      // ignore if srcVersion is unspecified - it will be detected and validated in the command
+      case (None, _) => Right(())
+      case _         => Left("Source version must be earlier than destination version")
+    }
+    val outputDir: ScallopOption[Path] = opt[Path](
+        descr = "Directory in which to output upgraded WDL file(s)",
+        short = 'O'
+    )
+    val overwrite: ScallopOption[Boolean] = toggle(
+        descrYes = "Overwrite existing files",
+        descrNo = "(Default) Do not overwrite existing files",
+        default = Some(false)
+    )
+    val check: ScallopOption[Boolean] = toggle(
+        descrYes = "(Default) Check generated code to make sure it parses and type-checks correctly",
+        descrNo = "Do not parse and type-check generated code",
+        default = Some(true)
+    )
+  }
+  addSubcommand(upgrade)
+
+  val fix = new FollowOptionalParserSubcommand(
+      name = "fix",
+      description = "Fix specification incompatibilities in WDL file and all its dependencies."
+  ) {
+    val srcVersion: ScallopOption[WdlVersion] = opt[WdlVersion](
+        descr = "WDL version of the document being upgraded",
+        default = None
+    )
+    val outputDir: ScallopOption[Path] = opt[Path](
+        descr = "Directory in which to output fixed WDL files; defaults to current directory",
+        short = 'O'
+    )
+    val overwrite: ScallopOption[Boolean] = toggle(
+        descrYes = "Overwrite existing files",
+        descrNo = "(Default) Do not overwrite existing files",
+        default = Some(false)
+    )
+  }
+  addSubcommand(fix)
+
+  val exec = new WdlToolsSubcommand(
+      name = "exec",
+      description = "Execute a WDL task"
+  ) {
+    val task: ScallopOption[String] = opt(
+        descr = "The task name - requred unless the WDL has a single task"
+    )
+    val inputsFile: ScallopOption[Path] = opt(
+        name = "inputs",
+        descr = "Task inputs JSON file - if not specified, inputs are read from stdin"
+    )
+    val runtimeDefaults: ScallopOption[Path] = opt(
+        descr = "JSON file with default runtime values"
+    )
+    val outputsFile: ScallopOption[Path] = opt(
+        name = "outputs",
+        descr = "Task outputs JSON file - if not specified, outputs are written to stdout"
+    )
+    val summaryFile: ScallopOption[Path] = opt(
+        name = "summary",
+        descr = "Also write a job summary in JSON format"
+    )
+    val container: ScallopOption[Boolean] = toggle(
+        descrYes = "Execute the task using Docker (if applicable)",
+        descrNo = "Do not use Docker - all dependencies must be installed on the local system",
+        default = Some(true)
+    )
+    val localDir: ScallopOption[List[Path]] =
+      opt[List[Path]](
+          descr =
+            "directory in which to search for imports; ignored if --nofollow-imports is specified"
+      )
+    val uri: ScallopOption[String] =
+      trailArg[String](descr = "path or String (file:// or http(s)://) to the main WDL file")
+  }
+  addSubcommand(exec)
+
+  val printTree = new WdlToolsSubcommand(
+      name = "printTree",
+      description = "Print the Abstract Syntax Tree for a WDL file."
+  ) {
+    val antlr4Trace: ScallopOption[Boolean] = opt(
+        descr = "enable trace logging of the ANTLR4 parser"
+    )
+    val uri: ScallopOption[String] =
+      trailArg[String](descr = "path or String (file:// or http(s)://) to the main WDL file")
+
+    val typed: ScallopOption[Boolean] = toggle(
+        descrYes = "Print the typed AST (document must pass type-checking)",
+        descrNo = "Print the raw AST",
+        default = Some(false)
+    )
+    val regime: ScallopOption[TypeCheckingRegime] = opt[TypeCheckingRegime](
+        descr = "Strictness of type checking",
+        default = Some(TypeCheckingRegime.Moderate)
+    )
+
+    override def init(): Unit = {
+      Antlr4Util.setParserTrace(antlr4Trace())
+    }
+  }
+  addSubcommand(printTree)
+
+  val generate = new WdlToolsSubcommand(
+      name = "new",
+      description = "Generate a new WDL task, workflow, or project."
+  ) {
+    val wdlVersion: ScallopOption[WdlVersion] = opt[WdlVersion](
+        descr = "WDL version to generate; currently only v1.0 is supported",
+        default = Some(WdlVersion.V1)
+    )
+    validateOpt(wdlVersion) {
+      case Some(version) if version != WdlVersion.V1 =>
+        Left("Only WDL v1.0 is supported currently")
+      case _ => Right(())
+    }
+    val interactive: ScallopOption[Boolean] = toggle(
+        descrYes = "Specify inputs and outputs interactively",
+        descrNo = "(Default) Do not specify inputs and outputs interactively",
+        default = Some(false)
+    )
+    val workflow: ScallopOption[Boolean] = toggle(
+        descrYes = "(Default) Generate a workflow",
+        descrNo = "Do not generate a workflow",
+        default = Some(true)
+    )
+    val task: ScallopOption[List[String]] = opt[List[String]](descr = "A task name")
+    val readmes: ScallopOption[Boolean] = toggle(
+        descrYes = "(Default) Generate a README file for each task/workflow",
+        descrNo = "Do not generate README files",
+        default = Some(true)
+    )
+    val docker: ScallopOption[String] = opt[String](descr = "The Docker image ID")
+    val dockerfile: ScallopOption[Boolean] = toggle(
+        descrYes = "Generate a Dockerfile template",
+        descrNo = "(Default) Do not generate a Dockerfile template",
+        default = Some(false)
+    )
+    val tests: ScallopOption[Boolean] = toggle(
+        descrYes = "(Default) Generate pytest-wdl test template",
+        descrNo = "Do not generate a pytest-wdl test template",
+        default = Some(true)
+    )
+    val makefile: ScallopOption[Boolean] = toggle(
+        descrYes = "(Default) Generate a Makefile",
+        descrNo = "Do not generate a Makefile",
+        default = Some(true)
+    )
+    val outputDir: ScallopOption[Path] = opt[Path](
+        descr =
+          "Directory in which to output formatted WDL files; if not specified, ./<name> is used",
+        short = 'O'
+    )
+    val overwrite: ScallopOption[Boolean] = toggle(
+        descrYes = "Overwrite existing files",
+        descrNo = "(Default) Do not overwrite existing files",
+        default = Some(false)
+    )
+    val name: ScallopOption[String] =
+      trailArg[String](descr = "The project name - this will also be the name of the workflow")
+  }
+  addSubcommand(generate)
+
+  val readmes = new FollowOptionalParserSubcommand(
+      name = "readmes",
+      description = "Generate README file stubs for tasks and workflows."
+  ) {
+    val developerReadmes: ScallopOption[Boolean] = toggle(
+        descrYes = "also generate developer READMEs",
+        default = Some(false)
+    )
+    val outputDir: ScallopOption[Path] = opt[Path](
+        descr =
+          "Directory in which to output README files; if not specified, the current directory is used",
+        short = 'O'
+    )
+    val overwrite: ScallopOption[Boolean] = toggle(
+        descrYes = "Overwrite existing files",
+        descrNo = "(Default) Do not overwrite existing files",
+        default = Some(false)
+    )
+  }
+  addSubcommand(readmes)
+
+  verify()
+}

--- a/src/main/scala/wdlTools/cli/package.scala
+++ b/src/main/scala/wdlTools/cli/package.scala
@@ -1,458 +1,99 @@
-package wdlTools.cli
+package wdlTools
 
-import java.net.URI
+import dx.util.{
+  AddressableFileSource,
+  FileNode,
+  FileSource,
+  FileSourceResolver,
+  FileUtils,
+  LocalFileSource
+}
+import wdlTools.syntax.{Parsers, SyntaxException, WdlVersion}
+import wdlTools.types.{TypeCheckingRegime, TypeException, TypeInfer}
+import wdlTools.types.TypedAbstractSyntax.Document
+
+import java.io.{ByteArrayOutputStream, PrintStream}
 import java.nio.file.{Path, Paths}
+import scala.collection.immutable.SeqMap
+import scala.jdk.CollectionConverters._
 
-import org.rogach.scallop.{
-  ArgType,
-  ScallopConf,
-  ScallopOption,
-  Subcommand,
-  ValueConverter,
-  singleArgConverter
-}
-import wdlTools.syntax.{Antlr4Util, WdlVersion}
-import wdlTools.types.TypeCheckingRegime
-import wdlTools.types.TypeCheckingRegime.TypeCheckingRegime
-import dx.util.FileUtils.{FileScheme, getUriScheme}
-import dx.util.{FileSourceResolver, Logger}
+package object cli {
 
-import scala.util.Try
-
-/**
-  * Base class for wdlTools CLI commands.
-  */
-trait Command {
-  def apply(): Unit
-}
-
-abstract class InitializableSubcommand(name: String) extends Subcommand(name) {
-  def init(): Unit
-}
-
-class WdlToolsConf(args: Seq[String]) extends ScallopConf(args) {
-  def exceptionHandler[T]: PartialFunction[Throwable, Either[String, Option[T]]] = {
-    case t: Throwable => Left(s"${t.getMessage}")
-  }
-  def listArgConverter[A](
-      conv: String => A,
-      handler: PartialFunction[Throwable, Either[String, Option[List[A]]]] = PartialFunction.empty
-  ): ValueConverter[List[A]] = new ValueConverter[List[A]] {
-    def parse(s: List[(String, List[String])]): Either[String, Option[List[A]]] = {
-      Try({
-        val l = s.flatMap(_._2).map(i => conv(i))
-        if (l.isEmpty) {
-          Right(None)
-        } else {
-          Right(Some(l))
-        }
-      }).recover(handler)
-        .recover({
-          case _: Exception => Left("wrong arguments format")
-        })
-        .get
-    }
-    val argType = ArgType.LIST
-  }
-  implicit val fileListConverter: ValueConverter[List[Path]] =
-    listArgConverter[Path](Paths.get(_), exceptionHandler[List[Path]])
-  implicit val versionConverter: ValueConverter[WdlVersion] =
-    singleArgConverter[WdlVersion](WdlVersion.withNameIgnoreCase, exceptionHandler[WdlVersion])
-  implicit val tcRegimeConverter: ValueConverter[TypeCheckingRegime] =
-    singleArgConverter[TypeCheckingRegime](TypeCheckingRegime.withNameIgnoreCase,
-                                           exceptionHandler[TypeCheckingRegime])
-
-  abstract class WdlToolsSubcommand(name: String, description: String)
-      extends InitializableSubcommand(name) {
-    // there is a compiler bug that prevents accessing name directly
-    banner(s"""Usage: wdlTools ${commandNameAndAliases.head} [OPTIONS] <path|uri>
-              |${description}
-              |
-              |Options:
-              |""".stripMargin)
-
-    val verbose: ScallopOption[Int] = tally(descr = "use more verbose output")
-    val quiet: ScallopOption[Boolean] = opt(descr = "use less verbose output")
-
-    /**
-      * The verbosity level
-      * @return
-      */
-    def init(): Unit = {
-      val quiet = this.quiet.getOrElse(default = false)
-      val traceLevel = this.verbose.getOrElse(default = 0)
-      Logger.set(quiet, traceLevel)
-    }
-  }
-
-  private def getParent(pathOrUri: String): Option[Path] = {
-    getUriScheme(pathOrUri) match {
-      case Some(FileScheme) => Some(Paths.get(URI.create(pathOrUri)).getParent)
-      case None             => Some(Paths.get(pathOrUri).getParent)
-      case _                => None
-    }
-  }
-
-  /**
-    * The local directories to search for WDL imports.
-    * @param pathOrUri a file path or URI, from which to get the parent directory to add to the paths
-    * @return
-    */
-  private def localDirectories(pathOrUri: String,
-                               localDirs: ScallopOption[List[Path]]): Vector[Path] = {
-    localDirs.toOption match {
-      case None        => getParent(pathOrUri).toVector
-      case Some(paths) => (paths.toSet ++ getParent(pathOrUri).toSet).toVector
-    }
-  }
-
-  class ParserSubcommand(name: String, description: String)
-      extends WdlToolsSubcommand(name: String, description: String) {
-    val antlr4Trace: ScallopOption[Boolean] = opt(
-        descr = "enable trace logging of the ANTLR4 parser"
-    )
-    val localDir: ScallopOption[List[Path]] =
-      opt[List[Path]](
-          descr =
-            "directory in which to search for imports; ignored if --nofollow-imports is specified"
+  def parseAndCheck(source: FileNode,
+                    wdlVersion: WdlVersion,
+                    followImports: Boolean = true,
+                    message: String,
+                    regime: TypeCheckingRegime.TypeCheckingRegime = TypeCheckingRegime.Moderate,
+                    fileResolver: FileSourceResolver = FileSourceResolver.get): Document = {
+    val errorHandler = new ErrorHandler()
+    val parsers = Parsers(followImports, fileResolver = fileResolver)
+    val parser = parsers.getParser(wdlVersion)
+    val checker =
+      TypeInfer(regime, fileResolver = fileResolver, errorHandler = Some(errorHandler.apply))
+    val document =
+      try {
+        val (document, _) = checker.apply(parser.parseDocument(source))
+        document
+      } catch {
+        case e: SyntaxException =>
+          throw new Exception(s"Failed to parse ${source}; ${message}", e)
+        case e: TypeException =>
+          throw new Exception(s"Failed to type-check ${source}; ${message}", e)
+      }
+    if (errorHandler.hasErrors) {
+      val msgStream = new ByteArrayOutputStream()
+      errorHandler.printErrors(new PrintStream(msgStream), effects = true)
+      throw new Exception(
+          s"Failed to type-check ${source}; ${message}:\n${msgStream.toString()}"
       )
-    val uri: ScallopOption[String] =
-      trailArg[String](descr = "path or String (file:// or http(s)://) to the main WDL file")
+    }
+    document
+  }
 
-    override def init(): Unit = {
-      super.init()
-      FileSourceResolver.set(localDirectories(uri(), localDir))
-      Antlr4Util.setParserTrace(antlr4Trace())
+  def writeDocuments[T <: FileSource](
+      docs: SeqMap[T, Iterable[String]],
+      outputDir: Option[Path] = None,
+      overwrite: Boolean = false
+  ): Map[AddressableFileSource, Path] = {
+    val writableDocs = docs.flatMap {
+      case (fs: AddressableFileSource, lines) if outputDir.isDefined => Some(fs -> lines)
+      case (local: LocalFileSource, lines) if overwrite =>
+        FileUtils.writeFileContent(local.canonicalPath,
+                                   lines.mkString(System.lineSeparator()),
+                                   overwrite = true)
+        None
+      case (fs, lines) =>
+        println(s"${fs.toString}\n${lines.mkString(System.lineSeparator())}")
+        None
+    }
+
+    if (writableDocs.nonEmpty) {
+      // determine the common ancestor path between all generated files
+      val rootPath = Paths.get("/")
+      val sourceToRelPath = writableDocs.keys.map { fs =>
+        fs -> rootPath.relativize(Paths.get(fs.folder).resolve(fs.name))
+      }.toMap
+      val pathComponents = sourceToRelPath.values.map(_.iterator().asScala.toVector)
+      val shortestPathSize = pathComponents.map(_.size).min
+      val commonPathComponents = pathComponents
+        .map(_.slice(0, shortestPathSize))
+        .transpose
+        .iterator
+        .map(_.toSet)
+        .takeWhile(_.size == 1)
+        .map(_.head.toString)
+        .toVector
+      val commonAncestor = Paths.get(commonPathComponents.head, commonPathComponents.tail: _*)
+      writableDocs.map {
+        case (fs, lines) =>
+          val outputPath = outputDir.get.resolve(commonAncestor.relativize(sourceToRelPath(fs)))
+          FileUtils.writeFileContent(outputPath,
+                                     lines.mkString(System.lineSeparator()),
+                                     overwrite = overwrite)
+          fs -> outputPath
+      }
+    } else {
+      Map.empty
     }
   }
-
-  version(s"wdlTools ${wdlTools.getVersion}")
-  banner("""Usage: wdlTools <COMMAND> [OPTIONS]
-           |Options:
-           |""".stripMargin)
-
-  class ParserCheckerSubcommand(name: String, description: String)
-      extends ParserSubcommand(name, description) {
-    val regime: ScallopOption[TypeCheckingRegime] = opt[TypeCheckingRegime](
-        descr = "Strictness of type checking",
-        default = Some(TypeCheckingRegime.Moderate)
-    )
-  }
-
-  val check = new ParserCheckerSubcommand(
-      name = "check",
-      description = "Type check WDL file."
-  ) {
-    val json: ScallopOption[Boolean] = toggle(
-        descrYes = "Output type-check errors as JSON",
-        descrNo = "Output type-check errors as plain text",
-        default = Some(false)
-    )
-    val outputFile: ScallopOption[Path] = opt[Path](
-        descr =
-          "File in which to write type-check errors; if not specified, errors are written to stdout"
-    )
-    val overwrite: ScallopOption[Boolean] = toggle(
-        descrYes = "Overwrite existing files",
-        descrNo = "(Default) Do not overwrite existing files",
-        default = Some(false)
-    )
-  }
-  addSubcommand(check)
-
-  class FollowOptionalParserSubcommand(name: String, description: String)
-      extends ParserSubcommand(name, description) {
-    val followImports: ScallopOption[Boolean] = toggle(
-        descrYes = "(Default) format imported files in addition to the main file",
-        descrNo = "only format the main file",
-        default = Some(true)
-    )
-  }
-
-  val docgen = new FollowOptionalParserSubcommand(
-      name = "docgen",
-      description = "Generate documentation from a WDL file and all its dependencies"
-  ) {
-    val title: ScallopOption[String] = opt[String](
-        descr = "Title for generated documentation"
-    )
-    val outputDir: ScallopOption[Path] = opt[Path](
-        descr = "Directory in which to output documentation",
-        short = 'O',
-        default = Some(Paths.get("docs"))
-    )
-    val overwrite: ScallopOption[Boolean] = toggle(
-        descrYes = "Overwrite existing files",
-        descrNo = "(Default) Do not overwrite existing files",
-        default = Some(false)
-    )
-  }
-  addSubcommand(docgen)
-
-  val format = new FollowOptionalParserSubcommand(
-      name = "format",
-      description = "Reformat WDL file and all its dependencies according to style rules."
-  ) {
-    val wdlVersion: ScallopOption[WdlVersion] = opt[WdlVersion](
-        descr = "WDL version to generate; currently only v1.0 is supported",
-        default = Some(WdlVersion.V1)
-    )
-    val supportedVersions: Set[WdlVersion] = Set(WdlVersion.V1, WdlVersion.V1_1)
-    validateOpt(wdlVersion) {
-      case Some(version) if !supportedVersions.contains(version) =>
-        Left("Only WDL v1.0 is supported currently")
-      case _ => Right(())
-    }
-    val outputDir: ScallopOption[Path] = opt[Path](
-        descr = "Directory in which to output formatted WDL files",
-        short = 'O'
-    )
-    val overwrite: ScallopOption[Boolean] = toggle(
-        descrYes = "Overwrite existing files",
-        descrNo = "(Default) Do not overwrite existing files",
-        default = Some(false)
-    )
-  }
-  addSubcommand(format)
-
-  val lint = new ParserCheckerSubcommand(
-      name = "lint",
-      description = "Check WDL file for common mistakes and bad code smells"
-  ) {
-    val config: ScallopOption[Path] = opt[Path](descr = "Path to lint config file")
-    val includeRules: ScallopOption[List[String]] = opt[List[String]](
-        descr =
-          "Lint rules to include; may be of the form '<rule>=<level>' to change the default level"
-    )
-    val excludeRules: ScallopOption[List[String]] =
-      opt[List[String]](descr = "Lint rules to exclude")
-    validateOpt(config, includeRules, excludeRules) {
-      case _ if config.isDefined && (includeRules.isDefined || excludeRules.isDefined) =>
-        Left("--config and --include-rules/--exclude-rules are mutually exclusive")
-      case _ => Right(())
-    }
-    val json: ScallopOption[Boolean] = toggle(
-        descrYes = "Output lint errors as JSON",
-        descrNo = "Output lint errors as plain text",
-        default = Some(false)
-    )
-    val outputFile: ScallopOption[Path] = opt[Path](
-        descr = "File in which to write lint errors; if not specified, errors are written to stdout"
-    )
-    val overwrite: ScallopOption[Boolean] = toggle(
-        descrYes = "Overwrite existing files",
-        descrNo = "(Default) Do not overwrite existing files",
-        default = Some(false)
-    )
-  }
-  addSubcommand(lint)
-
-  val upgrade = new FollowOptionalParserSubcommand(
-      name = "upgrade",
-      description = "Upgrade a WDL file to a more recent version"
-  ) {
-    val srcVersion: ScallopOption[WdlVersion] = opt[WdlVersion](
-        descr = "WDL version of the document being upgraded",
-        default = None
-    )
-    val destVersion: ScallopOption[WdlVersion] = opt[WdlVersion](
-        descr = "WDL version of the document being upgraded",
-        default = Some(WdlVersion.V1)
-    )
-    val supportedVersions: Set[WdlVersion] = Set(WdlVersion.V1, WdlVersion.V1_1)
-    validateOpt(destVersion) {
-      case Some(version) if !supportedVersions.contains(version) =>
-        Left(
-            s"Only WDL versions ${supportedVersions.map(_.name).mkString(",")} are supported currently"
-        )
-      case _ => Right(())
-    }
-    validateOpt(srcVersion, destVersion) {
-      case (Some(src), Some(dst)) if src < dst => Right(())
-      // ignore if srcVersion is unspecified - it will be detected and validated in the command
-      case (None, _) => Right(())
-      case _         => Left("Source version must be earlier than destination version")
-    }
-    val outputDir: ScallopOption[Path] = opt[Path](
-        descr = "Directory in which to output upgraded WDL file(s)",
-        short = 'O'
-    )
-    val overwrite: ScallopOption[Boolean] = toggle(
-        descrYes = "Overwrite existing files",
-        descrNo = "(Default) Do not overwrite existing files",
-        default = Some(false)
-    )
-  }
-  addSubcommand(upgrade)
-
-  val fix = new FollowOptionalParserSubcommand(
-      name = "fix",
-      description = "Fix specification incompatibilities in WDL file and all its dependencies."
-  ) {
-    val srcVersion: ScallopOption[WdlVersion] = opt[WdlVersion](
-        descr = "WDL version of the document being upgraded",
-        default = None
-    )
-    val baseUri: ScallopOption[String] = opt[String](
-        descr =
-          "Base URI for imports; output directories will be relative to this URI; defaults to the parent directory of the main WDL file",
-        default = None
-    )
-    val outputDir: ScallopOption[Path] = opt[Path](
-        descr = "Directory in which to output fixed WDL files; defaults to current directory",
-        short = 'O'
-    )
-    val overwrite: ScallopOption[Boolean] = toggle(
-        descrYes = "Overwrite existing files",
-        descrNo = "(Default) Do not overwrite existing files",
-        default = Some(false)
-    )
-  }
-  addSubcommand(fix)
-
-  val exec = new WdlToolsSubcommand(
-      name = "exec",
-      description = "Execute a WDL task"
-  ) {
-    val task: ScallopOption[String] = opt(
-        descr = "The task name - requred unless the WDL has a single task"
-    )
-    val inputsFile: ScallopOption[Path] = opt(
-        name = "inputs",
-        descr = "Task inputs JSON file - if not specified, inputs are read from stdin"
-    )
-    val runtimeDefaults: ScallopOption[Path] = opt(
-        descr = "JSON file with default runtime values"
-    )
-    val outputsFile: ScallopOption[Path] = opt(
-        name = "outputs",
-        descr = "Task outputs JSON file - if not specified, outputs are written to stdout"
-    )
-    val summaryFile: ScallopOption[Path] = opt(
-        name = "summary",
-        descr = "Also write a job summary in JSON format"
-    )
-    val container: ScallopOption[Boolean] = toggle(
-        descrYes = "Execute the task using Docker (if applicable)",
-        descrNo = "Do not use Docker - all dependencies must be installed on the local system",
-        default = Some(true)
-    )
-    val localDir: ScallopOption[List[Path]] =
-      opt[List[Path]](
-          descr =
-            "directory in which to search for imports; ignored if --nofollow-imports is specified"
-      )
-    val uri: ScallopOption[String] =
-      trailArg[String](descr = "path or String (file:// or http(s)://) to the main WDL file")
-  }
-  addSubcommand(exec)
-
-  val printTree = new WdlToolsSubcommand(
-      name = "printTree",
-      description = "Print the Abstract Syntax Tree for a WDL file."
-  ) {
-    val antlr4Trace: ScallopOption[Boolean] = opt(
-        descr = "enable trace logging of the ANTLR4 parser"
-    )
-    val uri: ScallopOption[String] =
-      trailArg[String](descr = "path or String (file:// or http(s)://) to the main WDL file")
-
-    val typed: ScallopOption[Boolean] = toggle(
-        descrYes = "Print the typed AST (document must pass type-checking)",
-        descrNo = "Print the raw AST",
-        default = Some(false)
-    )
-    val regime: ScallopOption[TypeCheckingRegime] = opt[TypeCheckingRegime](
-        descr = "Strictness of type checking",
-        default = Some(TypeCheckingRegime.Moderate)
-    )
-
-    override def init(): Unit = {
-      Antlr4Util.setParserTrace(antlr4Trace())
-    }
-  }
-  addSubcommand(printTree)
-
-  val generate = new WdlToolsSubcommand(
-      name = "new",
-      description = "Generate a new WDL task, workflow, or project."
-  ) {
-    val wdlVersion: ScallopOption[WdlVersion] = opt[WdlVersion](
-        descr = "WDL version to generate; currently only v1.0 is supported",
-        default = Some(WdlVersion.V1)
-    )
-    validateOpt(wdlVersion) {
-      case Some(version) if version != WdlVersion.V1 =>
-        Left("Only WDL v1.0 is supported currently")
-      case _ => Right(())
-    }
-    val interactive: ScallopOption[Boolean] = toggle(
-        descrYes = "Specify inputs and outputs interactively",
-        descrNo = "(Default) Do not specify inputs and outputs interactively",
-        default = Some(false)
-    )
-    val workflow: ScallopOption[Boolean] = toggle(
-        descrYes = "(Default) Generate a workflow",
-        descrNo = "Do not generate a workflow",
-        default = Some(true)
-    )
-    val task: ScallopOption[List[String]] = opt[List[String]](descr = "A task name")
-    val readmes: ScallopOption[Boolean] = toggle(
-        descrYes = "(Default) Generate a README file for each task/workflow",
-        descrNo = "Do not generate README files",
-        default = Some(true)
-    )
-    val docker: ScallopOption[String] = opt[String](descr = "The Docker image ID")
-    val dockerfile: ScallopOption[Boolean] = toggle(
-        descrYes = "Generate a Dockerfile template",
-        descrNo = "(Default) Do not generate a Dockerfile template",
-        default = Some(false)
-    )
-    val tests: ScallopOption[Boolean] = toggle(
-        descrYes = "(Default) Generate pytest-wdl test template",
-        descrNo = "Do not generate a pytest-wdl test template",
-        default = Some(true)
-    )
-    val makefile: ScallopOption[Boolean] = toggle(
-        descrYes = "(Default) Generate a Makefile",
-        descrNo = "Do not generate a Makefile",
-        default = Some(true)
-    )
-    val outputDir: ScallopOption[Path] = opt[Path](
-        descr =
-          "Directory in which to output formatted WDL files; if not specified, ./<name> is used",
-        short = 'O'
-    )
-    val overwrite: ScallopOption[Boolean] = toggle(
-        descrYes = "Overwrite existing files",
-        descrNo = "(Default) Do not overwrite existing files",
-        default = Some(false)
-    )
-    val name: ScallopOption[String] =
-      trailArg[String](descr = "The project name - this will also be the name of the workflow")
-  }
-  addSubcommand(generate)
-
-  val readmes = new FollowOptionalParserSubcommand(
-      name = "readmes",
-      description = "Generate README file stubs for tasks and workflows."
-  ) {
-    val developerReadmes: ScallopOption[Boolean] = toggle(
-        descrYes = "also generate developer READMEs",
-        default = Some(false)
-    )
-    val outputDir: ScallopOption[Path] = opt[Path](
-        descr =
-          "Directory in which to output README files; if not specified, the current directory is used",
-        short = 'O'
-    )
-    val overwrite: ScallopOption[Boolean] = toggle(
-        descrYes = "Overwrite existing files",
-        descrNo = "(Default) Do not overwrite existing files",
-        default = Some(false)
-    )
-  }
-  addSubcommand(readmes)
-
-  verify()
 }

--- a/src/main/scala/wdlTools/cli/package.scala
+++ b/src/main/scala/wdlTools/cli/package.scala
@@ -74,7 +74,8 @@ package object cli {
         fs -> rootPath.relativize(Paths.get(fs.folder).resolve(fs.name))
       }.toMap
       val pathComponents = sourceToRelPath.values.map(_.iterator().asScala.toVector)
-      val shortestPathSize = pathComponents.map(_.size).min
+      // don't include the file name in the path components
+      val shortestPathSize = pathComponents.map(_.size - 1).min
       val commonPathComponents = pathComponents
         .map(_.slice(0, shortestPathSize))
         .transpose

--- a/src/main/scala/wdlTools/generators/code/Upgrader.scala
+++ b/src/main/scala/wdlTools/generators/code/Upgrader.scala
@@ -3,6 +3,8 @@ package wdlTools.generators.code
 import wdlTools.syntax.{Parsers, WdlVersion}
 import dx.util.{FileNode, FileSourceResolver, Logger}
 
+import scala.collection.immutable.SeqMap
+
 case class Upgrader(followImports: Boolean = false,
                     fileResolver: FileSourceResolver = FileSourceResolver.get,
                     logger: Logger = Logger.get) {
@@ -17,7 +19,7 @@ case class Upgrader(followImports: Boolean = false,
     */
   def upgrade(docSource: FileNode,
               sourceVersion: Option[WdlVersion] = None,
-              targetVersion: WdlVersion = WdlVersion.V1): Map[FileNode, Seq[String]] = {
+              targetVersion: WdlVersion = WdlVersion.V1): SeqMap[FileNode, Seq[String]] = {
     val parser = if (sourceVersion.isDefined) {
       parsers.getParser(sourceVersion.get)
     } else {
@@ -28,7 +30,7 @@ case class Upgrader(followImports: Boolean = false,
     val formatter = WdlFormatter(Some(targetVersion), followImports)
 
     // parse and format the document (and any imports)
-    parser.Walker[Map[FileNode, Seq[String]]](docSource, Map.empty).walk { (doc, results) =>
+    parser.Walker[SeqMap[FileNode, Seq[String]]](docSource, SeqMap.empty).walk { (doc, results) =>
       if (doc.version.value >= targetVersion) {
         throw new Exception(s"Cannot convert WDL version ${doc.version} to ${targetVersion}")
       }

--- a/src/main/scala/wdlTools/generators/code/WdlFormatter.scala
+++ b/src/main/scala/wdlTools/generators/code/WdlFormatter.scala
@@ -9,6 +9,7 @@ import wdlTools.syntax.{Comment, CommentMap, Operator, Parsers, Quoting, SourceL
 import dx.util.{FileNode, FileSourceResolver, Logger}
 
 import java.net.URI
+import scala.collection.immutable.SeqMap
 import scala.collection.{BufferedIterator, mutable}
 
 object WdlFormatter {
@@ -1904,9 +1905,9 @@ case class WdlFormatter(targetVersion: Option[WdlVersion] = None,
     formatElement(document, document.comments)
   }
 
-  def formatDocuments(docSource: FileNode): Map[FileNode, Vector[String]] = {
+  def formatDocuments(docSource: FileNode): SeqMap[FileNode, Vector[String]] = {
     Parsers(followImports, fileResolver, logger = logger)
-      .getDocumentWalker[Map[FileNode, Vector[String]]](docSource, Map.empty)
+      .getDocumentWalker[SeqMap[FileNode, Vector[String]]](docSource, SeqMap.empty)
       .walk { (doc, results) =>
         results + (doc.source -> formatDocument(doc))
       }

--- a/src/main/scala/wdlTools/types/TypeInfer.scala
+++ b/src/main/scala/wdlTools/types/TypeInfer.scala
@@ -574,6 +574,13 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
     }
   }
 
+  private def isReadFunction(expr: AST.Expr): Boolean = {
+    expr match {
+      case AST.ExprApply(funcName, _) if funcName.startsWith("read_") => true
+      case _                                                          => false
+    }
+  }
+
   private def translateDeclaration(
       decl: AST.Declaration,
       section: Section,
@@ -588,7 +595,7 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
       case Some(expr) =>
         val e = applyExpr(expr, ctx, bindings, section = section)
         val rhsType = e.wdlType
-        val unifyCtx = UnificationContext(section)
+        val unifyCtx = UnificationContext(section, inReadFunction = isReadFunction(expr))
         val wdlType = if (unify.isCoercibleTo(lhsType, rhsType, unifyCtx)) {
           lhsType
         } else {

--- a/src/main/scala/wdlTools/types/Unification.scala
+++ b/src/main/scala/wdlTools/types/Unification.scala
@@ -23,7 +23,8 @@ object Section extends Enum {
 }
 
 case class UnificationContext(section: Section.Section = Section.Other,
-                              inPlaceholder: Boolean = false)
+                              inPlaceholder: Boolean = false,
+                              inReadFunction: Boolean = false)
 
 object UnificationContext {
   def empty: UnificationContext = UnificationContext()
@@ -127,6 +128,12 @@ case class Unification(regime: TypeCheckingRegime, logger: Logger = Logger.get) 
           logger.trace(s"lenient coercion from ${innerFrom} to T_String",
                        minLevel = TraceLevel.VVerbose)
           Some(Enum.max(minPriority, Priority.RegimeAllowed))
+        case (T_Boolean | T_Int | T_Float, T_String) if ctx.inReadFunction =>
+          // coercion from String to Int|Float|Boolean is specifically allowed
+          // in the context of read_* functions, for example:
+          //  Array[Int] = read_string("ints.txt")
+          //  Map[String, Int] = read_map("string_to_int.tsv")
+          Some(Enum.max(minPriority, Priority.ContextAllowed))
         case (T_Int, T_Float | T_String) if regime <= Lenient =>
           // we can allow this coercion assuming 1) a Float value that coerces
           // exactly to an int, or 2) a String value that can be parsed to an Int -


### PR DESCRIPTION
* Update dsScala to fix path relativization bugs
* Handle imports that are relative to a common ancestor of the importing file, but not in a subdirectory of the importing file's parent directory
* Make the file writing code into a common function shared by the `fix`, `format` and `upgrade` commands
* Allow return values of `read_*` functions to be immediately coerced to non-`String` values