### PR TITLE
APPS-813 parse default and sep with = token

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Change log
 
+## in develop
+
+* Fixes parsing of placeholder options in draft-2 and 1.0 such that `default` and `sep` are no longer treated as reserved words
+
 ## 0.17.0 (2021-09-15)
 
 * **Breaking Change** `Eval.applyMap` is changed to `Eval.applyAll` and takes a `Vector` rather than `Map` argument. This is done to ensure the expressions are evaluated in order in case there are dependencies between them.

--- a/src/main/antlr4/draft_2/WdlDraft2Lexer.g4
+++ b/src/main/antlr4/draft_2/WdlDraft2Lexer.g4
@@ -34,8 +34,8 @@ PAIR: 'Pair';
 OBJECT: 'Object';
 OBJECTLITERAL: 'object';
 
-SEP: 'sep';
-DEFAULT: 'default';
+SEPEQUAL: 'sep';
+DEFAULTEQUAL: 'default';
 
 // Primitive Literals
 IntLiteral

--- a/src/main/antlr4/draft_2/WdlDraft2Parser.g4
+++ b/src/main/antlr4/draft_2/WdlDraft2Parser.g4
@@ -45,8 +45,8 @@ number
 
 expression_placeholder_option
 	: BoolLiteral EQUAL string
-	| SEP EQUAL string
-	| DEFAULT EQUAL expr
+	| SEPEQUAL EQUAL string
+	| DEFAULTEQUAL EQUAL expr
 	;
 
 string_part

--- a/src/main/antlr4/v1/WdlV1Lexer.g4
+++ b/src/main/antlr4/v1/WdlV1Lexer.g4
@@ -36,8 +36,8 @@ PAIR: 'Pair';
 OBJECT: 'Object';
 OBJECTLITERAL: 'object';
 
-SEP: 'sep';
-DEFAULT: 'default';
+SEPEQUAL: 'sep=';
+DEFAULTEQUAL: 'default=';
 
 // Primitive Literals
 IntLiteral

--- a/src/main/antlr4/v1/WdlV1Parser.g4
+++ b/src/main/antlr4/v1/WdlV1Parser.g4
@@ -45,8 +45,8 @@ number
 
 expression_placeholder_option
   : BoolLiteral EQUAL string
-  | SEP EQUAL string
-  | DEFAULT EQUAL expr
+  | SEPEQUAL string
+  | DEFAULTEQUAL expr
   ;
 
 string_part

--- a/src/main/scala/wdlTools/syntax/draft_2/ParseTop.scala
+++ b/src/main/scala/wdlTools/syntax/draft_2/ParseTop.scala
@@ -245,12 +245,12 @@ wdl_type
   private def parse_placeholder_option(
       ctx: WdlDraft2Parser.Expression_placeholder_optionContext
   ): (String, Expr) = {
-    if (ctx.DEFAULT() != null) {
+    if (ctx.DEFAULTEQUAL() != null) {
       ("default", visitExpr(ctx.expr()))
     } else {
       val optionType = if (ctx.BoolLiteral() != null) {
         ctx.BoolLiteral().getText.toLowerCase()
-      } else if (ctx.SEP() != null) {
+      } else if (ctx.SEPEQUAL() != null) {
         "sep"
       } else {
         throw new SyntaxException(s"unrecognized placeholder option",

--- a/src/main/scala/wdlTools/syntax/v1/ParseTop.scala
+++ b/src/main/scala/wdlTools/syntax/v1/ParseTop.scala
@@ -214,12 +214,12 @@ wdl_type
   private def parse_placeholder_option(
       ctx: WdlV1Parser.Expression_placeholder_optionContext
   ): (String, Expr) = {
-    if (ctx.DEFAULT() != null) {
+    if (ctx.DEFAULTEQUAL() != null) {
       ("default", visitExpr(ctx.expr))
     } else {
       val optionType = if (ctx.BoolLiteral() != null) {
         ctx.BoolLiteral().getText.toLowerCase()
-      } else if (ctx.SEP() != null) {
+      } else if (ctx.SEPEQUAL() != null) {
         "sep"
       } else {
         throw new SyntaxException(s"unrecognized placeholder option",

--- a/src/test/resources/syntax/v1_1/custom_runtime.wdl
+++ b/src/test/resources/syntax/v1_1/custom_runtime.wdl
@@ -1,0 +1,17 @@
+version 1.1
+task dyno_runtime {
+  input {
+    Int i
+  }
+  command <<<
+    echo "~{i}" > ~{i}
+  >>>
+  output {
+    File dyno_out="${i}"
+  }
+  runtime {
+    dx_timeout: "48H"
+    dx_instance_type: "mem1_ssd1_v2_x2"
+    dx_restart: object { max: 1, default: 2 }
+  }
+}

--- a/src/test/resources/types/v1/optional_placeholder_value.wdl
+++ b/src/test/resources/types/v1/optional_placeholder_value.wdl
@@ -38,8 +38,8 @@ task PeakCalling {
   command {
     set -e
     macs2 callpeak \
-    --treatment ~{sep = ' ' inputBams} \
-    ~{true="--control" false="" defined(controlBams)} ~{sep = ' ' controlBams} \
+    --treatment ~{sep=' ' inputBams} \
+    ~{true="--control" false="" defined(controlBams)} ~{sep=' ' controlBams} \
     --outdir ~{outDir} \
     --name ~{sampleName} \
     ~{true='--nomodel' false='' nomodel}

--- a/src/test/scala/wdlTools/syntax/v1_1/ConcreteSyntaxV1_1Test.scala
+++ b/src/test/scala/wdlTools/syntax/v1_1/ConcreteSyntaxV1_1Test.scala
@@ -3,7 +3,14 @@ package wdlTools.syntax.v1_1
 import dx.util.{FileSourceResolver, Logger}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import wdlTools.syntax.v1_1.ConcreteSyntax.Document
+import wdlTools.syntax.v1_1.ConcreteSyntax.{
+  Document,
+  ExprInt,
+  ExprMember,
+  ExprObjectLiteral,
+  ExprString,
+  Task
+}
 
 import java.nio.file.Paths
 
@@ -26,5 +33,24 @@ class ConcreteSyntaxV1_1Test extends AnyFlatSpec with Matchers {
 
   it should "parse nested expressions" in {
     getDocument("nested_expr.wdl")
+  }
+
+  it should "parse a task with custom runtime attribute" in {
+    val doc = getDocument("custom_runtime.wdl")
+    val tasks = doc.elements.collect {
+      case t: Task => t
+    }
+    tasks.size shouldBe 1
+    val runtime = tasks.head.runtime.get
+    val kvmap = runtime.kvs.map(kv => kv.id -> kv.expr).toMap
+    kvmap.keySet shouldBe Set("dx_timeout", "dx_instance_type", "dx_restart")
+    kvmap("dx_restart") should matchPattern {
+      case ExprObjectLiteral(
+          Vector(
+              ExprMember(ExprString("max", _), ExprInt(1)),
+              ExprMember(ExprString("default", _), ExprInt(2))
+          )
+          ) =>
+    }
   }
 }


### PR DESCRIPTION
Parsing the object value for `dx_restart` was failing due to `default` and `sep` being treated as reserved words in draft-2 and 1.0. I just applied the same fix as in 1.1, which is to treat `default=` and `sep=` as single tokens.