### PR TITLE
Fix for #230

### DIFF
--- a/src/test/resources/eval/v2/bug_230.wdl
+++ b/src/test/resources/eval/v2/bug_230.wdl
@@ -1,0 +1,10 @@
+version development
+
+task bug_230 {
+    command <<<
+    >>>
+
+    runtime {
+        memory: "1 GiB"
+    }
+}


### PR DESCRIPTION
In a `V2Runtime`, the `get` method is currently trying to coerce to the intersection of the allowed and destination types. For `memory` (and maybe others) there is a problem - the allowed types are `[T_String, T_Int]` but the dest type is `[T_Int]`, so the intersection is `[T_Int]` and coercion from `T_String` throws an exception. What you need to do instead is first evaluate the expression to one of the allowed types, then coerce to the destination type, which is what is implemented in this PR.