### PR TITLE
Don't unwrap optional for OverridableInputParameterWithDefault

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Change log
 
+## in develop
+
+* No longer unwraps optional type for an input with a default value
+
 ## 0.14.3 (2021-07-06)
 
 * Code generator/formatter handles empty blocks

--- a/src/main/scala/wdlTools/syntax/package.scala
+++ b/src/main/scala/wdlTools/syntax/package.scala
@@ -13,7 +13,7 @@ object WdlVersion {
   case object Draft_2 extends WdlVersion("draft-2", 0, aliases = Set.empty)
   case object V1 extends WdlVersion("1.0", 1, aliases = Set("draft-3"))
   case object V1_1 extends WdlVersion("1.1", 2, aliases = Set("1.1.0", "1.1.1"))
-  case object V2 extends WdlVersion("2.0", 3, aliases = Set("development"))
+  case object V2 extends WdlVersion("development", 3, aliases = Set("2.0"))
 
   val All: Vector[WdlVersion] = Vector(V2, V1_1, V1, Draft_2).sortWith(_ < _)
 

--- a/src/main/scala/wdlTools/types/TypeInfer.scala
+++ b/src/main/scala/wdlTools/types/TypeInfer.scala
@@ -676,10 +676,7 @@ case class TypeInfer(regime: TypeCheckingRegime = TypeCheckingRegime.Moderate,
               case (_, None) =>
                 TAT.RequiredInputParameter(decl.name, wdlType)(decl.loc)
               case (t, Some(expr)) =>
-                // drop any optional type wrapper if this is an input with a default value
-                TAT.OverridableInputParameterWithDefault(decl.name,
-                                                         TypeUtils.unwrapOptional(t),
-                                                         expr)(decl.loc)
+                TAT.OverridableInputParameterWithDefault(decl.name, t, expr)(decl.loc)
             }
             (tInputParams :+ tParam, names + decl.name, afterBindings)
         }

--- a/src/test/resources/corpora_repos.json
+++ b/src/test/resources/corpora_repos.json
@@ -245,6 +245,12 @@
           }
         },
         {
+          "include": [
+            "deepvariant.wdl"
+          ],
+          "fix": true
+        },
+        {
           "exclude": [
             "bedtools.wdl",
             "bcftools.wdl",
@@ -256,6 +262,7 @@
             "collect-columns.wdl",
             "common.wdl",
             "cutadapt.wdl",
+            "deepvariant.wdl",
             "fastqc.wdl",
             "flash.wdl",
             "gatk.wdl",

--- a/src/test/resources/format/before/none_literal.wdl
+++ b/src/test/resources/format/before/none_literal.wdl
@@ -1,0 +1,30 @@
+version development
+
+workflow none_literal {
+  input {
+    Int? int_in = None
+  }
+
+  call none_in_command
+
+  output {
+    Int? out = int_in
+    Int? out2 = None
+    Int out3 = select_first([out, out2, None, 3])
+    String out_none = none_in_command.s
+  }
+}
+
+task none_in_command {
+  command <<<
+    echo ~{if defined(None) then "Some" else "None"}
+  >>>
+
+  output {
+    String s = read_string(stdout())
+  }
+
+  runtime {
+    container: "ubuntu:latest"
+  }
+}

--- a/src/test/scala/wdlTools/format/GeneratorTest.scala
+++ b/src/test/scala/wdlTools/format/GeneratorTest.scala
@@ -155,4 +155,8 @@ class GeneratorTest extends AnyFlatSpec with Matchers {
   it should "handle struct field access" in {
     generate("struct_field.wdl", validateContentSelf = true)
   }
+
+  it should "handle None literal" in {
+    generate("none_literal.wdl", validateContentSelf = true, wdlVersion = WdlVersion.V2)
+  }
 }


### PR DESCRIPTION
In WDL 1.1+, optional inputs with a default value can be set to `None`, so the optional type needs to be maintained.