### PR TITLE
APPS-1149 optional elements in structs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## in develop
 
 * `TAT.Workflow` has a `source` attribute in analogy to `TAT.Document` to be used for checksum calculation for App/Job reuse
+* Fixes evaluation of structs as input parameters of workflow/scatter: hash inputs are coerced from object to struct, and their optional elements are assigned to Null if not specified in job inputs.
 
 ## 0.17.8 (2022-03-15)
 

--- a/src/main/scala/wdlTools/eval/Coercion.scala
+++ b/src/main/scala/wdlTools/eval/Coercion.scala
@@ -14,8 +14,10 @@ object Coercion {
                              loc: SourceLocation,
                              allowNonstandardCoercions: Boolean,
                              isReadResult: Boolean): V_Struct = {
-    if (fieldTypes.keys.toSet != fieldValues.keys.toSet) {
-      throw new EvalException(s"struct ${structName} has wrong fields", loc)
+    val requiredFieldTypes = fieldTypes.filterNot(_._2.isInstanceOf[WdlTypes.T_Optional])
+    if (!requiredFieldTypes.keys.toSet.subsetOf(fieldValues.keys.toSet)) {
+      val missingFieldTypes = requiredFieldTypes.keys.toSet.diff(fieldValues.keys.toSet)
+      throw new EvalException(s"struct ${structName} has missing required fields: ${missingFieldTypes.mkString(",")}", loc)
     }
 
     // coerce each member to the struct type

--- a/src/main/scala/wdlTools/eval/Coercion.scala
+++ b/src/main/scala/wdlTools/eval/Coercion.scala
@@ -23,7 +23,7 @@ object Coercion {
     // coerce each member to the struct type
     val coercedValues = fieldTypes.map {
       case (name, t) =>
-        name -> coerceTo(t, fieldValues(name), loc, allowNonstandardCoercions, isReadResult)
+        name -> coerceTo(t, fieldValues.getOrElse(name, V_Null), loc, allowNonstandardCoercions, isReadResult)
     }
 
     V_Struct(structName, coercedValues)

--- a/src/main/scala/wdlTools/eval/Coercion.scala
+++ b/src/main/scala/wdlTools/eval/Coercion.scala
@@ -17,13 +17,20 @@ object Coercion {
     val requiredFieldTypes = fieldTypes.filterNot(_._2.isInstanceOf[WdlTypes.T_Optional])
     if (!requiredFieldTypes.keys.toSet.subsetOf(fieldValues.keys.toSet)) {
       val missingFieldTypes = requiredFieldTypes.keys.toSet.diff(fieldValues.keys.toSet)
-      throw new EvalException(s"struct ${structName} has missing required fields: ${missingFieldTypes.mkString(",")}", loc)
+      throw new EvalException(
+          s"struct ${structName} has missing required fields: ${missingFieldTypes.mkString(",")}",
+          loc
+      )
     }
 
     // coerce each member to the struct type
     val coercedValues = fieldTypes.map {
       case (name, t) =>
-        name -> coerceTo(t, fieldValues.getOrElse(name, V_Null), loc, allowNonstandardCoercions, isReadResult)
+        name -> coerceTo(t,
+                         fieldValues.getOrElse(name, V_Null),
+                         loc,
+                         allowNonstandardCoercions,
+                         isReadResult)
     }
 
     V_Struct(structName, coercedValues)

--- a/src/main/scala/wdlTools/exec/InputOutput.scala
+++ b/src/main/scala/wdlTools/exec/InputOutput.scala
@@ -35,7 +35,11 @@ object InputOutput {
             // ensure the required value is not T_Optional
             val v = WdlValueUtils.unwrapOptional(inputValues(decl.name))
             val t = param.wdlType
-            Coercion.coerceTo(t, v, SourceLocation.empty, evaluator.allowNonstandardCoercions,false)
+            Coercion.coerceTo(t,
+                              v,
+                              SourceLocation.empty,
+                              evaluator.allowNonstandardCoercions,
+                              false)
           case RequiredInputParameter(_, WdlTypes.T_Array(_, false)) if nullCollectionAsEmpty =>
             // Special handling for required input Arrays that are non-optional but
             // allowed to be empty and do not have a value specified - set the value
@@ -56,7 +60,11 @@ object InputOutput {
             // ensure the optional value is T_Optional
             val v = inputValues(param.name)
             val t = param.wdlType
-            Coercion.coerceTo(t, v, SourceLocation.empty, evaluator.allowNonstandardCoercions,false)
+            Coercion.coerceTo(t,
+                              v,
+                              SourceLocation.empty,
+                              evaluator.allowNonstandardCoercions,
+                              false)
           case _: OptionalInputParameter =>
             WdlValues.V_Null
           case OverridableInputParameterWithDefault(name, wdlType, defaultExpr) =>

--- a/src/main/scala/wdlTools/exec/InputOutput.scala
+++ b/src/main/scala/wdlTools/exec/InputOutput.scala
@@ -3,6 +3,7 @@ package wdlTools.exec
 import java.nio.file.Files
 import spray.json._
 import wdlTools.eval.{
+  Coercion,
   Eval,
   EvalException,
   VBindings,
@@ -32,7 +33,9 @@ object InputOutput {
         val value = decl match {
           case param: RequiredInputParameter if inputValues.contains(param.name) =>
             // ensure the required value is not T_Optional
-            WdlValueUtils.unwrapOptional(inputValues(decl.name))
+            val v = WdlValueUtils.unwrapOptional(inputValues(decl.name))
+            val t = param.wdlType
+            Coercion.coerceTo(t, v, SourceLocation.empty, evaluator.allowNonstandardCoercions,false)
           case RequiredInputParameter(_, WdlTypes.T_Array(_, false)) if nullCollectionAsEmpty =>
             // Special handling for required input Arrays that are non-optional but
             // allowed to be empty and do not have a value specified - set the value
@@ -51,7 +54,9 @@ object InputOutput {
             )
           case param if inputValues.contains(param.name) =>
             // ensure the optional value is T_Optional
-            inputValues(param.name)
+            val v = inputValues(param.name)
+            val t = param.wdlType
+            Coercion.coerceTo(t, v, SourceLocation.empty, evaluator.allowNonstandardCoercions,false)
           case _: OptionalInputParameter =>
             WdlValues.V_Null
           case OverridableInputParameterWithDefault(name, wdlType, defaultExpr) =>

--- a/src/test/resources/exec/structs.wdl
+++ b/src/test/resources/exec/structs.wdl
@@ -1,0 +1,9 @@
+version 1.1
+
+struct MyStructDB {
+  String? database_name
+  Int? num_columns
+  Int num_rows
+  String? value_types
+}
+

--- a/src/test/resources/exec/task_input_struct_optional_element.wdl
+++ b/src/test/resources/exec/task_input_struct_optional_element.wdl
@@ -1,0 +1,21 @@
+version 1.1
+
+struct MyStructDB {
+  Int? num_columns
+  Int num_rows
+}
+
+task test_task {
+  input {
+    MyStructDB database
+  }
+
+  command <<< 
+    echo ~{database.num_columns}
+    echo ~{database.num_rows}
+  >>>
+
+  runtime {}
+
+  output {}
+}

--- a/src/test/resources/exec/workflow_input_struct_optional_element.wdl
+++ b/src/test/resources/exec/workflow_input_struct_optional_element.wdl
@@ -1,0 +1,41 @@
+version 1.1
+
+import "structs.wdl"
+
+workflow test_workflow {
+  input {
+    MyStructDB database
+    Array[String] prefixes
+  }
+
+  scatter (prefix in prefixes) {
+    call test_task {
+      input:
+        prefix = prefix,
+        database = database
+    }
+  }
+  
+  output {
+    Array[File] final_output = test_task.task_output
+  }
+}
+
+task test_task {
+  input {
+    String prefix
+    MyStructDB database
+  }
+
+  command <<<
+     echo ~{prefix} > output.txt
+  >>>
+
+  runtime {
+    docker: "debian:stretch-slim"
+  }
+
+  output {
+    File task_output = "output.txt"
+  }
+}

--- a/src/test/resources/exec/workflow_scatter_input_struct_optional_element.wdl
+++ b/src/test/resources/exec/workflow_scatter_input_struct_optional_element.wdl
@@ -5,17 +5,19 @@ import "structs.wdl"
 workflow test_workflow {
   input {
     MyStructDB database
-    String prefix
+    Array[String] prefixes
   }
 
-  call test_task {
+  scatter (prefix in prefixes) {
+    call test_task {
       input:
         prefix = prefix,
         database = database
     }
+  }
   
   output {
-    File final_output = test_task.task_output
+    Array[File] final_output = test_task.task_output
   }
 }
 

--- a/src/test/scala/wdlTools/eval/EvalTest.scala
+++ b/src/test/scala/wdlTools/eval/EvalTest.scala
@@ -12,6 +12,7 @@ import wdlTools.types.{TypeCheckingRegime, TypeInfer, TypedAbstractSyntax => TAT
 import wdlTools.types.WdlTypes._
 
 import java.io.File
+import scala.collection.immutable.SeqMap
 
 class EvalTest extends AnyFlatSpec with Matchers with Inside {
   private val v1Dir = Paths.get(getClass.getResource("/eval/v1").getPath)
@@ -602,6 +603,32 @@ class EvalTest extends AnyFlatSpec with Matchers with Inside {
         "RG_LB" -> (T_String, V_String("dataset_dataset_str1"))
     )
     evaluator.applyExprAndCoerce(call.inputs("rg"), T_String, Eval.createBindingsFromEnv(env))
+  }
+
+  it should "coerce workflow object input to struct with optional elements" in {
+    val tDoc = parseAndTypeCheck(execDir.resolve("workflow_input_struct_optional_element.wdl"))
+    val scatters = tDoc.workflow.get.body.collect {
+      case scatter: TAT.Scatter => scatter
+    }
+    scatters.size shouldBe 1
+    val scatter = scatters.head
+    val calls = scatter.body.collect {
+      case call: TAT.Call => call
+    }
+    calls.size shouldBe 1
+    val call = calls.head
+    val evaluator = createEvaluator()
+    val inputs =
+      Map("database" -> V_Object(SeqMap("num_rows" -> V_Int(5), "num_rows_extra" -> V_Int(5))))
+
+    val value = evaluator.applyExprAndCoerce(call.inputs("database"),
+                                             call.callee.input("database")._1,
+                                             WdlValueBindings(inputs))
+    value shouldBe V_Struct("MyStructDB",
+                            "database_name" -> V_Null,
+                            "num_columns" -> V_Null,
+                            "num_rows" -> V_Int(5),
+                            "value_types" -> V_Null)
   }
 
   it should "handle escape sequences" in {

--- a/src/test/scala/wdlTools/eval/EvalTest.scala
+++ b/src/test/scala/wdlTools/eval/EvalTest.scala
@@ -617,7 +617,7 @@ class EvalTest extends AnyFlatSpec with Matchers with Inside {
     }
     calls.size shouldBe 1
     val call = calls.head
-    val evaluator = createEvaluator()
+    val evaluator = createEvaluator(WdlVersion.V1_1)
     val inputs =
       Map("database" -> V_Object(SeqMap("num_rows" -> V_Int(5), "num_rows_extra" -> V_Int(5))))
 

--- a/src/test/scala/wdlTools/eval/EvalTest.scala
+++ b/src/test/scala/wdlTools/eval/EvalTest.scala
@@ -619,7 +619,7 @@ class EvalTest extends AnyFlatSpec with Matchers with Inside {
     val call = calls.head
     val evaluator = createEvaluator(WdlVersion.V1_1)
     val inputs =
-      Map("database" -> V_Object(SeqMap("num_rows" -> V_Int(5), "num_rows_extra" -> V_Int(5))))
+      Map("database" -> V_Object(SeqMap("num_rows" -> V_Int(5), "num_rows_extra" -> V_Int(10))))
 
     val value = evaluator.applyExprAndCoerce(call.inputs("database"),
                                              call.callee.input("database")._1,

--- a/src/test/scala/wdlTools/exec/ExecTest.scala
+++ b/src/test/scala/wdlTools/exec/ExecTest.scala
@@ -55,7 +55,7 @@ class ExecTest extends AnyFlatSpec with Matchers with Inside {
     // )
     val task = doc.elements.collectFirst({ case t: TAT.Task => t }).get
     val inputValues = Map(
-        "database" -> V_Object(SeqMap("num_rows" -> V_Int(5), "num_rows_extra" -> V_Int(5)))
+        "database" -> V_Object(SeqMap("num_rows" -> V_Int(5), "num_rows_extra" -> V_Int(10)))
     )
     val values = InputOutput.inputsFromValues(task.name,
                                               task.inputs,

--- a/src/test/scala/wdlTools/exec/ExecTest.scala
+++ b/src/test/scala/wdlTools/exec/ExecTest.scala
@@ -10,6 +10,7 @@ import wdlTools.syntax.{Parsers, WdlVersion}
 import wdlTools.types.{TypeCheckingRegime, TypeInfer, TypedAbstractSyntax => TAT}
 
 import java.nio.file.{Path, Paths}
+import scala.collection.immutable.SeqMap
 
 class ExecTest extends AnyFlatSpec with Matchers with Inside {
   private val execDir = Paths.get(getClass.getResource("/exec").getPath)
@@ -45,5 +46,46 @@ class ExecTest extends AnyFlatSpec with Matchers with Inside {
                                               ignoreDefaultEvalError = false,
                                               nullCollectionAsEmpty = true)
     values("row") shouldBe V_Pair(V_String("str1"), V_Pair(V_String("str2"), V_String("str3")))
+  }
+
+  it should "evaluate task input struct with optional element" in {
+    val doc = parseAndTypeCheck(execDir.resolve("task_input_struct_optional_element.wdl"))
+    // val wf = doc.workflow.getOrElse(
+    //     None
+    // )
+    val task = doc.elements.collectFirst({ case t: TAT.Task => t }).get
+    val inputValues = Map(
+        "database" -> V_Object(SeqMap("num_rows" -> V_Int(5), "num_rows_extra" -> V_Int(5)))
+    )
+    val values = InputOutput.inputsFromValues(task.name,
+                                              task.inputs,
+                                              inputValues,
+                                              evaluator,
+                                              ignoreDefaultEvalError = false,
+                                              nullCollectionAsEmpty = true)
+    values("database") shouldBe V_Struct("MyStructDB",
+                                         "num_columns" -> V_Null,
+                                         "num_rows" -> V_Int(5))
+  }
+
+  it should "evaluate workflow input struct with optional element" in {
+    val doc = parseAndTypeCheck(execDir.resolve("workflow_input_struct_optional_element.wdl"))
+    val wf = doc.workflow.getOrElse(
+        throw new ExecException("expected workflow")
+    )
+    val inputValues = Map(
+        "database" -> V_Object(SeqMap("num_rows" -> V_Int(5), "num_rows_extra" -> V_Int(5)))
+    )
+    val values = InputOutput.inputsFromValues(wf.name,
+                                              wf.inputs,
+                                              inputValues,
+                                              evaluator,
+                                              ignoreDefaultEvalError = false,
+                                              nullCollectionAsEmpty = true)
+    values("database") shouldBe V_Struct("MyStructDB",
+                                         "database_name" -> V_Null,
+                                         "num_columns" -> V_Null,
+                                         "num_rows" -> V_Int(5),
+                                         "value_types" -> V_Null)
   }
 }

--- a/src/test/scala/wdlTools/exec/ExecTest.scala
+++ b/src/test/scala/wdlTools/exec/ExecTest.scala
@@ -67,25 +67,4 @@ class ExecTest extends AnyFlatSpec with Matchers with Inside {
                                          "num_columns" -> V_Null,
                                          "num_rows" -> V_Int(5))
   }
-
-  it should "evaluate workflow input struct with optional element" in {
-    val doc = parseAndTypeCheck(execDir.resolve("workflow_input_struct_optional_element.wdl"))
-    val wf = doc.workflow.getOrElse(
-        throw new ExecException("expected workflow")
-    )
-    val inputValues = Map(
-        "database" -> V_Object(SeqMap("num_rows" -> V_Int(5), "num_rows_extra" -> V_Int(5)))
-    )
-    val values = InputOutput.inputsFromValues(wf.name,
-                                              wf.inputs,
-                                              inputValues,
-                                              evaluator,
-                                              ignoreDefaultEvalError = false,
-                                              nullCollectionAsEmpty = true)
-    values("database") shouldBe V_Struct("MyStructDB",
-                                         "database_name" -> V_Null,
-                                         "num_columns" -> V_Null,
-                                         "num_rows" -> V_Int(5),
-                                         "value_types" -> V_Null)
-  }
 }

--- a/src/test/scala/wdlTools/exec/ExecTest.scala
+++ b/src/test/scala/wdlTools/exec/ExecTest.scala
@@ -50,9 +50,6 @@ class ExecTest extends AnyFlatSpec with Matchers with Inside {
 
   it should "evaluate task input struct with optional element" in {
     val doc = parseAndTypeCheck(execDir.resolve("task_input_struct_optional_element.wdl"))
-    // val wf = doc.workflow.getOrElse(
-    //     None
-    // )
     val task = doc.elements.collectFirst({ case t: TAT.Task => t }).get
     val inputValues = Map(
         "database" -> V_Object(SeqMap("num_rows" -> V_Int(5), "num_rows_extra" -> V_Int(10)))


### PR DESCRIPTION
This PR is to fix the evaluation of structs as input parameters of workflow/scatter: 

- [x] hash inputs should be coerced from object to struct
- [x] their optional elements should be assigned to Null if not specified in job inputs.

- [x] add tests
    - [x] task struct input
    - [x] workflow struct input
    - [x] workflow struct input to scatter input