### PR TITLE
APPS-912 version error msg fix

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,11 @@
 
 ## in develop
 
-...
+* Draft-2 parser. Previous behavior: if `version` is not declared, it is assumed to be `draft-2`, which has no formal 
+input definitions for tasks and workflows. However, if a user forgets to declare the `version` while working on workflow 
+of a version greater than `draft-2` with formal definition of `input`, the parser fails to follow the syntax and throws 
+the errors not related to the version or the formatting of the input section. Here this behavior is fixed: if `version` 
+is not detected and `draft-2` is assumed, we check if the `input` section is defined and throw an exception in this case. 
 
 ## 0.17.15 (2022-12-13)
 

--- a/src/main/scala/wdlTools/syntax/draft_2/ParseTop.scala
+++ b/src/main/scala/wdlTools/syntax/draft_2/ParseTop.scala
@@ -935,9 +935,15 @@ any_decls
     * declarations: 1) unbound, 2) bound with a literal value (i.e. not requiring evaluation), and
     * 3) bound with an expression requiring evaluation. Only the first two types of declarations may
     * be inputs; however, all three types of declarations can be mixed together. This method creates
-    * a synthetic InputSection contianing only declarations of type 1 and 2.
+    * a synthetic InputSection containing only declarations of type 1 and 2.
     */
   override def visitTask(ctx: WdlDraft2Parser.TaskContext): Task = {
+    if (hasFormalInputSection(ctx)) {
+      throw new SyntaxException(
+          "Draft 2 version of WDL should not contain a formal `input` section",
+          getSourceLocation(grammar.docSource, ctx)
+      )
+    }
     val name = getIdentifierText(ctx.Identifier(), ctx)
     val elems = ctx.task_element().asScala.toVector
     val output: Option[OutputSection] = atMostOneSection(elems.collect {
@@ -1144,6 +1150,12 @@ scatter
     }
   }
 
+  /**
+    * */
+  private def hasFormalInputSection(ctx: ParserRuleContext): Boolean = {
+    ctx.children.asScala.toList.exists(x => x.getText == "input")
+  }
+
   /*
   workflow_element
     : workflow_input #input
@@ -1164,9 +1176,15 @@ scatter
     * There are three types of declarations: 1) unbound, 2) bound with a literal value (i.e. not requiring
     * evaluation), and 3) bound with an expression requiring evaluation. Only the first two types of
     * declarations may be inputs; however, all three types of declarations can be mixed together. This method
-    * creates a synthetic InputSection contianing only declarations of type 1 and 2.
+    * creates a synthetic InputSection containing only declarations of type 1 and 2.
     */
   override def visitWorkflow(ctx: WdlDraft2Parser.WorkflowContext): Workflow = {
+    if (hasFormalInputSection(ctx)) {
+      throw new SyntaxException(
+          "Draft 2 version of WDL should not contain a formal `input` section",
+          getSourceLocation(grammar.docSource, ctx)
+      )
+    }
     val name = getIdentifierText(ctx.Identifier(), ctx)
     val elems: Vector[WdlDraft2Parser.Workflow_elementContext] =
       ctx.workflow_element().asScala.toVector


### PR DESCRIPTION
Shows correct error message when no version specified -> assumed `draft-2` -> detected formal `input` section (should not be there for `draft-2`).