### PR TITLE
Return codes2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## in develop
 
 * Adds parameters for runtime and hint overrides to `Eval.Runtime` and `Eval.Meta` classes
+* Fixes parsing of `runtime.returnCodes`
 
 ## 0.15.0 (2021-08-16)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Change log
 
+## in develop
+
+* Additional fixes to parsing `runtime.returnCodes`
+
 ## 0.16.0 (2021-09-09)
 
 * Adds parameters for runtime and hint overrides to `Eval.Runtime` and `Eval.Meta` classes

--- a/src/main/scala/wdlTools/eval/Runtime.scala
+++ b/src/main/scala/wdlTools/eval/Runtime.scala
@@ -87,7 +87,7 @@ abstract class Runtime(runtime: Map[String, TAT.Expr],
     */
   def returnCodes: Option[Set[Int]] = {
     val loc = getSourceLocation(Runtime.ReturnCodesKey)
-    get(Runtime.ReturnCodesKey, Vector(T_String, T_Int, T_Array(T_Int))) match {
+    get(Runtime.ReturnCodesKey, Vector(T_Int, T_Array(T_Int), T_String)) match {
       case None                => Some(Runtime.ReturnCodesDefault)
       case Some(V_String("*")) => None
       case Some(V_Int(i))      => Some(Set(i.toInt))


### PR DESCRIPTION
The `get` function coerces to the first allowed type. Since `Int` can be coerced to `String`, it returns a `String` even when the value is an `Int`. So `T_String` has to come last.