### PR TITLE
[COMPUTE-1305] updated runner to 24.04

### DIFF
--- a/.github/workflows/actions/install-sbt/action.yml
+++ b/.github/workflows/actions/install-sbt/action.yml
@@ -1,0 +1,15 @@
+name: 'Install SBT'
+description: 'This action installs SBT'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install SBT
+      id: install-sbt
+      run: |
+        sudo apt-get update
+        echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
+        curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x99E82A75642AC823" | sudo apt-key add
+        sudo apt-get update
+        sudo apt-get install -y sbt
+      shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,14 +15,16 @@ permissions:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # v1.4.3
         with:
           java-version: 11
+      - name: Install SBT
+        uses: ./.github/workflows/actions/install-sbt
       - name: Install & build
         run: |
           # compile antlr4 sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,16 @@ permissions:
 jobs:
   run-release:
     name: wdlTools Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # v1.4.3
         with:
           java-version: 11
+      - name: Install SBT
+        uses: ./.github/workflows/actions/install-sbt
       - name: Install & build
         run: |
           # compile antlr4 sources
@@ -67,7 +69,7 @@ jobs:
           sed -n '/## ${{ steps.version.outputs.version }}/,/##/p' RELEASE_NOTES.md | sed '1d; $d' > $RELEASE_NOTES_PATH
           echo ::set-output name=release-notes-path::$(echo "${RELEASE_NOTES_PATH}")
       - name: Commit changes to application.conf files
-        uses: EndBug/add-and-commit@v7
+        uses: EndBug/add-and-commit@8c12ff729a98cfbcd3fe38b49f55eceb98a5ec02 # v7.5.0
         with:
           message: 'Release ${{ steps.version.outputs.version }}'
           add: '[
@@ -77,7 +79,7 @@ jobs:
           tag: ${{ steps.version.outputs.version }}
       - name: Create release entry
         id: create-release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -88,7 +90,7 @@ jobs:
           prerelease: false
       - name: Upload assembly JAR
         id: upload-release-assembly
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -112,7 +114,7 @@ jobs:
           sbt publish
       - name: Rollback release if unsuccessfull
         if: ${{ cancelled() || failure() }}
-        uses: author/action-rollback@stable
+        uses: author/action-rollback@f4473931b1155b601092ec00eb1fa4882b80219f # 1.0.4
         with:
           release_id: ${{ steps.create-release.outputs.id }}
           tag: ${{ steps.version.outputs.version }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -10,14 +10,16 @@ permissions:
 jobs:
   publish:
     name: Publish Snapshot
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # v1.4.3
         with:
           java-version: 11
+      - name: Install SBT
+        uses: ./.github/workflows/actions/install-sbt
       - name: Install other dependencies
         run: |
           sudo apt update -y && sudo apt install -y jq
@@ -44,7 +46,7 @@ jobs:
           version_id=`echo $version_json | jq -r ".data.repository.packages.nodes[0].version.id"`
           echo ::set-output name=version_id::"${version_id}"
       - name: Delete existing snapshot
-        uses: actions/delete-package-versions@v2
+        uses: actions/delete-package-versions@000223ef3eaa3505c63d4c610f57ef103bcab46d # v2.0.2
         if: ${{ steps.versions.outputs.version_id != 'null' }}
         with:
           repo: dnanexus

--- a/src/test/resources/corpora_repos.json
+++ b/src/test/resources/corpora_repos.json
@@ -62,8 +62,10 @@
       ]
     },
     {
-      "url": "https://github.com/broadinstitute/gtex-pipeline.git",
-      "tag": "eb6835bad68d63c176be695b986898b5527d7588",
+      "_url": "https://github.com/broadinstitute/gtex-pipeline.git",
+      "_tag": "eb6835bad68d63c176be695b986898b5527d7588",
+      "url": "https://github.com/wormsik/gtex-pipeline.git",
+      "tag": "rnasec_samtofastq_update",
       "entrypoints": [
         {
           "dir": "rnaseq",


### PR DESCRIPTION
updated runner to 24.04
added sha to actions usage

failing test is caused by old api version in 3rd party project, waiting for PR merge
https://github.com/broadinstitute/gtex-pipeline/pull/107

until 3rd party will be fixed, repository is redirected to wormsiks fix branch