### PR TITLE
Handle T_Any in placeholders

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## in develop
 
 * Handles accessing object fields within placeholders
+* Allows comparison of object fields to `String`
 
 ## 0.14.2 (2021-06-28)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Change log
 
+## in develop
+
+* Handles accessing object fields within placeholders
+
 ## 0.14.2 (2021-06-28)
 
 * Updates dxCommon version, which fixes the output of the `printTree` command

--- a/src/main/scala/wdlTools/types/Stdlib.scala
+++ b/src/main/scala/wdlTools/types/Stdlib.scala
@@ -75,7 +75,9 @@ case class Stdlib(regime: TypeCheckingRegime,
         T_Function2(funcName, T_Int, T_Float, T_Boolean),
         T_Function2(funcName, T_Float, T_Int, T_Boolean),
         T_Function2(funcName, T_File, T_String, T_Boolean),
-        T_Function2(funcName, T_Var(0), T_Var(0), T_Boolean)
+        T_Function2(funcName, T_Var(0), T_Var(0), T_Boolean),
+        T_Function2(funcName, T_Any, T_String, T_Boolean),
+        T_Function2(funcName, T_String, T_Any, T_Boolean)
     )
   }
 

--- a/src/main/scala/wdlTools/types/TypeInfer.scala
+++ b/src/main/scala/wdlTools/types/TypeInfer.scala
@@ -886,13 +886,15 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
     val tRuntime = task.runtime.map(applyRuntime(_, declCtx))
     val tHints = task.hints.map(applyHints(_, declCtx))
 
-    // check that all expressions can be coereced to a string inside
-    // the command section
+    // Check that all expressions can be coereced to a string inside
+    // the command section. If type is T_Any we allow it here - the
+    // actual type will be checked at runtime.
     val tCommandParts = task.command.parts.map { expr =>
       val e = applyExpr(expr, declCtx, exprState = ExprState.InString)
       e.wdlType match {
         case x if isPrimitive(x)             => e
         case T_Optional(x) if isPrimitive(x) => e
+        case T_Any                           => e
         case other =>
           handleError(
               s"""Expression ${prettyFormatExpr(e)} in the command section has type ${other},

--- a/src/test/resources/types/draft2/object_fields.wdl
+++ b/src/test/resources/types/draft2/object_fields.wdl
@@ -29,7 +29,11 @@ task use_object {
 workflow object_access {
   call mk_object
   call use_object { input: obj_in = mk_object.out }
+  if (mk_object.out.a == "1") {
+    String greet = "hello"
+  }
   output {
     Array[String] lines = use_object.lines
+    String? greeting = greet
   }
 }

--- a/src/test/resources/types/draft2/object_fields.wdl
+++ b/src/test/resources/types/draft2/object_fields.wdl
@@ -1,0 +1,35 @@
+task mk_object {
+  command {
+    echo -e "a\tb\tc"
+    echo -e "1\t2\t3"
+  }
+  output {
+    Object out = read_object(stdout())
+  }
+  runtime {
+    docker: "ubuntu:latest"
+  }
+}
+
+task use_object {
+  Object obj_in
+  command {
+    echo ${obj_in.a}
+    echo ${obj_in.b}
+    echo ${obj_in.c}
+  }
+  output {
+    Array[String] lines = read_lines(stdout())
+  }
+  runtime {
+    docker: "ubuntu:latest"
+  }
+}
+
+workflow object_access {
+  call mk_object
+  call use_object { input: obj_in = mk_object.out }
+  output {
+    Array[String] lines = use_object.lines
+  }
+}

--- a/src/test/scala/wdlTools/types/TypeInferComplianceTest.scala
+++ b/src/test/scala/wdlTools/types/TypeInferComplianceTest.scala
@@ -35,7 +35,8 @@ class TypeInferComplianceTest extends AnyWordSpec with Matchers {
 
   private val draft2ControlTable: Vector[(String, TResult)] = Vector(
       ("call_with_defaults.wdl", TResult(correct = true)),
-      ("population.wdl", TResult(correct = true))
+      ("population.wdl", TResult(correct = true)),
+      ("object_fields.wdl", TResult(correct = true))
   )
 
   private val v1ControlTable: Vector[(String, TResult)] = Vector(


### PR DESCRIPTION
An `Object` returned by the `read_object` function will have fields that are type `T_Any` but have `String` values. This PR allows expressions of type `T_Any` at type-check type type and the actual type will be checked at runtime.