### PR TITLE
APPS-957 Logging and stderr fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val wdlTools = root.settings(
 )
 
 lazy val dependencies = {
-  val dxCommonVersion = "0.10.0"
+  val dxCommonVersion = "0.10.1"
   val antlr4Version = "4.9.3"
   val scallopVersion = "4.1.0"
   val typesafeVersion = "1.4.1"

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val wdlTools = root.settings(
 )
 
 lazy val dependencies = {
-  val dxCommonVersion = "0.10.1"
+  val dxCommonVersion = "0.10.2-SNAPSHOT"
   val antlr4Version = "4.9.3"
   val scallopVersion = "4.1.0"
   val typesafeVersion = "1.4.1"

--- a/build.sbt
+++ b/build.sbt
@@ -91,9 +91,7 @@ val releaseTarget = Option(System.getProperty("releaseTarget")).getOrElse("githu
 
 lazy val settings = Seq(
     scalacOptions ++= compilerOptions,
-    // exclude Java sources from scaladoc
-    //Compile / scalacOptions ++= Seq("-no-java-comments", "-no-link-warnings"),
-    //doc / scalacOptions ++= Seq("-no-java-comments", "-no-link-warnings"),
+    Compile / doc / scalacOptions ++= Seq("-no-java-comments", "-no-link-warnings"),
     javacOptions ++= Seq("-Xlint:deprecation"),
     // reduce the maximum number of errors shown by the Scala compiler
     maxErrors := 20,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,21 +1,20 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
+//addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 // sbt-sonatype plugin used to publish artifact to maven central via sonatype nexus
 // sbt-pgp plugin used to sign the artifcat with pgp keys
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+//addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+//addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 // sbt-github-packages plugin used to publish snapshot versions to github packages
 addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.2")
 
 // This prevents the SLF dialog from appearing when starting
 // an SBT session
-libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.24"
+libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.32"
 // only load git plugin if we're actually in a git repo
 libraryDependencies ++= {
-  if (baseDirectory.value / "../.git" isDirectory)
+  if ((baseDirectory.value / "../.git").isDirectory)
     Seq(
         Defaults.sbtPluginExtra("com.typesafe.sbt" % "sbt-git" % "1.0.0",
                                 (sbtBinaryVersion in update).value,

--- a/src/main/scala/wdlTools/eval/Stdlib.scala
+++ b/src/main/scala/wdlTools/eval/Stdlib.scala
@@ -815,7 +815,7 @@ case class Stdlib(paths: EvalPaths,
   // since: draft-1
   private def stderr(ctx: FunctionContext): V_File = {
     ctx.assertNoArgs()
-    val stderrFile = paths.getStdoutFile(true)
+    val stderrFile = paths.getStderrFile(true)
     ioSupport.ensureFileExists(stderrFile.asJavaPath, "stderr", ctx.loc)
     V_File(stderrFile.toString)
   }

--- a/src/main/scala/wdlTools/exec/TaskExecutor.scala
+++ b/src/main/scala/wdlTools/exec/TaskExecutor.scala
@@ -139,14 +139,12 @@ case class TaskExecutor(taskContext: TaskContext,
     }
     logger.trace(s"Executing command file ${commandFile}")
     // execute the shell script in a child job - this call will only fail on timeout
-    println("before")
     val (retcode, _, _) =
       SysUtils.runCommand(commandFile.toString,
                           timeout,
                           exceptionOnFailure = false,
                           stdoutMode = StdMode.Forward,
                           stderrMode = StdMode.Forward)
-    println("after")
     if (taskContext.runtime.isValidReturnCode(retcode)) {
       //TaskExecutorSuccess(retcode, taskContext.jsonOutputs, stdout, stderr)
       TaskExecutorSuccess(retcode, taskContext.jsonOutputs, "", "")

--- a/src/main/scala/wdlTools/exec/TaskExecutor.scala
+++ b/src/main/scala/wdlTools/exec/TaskExecutor.scala
@@ -1,10 +1,9 @@
 package wdlTools.exec
 
 import java.nio.file.{Files, Path}
-
 import spray.json.{JsNumber, JsObject, JsString, JsValue}
 import wdlTools.generators.Renderer
-import dx.util.{ExecPaths, FileUtils, Logger, SysUtils, errorMessage}
+import dx.util.{ExecPaths, FileUtils, Logger, StdMode, SysUtils, errorMessage}
 
 sealed trait TaskExecutorResult {
   def toJson: Map[String, JsValue]
@@ -141,13 +140,19 @@ case class TaskExecutor(taskContext: TaskContext,
     logger.trace(s"Executing command file ${commandFile}")
     // execute the shell script in a child job - this call will only fail on timeout
     println("before")
-    val (retcode, stdout, stderr) =
-      SysUtils.execScript(commandFile, timeout, exceptionOnFailure = false)
+    val (retcode, _, _) =
+      SysUtils.runCommand(commandFile.toString,
+                          timeout,
+                          exceptionOnFailure = false,
+                          stdoutMode = StdMode.Forward,
+                          stderrMode = StdMode.Forward)
     println("after")
     if (taskContext.runtime.isValidReturnCode(retcode)) {
-      TaskExecutorSuccess(retcode, taskContext.jsonOutputs, stdout, stderr)
+      //TaskExecutorSuccess(retcode, taskContext.jsonOutputs, stdout, stderr)
+      TaskExecutorSuccess(retcode, taskContext.jsonOutputs, "", "")
     } else {
-      TaskExecutorCommandFailure(retcode, stdout, stderr)
+      //TaskExecutorCommandFailure(retcode, stdout, stderr)
+      TaskExecutorCommandFailure(retcode, "", "")
     }
   }
 

--- a/src/main/scala/wdlTools/exec/TaskExecutor.scala
+++ b/src/main/scala/wdlTools/exec/TaskExecutor.scala
@@ -140,8 +140,10 @@ case class TaskExecutor(taskContext: TaskContext,
     }
     logger.trace(s"Executing command file ${commandFile}")
     // execute the shell script in a child job - this call will only fail on timeout
+    println("before")
     val (retcode, stdout, stderr) =
       SysUtils.execScript(commandFile, timeout, exceptionOnFailure = false)
+    println("after")
     if (taskContext.runtime.isValidReturnCode(retcode)) {
       TaskExecutorSuccess(retcode, taskContext.jsonOutputs, stdout, stderr)
     } else {

--- a/src/main/scala/wdlTools/exec/package.scala
+++ b/src/main/scala/wdlTools/exec/package.scala
@@ -23,8 +23,8 @@ object ExecException {
   }
 }
 
-class DefaultExecPaths(rootDir: PosixPath, tempDir: PosixPath)
-    extends DefaultEvalPaths(rootDir, tempDir)
+class DefaultExecPaths(rootDir: PosixPath, val tempDir: PosixPath, isLocal: Boolean)
+    extends DefaultEvalPaths(rootDir, tempDir, isLocal)
     with ExecPaths {
   def getCommandFile(ensureParentExists: Boolean = false): PosixPath = {
     getMetaDir(ensureParentExists).resolve(DefaultExecPaths.DefaultCommandScript)
@@ -49,8 +49,8 @@ object DefaultExecPaths {
   val DefaultContainerRunScript = "containerRunScript"
   val DefaultContainerId = "containerId"
 
-  def apply(executionDir: PosixPath, tempDir: PosixPath): ExecPaths = {
-    new DefaultExecPaths(executionDir, tempDir)
+  def apply(executionDir: PosixPath, tempDir: PosixPath, isLocal: Boolean): ExecPaths = {
+    new DefaultExecPaths(executionDir, tempDir, isLocal)
   }
 
   def createLocalPathsFromDir(executionDir: Path = FileUtils.cwd(absolute = true),
@@ -58,18 +58,18 @@ object DefaultExecPaths {
     if (!Files.isDirectory(executionDir)) {
       throw new ExecException(s"${executionDir} does not exist or is not a directory")
     }
-    DefaultExecPaths(PosixPath(executionDir.toString), PosixPath(tempDir.toString))
+    DefaultExecPaths(PosixPath(executionDir.toString), PosixPath(tempDir.toString), isLocal = true)
   }
 
   def createLocalPathsFromTemp(): ExecPaths = {
-    val rootDir = PosixPath(Files.createTempDirectory("wdlTools").toString)
+    val rootDir = PosixPath(Files.createTempDirectory("wdlTools").toRealPath().toString)
     val tempDir = rootDir.resolve(DefaultEvalPaths.DefaultTempDir)
-    DefaultExecPaths(rootDir, tempDir)
+    DefaultExecPaths(rootDir, tempDir, isLocal = true)
   }
 
   def createContainerPaths(containerExecutionDir: PosixPath,
                            containerTempDir: PosixPath = PosixPath("/tmp")): ExecPaths = {
-    DefaultExecPaths(containerExecutionDir, containerTempDir)
+    DefaultExecPaths(containerExecutionDir, containerTempDir, isLocal = false)
   }
 
   def createLocalContainerPair(

--- a/src/test/scala/wdlTools/eval/IoSupportTest.scala
+++ b/src/test/scala/wdlTools/eval/IoSupportTest.scala
@@ -26,10 +26,11 @@ class IoSupportTest extends AnyFlatSpec with Matchers with Inside {
   }
 
   private def setup(): (EvalPaths, FileSourceResolver) = {
-    val baseDir = Files.createTempDirectory("eval")
+    val baseDir = Files.createTempDirectory("eval").toRealPath()
     baseDir.toFile.deleteOnExit()
     val tmpDir = baseDir.resolve("tmp")
-    val evalPaths = DefaultEvalPaths(PosixPath(baseDir.toString), PosixPath(tmpDir.toString))
+    val evalPaths =
+      DefaultEvalPaths(PosixPath(baseDir.toString), PosixPath(tmpDir.toString), isLocal = true)
     val fileResolver =
       FileSourceResolver.create(Vector(srcDir, evalPaths.getWorkDir().asJavaPath),
                                 Vector(DxProtocol))

--- a/src/test/scala/wdlTools/format/FixerTest.scala
+++ b/src/test/scala/wdlTools/format/FixerTest.scala
@@ -19,7 +19,7 @@ class FixerTest extends AnyFlatSpec with Matchers {
   private def fix(name: String, validate: Boolean): Unit = {
     val fixer = Fixer()
     val docSource = getWdlSource(name, "before")
-    val outputDir = Files.createTempDirectory("fix")
+    val outputDir = Files.createTempDirectory("fix").toRealPath()
     outputDir.toFile.deleteOnExit()
     val fixedSource = fixer.fix(docSource, outputDir)
     if (validate) {

--- a/src/test/scala/wdlTools/types/CorporaTest.scala
+++ b/src/test/scala/wdlTools/types/CorporaTest.scala
@@ -22,7 +22,7 @@ class CorporaTest extends AnyWordSpec with Matchers {
   if (corporaAvailable) {
     val logger = Logger.Quiet
     lazy val fixDir = {
-      val fixDir = Files.createTempDirectory("fix")
+      val fixDir = Files.createTempDirectory("fix").toRealPath()
       fixDir.toFile.deleteOnExit()
       fixDir
     }


### PR DESCRIPTION
* Update dxCommon, switch to using `SysUtils.runCommand` in `Exec` command
* Forward command stdout/stderr rather than buffering it
* Fix bug in `stderr()` standard library function