### PR TITLE
APPS-930 bugfix in `eval.Meta`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,14 @@
 
 * Updates dxCommon dependency
 
+## in develop
+
+* Fixes `eval.Meta.get` to respect override values
+
+## 0.17.3 (2021-11-15)
+
+* Updates to latest dxCommon
+
 ## 0.17.2 (2021-11-10)
 
 * Fixes infinite loop when calling `wdlTools.eval.Runtime.contains` with "docker" or "container"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 wdlTools {
-    version = "0.17.3"
+    version = "0.17.4-SNAPSHOT"
 }
 
 #

--- a/src/main/scala/wdlTools/eval/Meta.scala
+++ b/src/main/scala/wdlTools/eval/Meta.scala
@@ -61,9 +61,9 @@ class Meta(kvs: Map[String, TAT.MetaValue],
   }
 
   override def get(id: String, wdlTypes: Vector[WdlTypes.T] = Vector.empty): Option[WdlValues.V] = {
-    overrideValues.flatMap(_.get(id, wdlTypes))
-    super
-      .get(id, wdlTypes)
+    overrideValues
+      .flatMap(_.get(id, wdlTypes))
+      .orElse(super.get(id, wdlTypes))
       .orElse(userDefaultValues.flatMap(_.get(id, wdlTypes)))
       .orElse(defaults.get(id))
   }


### PR DESCRIPTION
Fixes `eval.Meta.get` to respect override values