### PR TITLE
Add support for multiline strings in `development`

### DIFF
--- a/src/main/antlr4/v2/WdlV2Parser.g4
+++ b/src/main/antlr4/v2/WdlV2Parser.g4
@@ -65,6 +65,7 @@ string_expr_with_string_part
 string
   : DQUOTE string_parts string_expr_with_string_part* DQUOTE #dquote_string
   | SQUOTE string_parts string_expr_with_string_part* SQUOTE #squote_string
+  | MULTILINE string_parts string_expr_with_string_part* MULTILINE #multiline_string
   ;
 
 primitive_literal


### PR DESCRIPTION
Multi-line strings have been approved for the `development` version of WDL: https://github.com/openwdl/wdl/pull/414. In addition, support for `command {}` style command blocks and `${}` style placeholders has been removed.

This PR adds the necessary changes to the ANTLR4 grammar.