### PR TITLE
APPS-873 do not follow aliases forever

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Change log
 
+## in develop
+
+* Fixes infinite loop when calling `wdlTools.eval.Runtime.contains` with "docker" or "container"
+
 ## 0.17.1 (2021-09-23)
 
 * Fixes parsing of placeholder options in draft-2 and 1.0 such that `default` and `sep` are no longer treated as reserved words

--- a/src/test/resources/eval/v1.1/no_container.wdl
+++ b/src/test/resources/eval/v1.1/no_container.wdl
@@ -1,0 +1,42 @@
+version 1.1
+
+task countTo {
+    input{
+        Int value
+    }
+    command {
+        seq 0 1 ${value}
+    }
+    runtime {
+    }
+    output {
+        File range = stdout()
+    }
+}
+
+task filterEvens {
+    input{
+        File numbers
+    }
+    command {
+        grep '[02468]$' ${numbers} > evens
+        grep '[13579]$' ${numbers} > odds
+    }
+    runtime {
+    }
+    output {
+     Map[String,File] counter_output = {"odds":"odds","evens":"evens"}
+    }
+}
+
+workflow countEvens {
+    input{
+        Int max
+        String sample
+    }
+    call countTo { input: value = max }
+    call filterEvens { input: numbers = countTo.range }
+    output {
+        Pair[String,Map[String,File]] counter_wf_output = (sample,filterEvens.counter_output)
+    }
+}


### PR DESCRIPTION
In `wdlTools.eval.Runtime`, `aliases` is a `SymmetricBiMap` so both keys and values are checked on a call to `contains`. For `container` (which has alias `docker`), this causes an infinite loop and eventually a `StackOverflowError`. This PR adds an optional parameter `followAlias` which is set to `false` on any recursive calls.